### PR TITLE
Removed confirmed pending transactions

### DIFF
--- a/ZcashLightClientKit/Transaction/PersistentTransactionManager.swift
+++ b/ZcashLightClientKit/Transaction/PersistentTransactionManager.swift
@@ -175,6 +175,15 @@ class PersistentTransactionManager: OutboundTransactionManager {
         try repository.update(tx)
         return tx
     }
+    
+    func delete(pendingTransaction: PendingTransactionEntity) throws {
+        do {
+            try repository.delete(pendingTransaction)
+        } catch {
+            throw TransactionManagerError.notPending(tx: pendingTransaction)
+        }
+    }
+    
 }
 
 class OutboundTransactionManagerBuilder {

--- a/ZcashLightClientKit/Transaction/TransactionManager.swift
+++ b/ZcashLightClientKit/Transaction/TransactionManager.swift
@@ -31,5 +31,10 @@ protocol OutboundTransactionManager {
     
     func allPendingTransactions() throws -> [PendingTransactionEntity]?
     
-    func handleReorg(at: BlockHeight) throws 
+    func handleReorg(at: BlockHeight) throws
+    
+    /**
+        deletes a pending transaction from the database
+     */
+    func delete(pendingTransaction: PendingTransactionEntity) throws
 }


### PR DESCRIPTION
refresh pending transactions on synced status. Confirmed transactions should be removed from the pending transactions database 