### PR TITLE
Fix spelling of the `.transparent` alternative of `Entity.TransactionEntity.ZcashTransaction.Output.Pool` 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Updated
 - Methods returning an array of `ZcashTransaction.Overview` try to evaluate transaction's missing blockTime. This typically applies to an expired transaction.  
 
+## Changed
+- The spelling of the `.transparent` alternative of `Entity.TransactionEntity.ZcashTransaction.Output.Pool` has been corrected from `.transaparent`.
+
 # 2.2.8 - 2025-01-10
 
 ## Added

--- a/Sources/ZcashLightClientKit/Entity/TransactionEntity.swift
+++ b/Sources/ZcashLightClientKit/Entity/TransactionEntity.swift
@@ -66,14 +66,14 @@ public enum ZcashTransaction {
 
     public struct Output: Equatable, Identifiable {
         public enum Pool: Equatable {
-            case transaparent
+            case transparent
             case sapling
             case orchard
             case other(Int)
             init(rawValue: Int) {
                 switch rawValue {
                 case 0:
-                    self = .transaparent
+                    self = .transparent
                 case 2:
                     self = .sapling
                 case 3:

--- a/Tests/DarksideTests/ShieldFundsTests.swift
+++ b/Tests/DarksideTests/ShieldFundsTests.swift
@@ -74,7 +74,7 @@ class ShieldFundsTests: ZcashTestCase {
     /// the transparent funds should be 10000 zatoshis both total and verified
     /// 9. shield the funds
     /// when funds are shielded the UTXOs should be marked as spend and not shown on the balance.
-    /// now balance should be zero shielded, zero transaparent.
+    /// now balance should be zero shielded, zero transparent.
     /// 10. clear the UTXO from darksidewalletd's cache
     /// 11. stage the pending shielding transaction in darksidewalletd ad `utxoHeight + 12`
     /// 12. advance the chain tip to sync the now mined shielding transaction
@@ -240,7 +240,7 @@ class ShieldFundsTests: ZcashTestCase {
 
         let postShieldingBalance = try await coordinator.synchronizer.getAccountsBalances()[accountUUID]?.unshielded ?? .zero
         // when funds are shielded the UTXOs should be marked as spend and not shown on the balance.
-        // now balance should be zero shielded, zero transaparent.
+        // now balance should be zero shielded, zero transparent.
         // verify that the balance has been marked as spent regardless of confirmation
         // FIXME: [#720] this should be zero, https://github.com/zcash/ZcashLightClientKit/issues/720
         XCTAssertEqual(postShieldingBalance, Zatoshi(10000))


### PR DESCRIPTION
This has been corrected from `.transaparent`. fixes #1401
