### PR TITLE
Add FFI and wallet integration for shielded voting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -160,7 +160,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -171,7 +171,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1376,7 +1376,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1599,7 +1599,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2336,7 +2336,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -2465,7 +2465,7 @@ dependencies = [
 [[package]]
 name = "imt-tree"
 version = "0.1.0"
-source = "git+https://github.com/valargroup/vote-nullifier-pir.git?branch=main#fcf8db07e7188b68e5100276d0aec089f5a13b9a"
+source = "git+https://github.com/valargroup/vote-nullifier-pir.git?branch=main#d6cdd4612aa1a7be82d8b6b8af3fc5a13f330d8a"
 dependencies = [
  "anyhow",
  "ff",
@@ -2473,13 +2473,12 @@ dependencies = [
  "hex",
  "pasta_curves",
  "rayon",
- "tracing",
 ]
 
 [[package]]
 name = "imt-tree"
 version = "0.1.0"
-source = "git+https://github.com/valargroup/vote-nullifier-pir.git#fcf8db07e7188b68e5100276d0aec089f5a13b9a"
+source = "git+https://github.com/valargroup/vote-nullifier-pir.git#d6cdd4612aa1a7be82d8b6b8af3fc5a13f330d8a"
 dependencies = [
  "anyhow",
  "ff",
@@ -2487,7 +2486,6 @@ dependencies = [
  "hex",
  "pasta_curves",
  "rayon",
- "tracing",
 ]
 
 [[package]]
@@ -2679,7 +2677,7 @@ version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a1886916523694cd6ea3d175f03a1e5010699a2a4cc13696d83d7bea1d80638"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2754,7 +2752,7 @@ dependencies = [
 [[package]]
 name = "librustvoting"
 version = "0.1.0"
-source = "git+https://github.com/valargroup/librustvoting.git#d87a01b70a8d261ae3b65828e5088e56c3eb658d"
+source = "git+https://github.com/valargroup/librustvoting.git#3860780a34ab37ced8a4db6752990474291d3610"
 dependencies = [
  "blake2b_simd",
  "ff",
@@ -3077,7 +3075,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3279,7 +3277,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 [[package]]
 name = "orchard"
 version = "0.11.0"
-source = "git+https://github.com/valargroup/voting-circuits.git#05503e205535fce5f0d5ab393eb88f952d15640b"
+source = "git+https://github.com/valargroup/voting-circuits.git#c00f26d828cf6d2f1db24792342dff343120d4f3"
 dependencies = [
  "aes",
  "bitvec",
@@ -3567,7 +3565,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 [[package]]
 name = "pir-client"
 version = "0.1.0"
-source = "git+https://github.com/valargroup/vote-nullifier-pir.git?branch=main#fcf8db07e7188b68e5100276d0aec089f5a13b9a"
+source = "git+https://github.com/valargroup/vote-nullifier-pir.git?branch=main#d6cdd4612aa1a7be82d8b6b8af3fc5a13f330d8a"
 dependencies = [
  "anyhow",
  "ff",
@@ -3586,7 +3584,7 @@ dependencies = [
 [[package]]
 name = "pir-types"
 version = "0.1.0"
-source = "git+https://github.com/valargroup/vote-nullifier-pir.git?branch=main#fcf8db07e7188b68e5100276d0aec089f5a13b9a"
+source = "git+https://github.com/valargroup/vote-nullifier-pir.git?branch=main#d6cdd4612aa1a7be82d8b6b8af3fc5a13f330d8a"
 dependencies = [
  "anyhow",
  "ff",
@@ -4282,7 +4280,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4819,7 +4817,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4831,7 +4829,7 @@ checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 [[package]]
 name = "spiral-rs"
 version = "0.4.0"
-source = "git+https://github.com/menonsamir/spiral-rs.git?rev=f2c23c7#f2c23c7ced192e80687b52134ee861098f764769"
+source = "git+https://github.com/valargroup/spiral-rs.git?branch=valar%2Favoid-avx512#e06c730f958ddd0717fda43ae43eb7c628290bd4"
 dependencies = [
  "fastrand",
  "getrandom 0.2.17",
@@ -5038,7 +5036,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6631,7 +6629,7 @@ checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 [[package]]
 name = "vote-commitment-tree"
 version = "0.1.0"
-source = "git+https://github.com/valargroup/librustvoting.git#d87a01b70a8d261ae3b65828e5088e56c3eb658d"
+source = "git+https://github.com/valargroup/librustvoting.git#3860780a34ab37ced8a4db6752990474291d3610"
 dependencies = [
  "anyhow",
  "ff",
@@ -6647,7 +6645,7 @@ dependencies = [
 [[package]]
 name = "vote-commitment-tree-client"
 version = "0.1.0"
-source = "git+https://github.com/valargroup/librustvoting.git#d87a01b70a8d261ae3b65828e5088e56c3eb658d"
+source = "git+https://github.com/valargroup/librustvoting.git#3860780a34ab37ced8a4db6752990474291d3610"
 dependencies = [
  "base64",
  "clap",
@@ -6664,7 +6662,7 @@ dependencies = [
 [[package]]
 name = "voting-circuits"
 version = "0.1.0"
-source = "git+https://github.com/valargroup/voting-circuits.git#05503e205535fce5f0d5ab393eb88f952d15640b"
+source = "git+https://github.com/valargroup/voting-circuits.git#c00f26d828cf6d2f1db24792342dff343120d4f3"
 dependencies = [
  "blake2b_simd",
  "ff",
@@ -6881,7 +6879,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6897,7 +6895,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
 dependencies = [
  "windows-collections",
- "windows-core 0.61.2",
+ "windows-core",
  "windows-future",
  "windows-link 0.1.3",
  "windows-numerics",
@@ -6909,7 +6907,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
 dependencies = [
- "windows-core 0.61.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -6926,25 +6924,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-core"
-version = "0.62.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
-dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
- "windows-strings 0.5.1",
-]
-
-[[package]]
 name = "windows-future"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
- "windows-core 0.61.2",
+ "windows-core",
  "windows-link 0.1.3",
  "windows-threading",
 ]
@@ -6989,7 +6974,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
- "windows-core 0.61.2",
+ "windows-core",
  "windows-link 0.1.3",
 ]
 
@@ -7379,7 +7364,7 @@ dependencies = [
 [[package]]
 name = "ypir"
 version = "0.1.0"
-source = "git+https://github.com/menonsamir/ypir.git?branch=artifact#b9801521301f34502496d694b2ac034857104ebc"
+source = "git+https://github.com/valargroup/ypir.git?branch=valar%2Fartifact#bb4d68bf0022b1b6cefc1fda8bf25ea8bce36fef"
 dependencies = [
  "cc",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,10 +3,10 @@
 version = 4
 
 [[package]]
-name = "adler2"
-version = "2.0.1"
+name = "adler"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "aead"
@@ -14,15 +14,15 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
- "crypto-common 0.1.7",
+ "crypto-common 0.1.6",
  "generic-array",
 ]
 
 [[package]]
 name = "aes"
-version = "0.8.4"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+checksum = "ac1f845298e95f983ff1944b728ae08b8cebab80d684f0a832ed0fc74dfa27e2"
 dependencies = [
  "cfg-if",
  "cipher",
@@ -32,9 +32,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+checksum = "0c378d78423fdad8089616f827526ee33c19f2fddbd5de1629152c9593ba4783"
 dependencies = [
  "memchr",
 ]
@@ -48,7 +48,7 @@ dependencies = [
  "amplify_derive",
  "amplify_num",
  "ascii",
- "getrandom 0.2.17",
+ "getrandom 0.2.10",
  "getrandom 0.3.4",
  "wasm-bindgen",
 ]
@@ -84,6 +84,12 @@ dependencies = [
  "quote",
  "syn 1.0.109",
 ]
+
+[[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
 
 [[package]]
 name = "android_system_properties"
@@ -152,21 +158,21 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
 
 [[package]]
 name = "arrayref"
-version = "0.3.9"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+checksum = "6b4930d2cb77ce62f89ee5d5289b4ac049559b1c45539271f5ed4fdc7db34545"
 
 [[package]]
 name = "arrayvec"
-version = "0.7.6"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
 name = "arti-client"
@@ -345,9 +351,9 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "axum"
@@ -509,13 +515,13 @@ dependencies = [
 
 [[package]]
 name = "blake2b_simd"
-version = "1.0.4"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b79834656f71332577234b50bfc009996f7449e0c056884e6a02492ded0ca2f3"
+checksum = "3c2f0dc9a68c6317d884f97cc36cf5a3d20ba14ce404227df55e1af708ab04bc"
 dependencies = [
  "arrayref",
  "arrayvec",
- "constant_time_eq",
+ "constant_time_eq 0.2.6",
 ]
 
 [[package]]
@@ -526,7 +532,7 @@ checksum = "ee29928bad1e3f94c9d1528da29e07a1d3d04817ae8332de1e8b846c8439f4b3"
 dependencies = [
  "arrayref",
  "arrayvec",
- "constant_time_eq",
+ "constant_time_eq 0.4.2",
 ]
 
 [[package]]
@@ -603,9 +609,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1"
 
 [[package]]
 name = "by_address"
@@ -615,15 +621,15 @@ checksum = "64fa3c856b712db6612c019f14756e64e4bcea13337a6b33b696333a9eaa2d06"
 
 [[package]]
 name = "bytemuck"
-version = "1.25.0"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+checksum = "374d28ec25809ee0e23827c2ab573d729e293f281dfe393500e7ad618baa61c6"
 
 [[package]]
 name = "byteorder"
-version = "1.5.0"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
@@ -694,9 +700,9 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
-version = "1.0.4"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chacha20"
@@ -724,21 +730,22 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "defd4e7873dbddba6c7c91e199c7fcb946abc4a6a4ac3195400bcfb01b5de877"
 dependencies = [
+ "android-tzdata",
  "iana-time-zone",
  "num-traits",
  "serde",
- "windows-link 0.2.1",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
 name = "ciborium"
-version = "0.2.2"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+checksum = "effd91f6c78e5a4ace8a5d3c0b6bfaec9e2baaef55f3efc00e45fb2e477ee926"
 dependencies = [
  "ciborium-io",
  "ciborium-ll",
@@ -747,15 +754,15 @@ dependencies = [
 
 [[package]]
 name = "ciborium-io"
-version = "0.2.2"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+checksum = "cdf919175532b369853f5d5e20b26b43112613fd6fe7aee757e35f7a44642656"
 
 [[package]]
 name = "ciborium-ll"
-version = "0.2.2"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+checksum = "defaa24ecc093c77630e6c15e17c51f5e187bf35ee514f4e2d67baaa96dae22b"
 dependencies = [
  "ciborium-io",
  "half",
@@ -767,7 +774,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common 0.1.7",
+ "crypto-common 0.1.6",
  "inout",
  "zeroize",
 ]
@@ -866,6 +873,12 @@ checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "constant_time_eq"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21a53c0a4d288377e7415b53dcfc3c04da5cdc2cc95c8d5ac178b58f0b861ad6"
+
+[[package]]
+name = "constant_time_eq"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
@@ -890,9 +903,9 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
-version = "0.9.4"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+checksum = "194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -925,18 +938,18 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.17"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+checksum = "a17b76ff3a4162b0b27f354a0c87015ddad39d35f9c0c36607a3bdd175dde1f1"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "crc32fast"
-version = "1.5.0"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
 dependencies = [
  "cfg-if",
 ]
@@ -986,30 +999,36 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.15"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+checksum = "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200"
 dependencies = [
+ "cfg-if",
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.6"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+checksum = "ce6fd6f855243022dcecf8702fef0c297d4338e226845fe067f6341ad9fa0cef"
 dependencies = [
+ "cfg-if",
  "crossbeam-epoch",
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "ae211234986c545741a7dc064309f67ee1e5ad243d0e48335adc0484d960bcc7"
 dependencies = [
+ "autocfg",
+ "cfg-if",
  "crossbeam-utils",
+ "memoffset",
+ "scopeguard",
 ]
 
 [[package]]
@@ -1029,9 +1048,9 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crunchy"
-version = "0.2.4"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-bigint"
@@ -1047,9 +1066,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.1.7"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
@@ -1237,7 +1256,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd5f2b7218a51c827a11d22d1439b598121fac94bf9b99452e4afffe512d78c9"
 dependencies = [
  "heck",
- "indexmap 2.14.0",
+ "indexmap 1.9.3",
  "itertools 0.14.0",
  "proc-macro-crate",
  "proc-macro2",
@@ -1310,7 +1329,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
  "const-oid",
- "crypto-common 0.1.7",
+ "crypto-common 0.1.6",
  "subtle",
 ]
 
@@ -1461,9 +1480,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
 name = "elliptic-curve"
@@ -1634,7 +1653,7 @@ checksum = "c06bad5d1e3a9cfc3825643e055eb7f1fc1b1d52d1543c8ddb9107abd6497f2e"
 dependencies = [
  "anyhow",
  "libc",
- "thiserror 1.0.69",
+ "thiserror 1.0.48",
 ]
 
 [[package]]
@@ -1681,9 +1700,9 @@ checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flate2"
-version = "1.1.9"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+checksum = "c6c98ee8095e9d1dcbf2fcc6d95acccb90d1c81db1e44725c6a984b1dbdfb010"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -1888,9 +1907,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.17"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -1908,22 +1927,9 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi 5.3.0",
+ "r-efi",
  "wasip2",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
-dependencies = [
- "cfg-if",
- "libc",
- "r-efi 6.0.0",
- "wasip2",
- "wasip3",
 ]
 
 [[package]]
@@ -1983,14 +1989,9 @@ dependencies = [
 
 [[package]]
 name = "half"
-version = "2.7.1"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
-dependencies = [
- "cfg-if",
- "crunchy",
- "zerocopy",
-]
+checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
 
 [[package]]
 name = "halo2_gadgets"
@@ -2032,15 +2033,14 @@ dependencies = [
 
 [[package]]
 name = "halo2_proofs"
-version = "0.3.2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05713f117155643ce10975e0bee44a274bcda2f4bb5ef29a999ad67c1fa8d4d3"
+checksum = "7b867a8d9bbb85fca76fff60652b5cd19b853a1c4d0665cb89bee68b18d2caf0"
 dependencies = [
  "blake2b_simd",
  "ff",
  "group",
  "halo2_legacy_pdqsort",
- "indexmap 1.9.3",
  "maybe-rayon",
  "pasta_curves",
  "rand_core 0.6.4",
@@ -2085,9 +2085,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
-version = "0.5.2"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
 
 [[package]]
 name = "hex"
@@ -2301,17 +2301,16 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.65"
+version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+checksum = "2fad5b825842d2b38bd206f3e81d6957625fd7f0a361e345c30e01a0ae2dd613"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
  "iana-time-zone-haiku",
  "js-sys",
- "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows 0.48.0",
 ]
 
 [[package]]
@@ -2404,12 +2403,6 @@ dependencies = [
  "zerotrie",
  "zerovec",
 ]
-
-[[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "ident_case"
@@ -2506,9 +2499,9 @@ dependencies = [
 
 [[package]]
 name = "inout"
-version = "0.1.4"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
 dependencies = [
  "generic-array",
 ]
@@ -2564,9 +2557,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.18"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
 name = "jiff"
@@ -2668,18 +2661,12 @@ dependencies = [
 
 [[package]]
 name = "lazy_static"
-version = "1.5.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 dependencies = [
  "spin",
 ]
-
-[[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
@@ -2689,19 +2676,19 @@ checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
 name = "libloading"
-version = "0.8.9"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+checksum = "d580318f95776505201b28cf98eb1fa5e4be3b689633ba6a3e6cd880ff22d8cb"
 dependencies = [
  "cfg-if",
- "windows-link 0.2.1",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "libm"
-version = "0.2.16"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+checksum = "f7012b1bbb0719e1097c47611d3898568c546d597c2e74d66f6087edd5233ff4"
 
 [[package]]
 name = "libredox"
@@ -2814,9 +2801,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.12.1"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "litemap"
@@ -2832,10 +2819,11 @@ checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "lock_api"
-version = "0.4.14"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+checksum = "c1cc9717a20b1bb222f333e6a92fd32f7d8a18ddc5a3191a11af45dcbf4dcd16"
 dependencies = [
+ "autocfg",
  "scopeguard",
 ]
 
@@ -2906,6 +2894,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "memuse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2937,12 +2934,11 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.9"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
 dependencies = [
- "adler2",
- "simd-adler32",
+ "adler",
 ]
 
 [[package]]
@@ -3048,10 +3044,11 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.6"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+checksum = "608e7659b5c3d7cba262d894801b9ec9d00de989e8a82bd4bef91d08da45cdc0"
 dependencies = [
+ "autocfg",
  "num-integer",
  "num-traits",
 ]
@@ -3100,9 +3097,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.19"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+checksum = "f30b0abd723be7e2ffca1272140fac1a2f084c77ec3e123c192b66af1ee9e6c2"
 dependencies = [
  "autocfg",
  "libm",
@@ -3110,9 +3107,9 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.17.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
  "hermit-abi",
  "libc",
@@ -3161,9 +3158,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.4"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -3182,15 +3179,15 @@ dependencies = [
 
 [[package]]
 name = "oorandom"
-version = "11.1.5"
+version = "11.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "opaque-debug"
-version = "0.3.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
@@ -3245,7 +3242,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 [[package]]
 name = "orchard"
 version = "0.11.0"
-source = "git+https://github.com/valargroup/voting-circuits.git#c00f26d828cf6d2f1db24792342dff343120d4f3"
+source = "git+https://github.com/valargroup/voting-circuits.git#ecca2f0e9faf6b077920fd2a2e96020e5f1e7254"
 dependencies = [
  "aes",
  "bitvec",
@@ -3287,9 +3284,9 @@ dependencies = [
 
 [[package]]
 name = "os_str_bytes"
-version = "6.6.1"
+version = "6.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1"
+checksum = "4d5d9eb14b174ee9aa2ef96dc2b94637a2d4b6e7cb873c7e171f0c20c6cf3eac"
 dependencies = [
  "memchr",
 ]
@@ -3349,9 +3346,9 @@ checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
-version = "0.12.5"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -3359,15 +3356,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.12"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+checksum = "93f00c865fe7cabf650081affecd3871070f26767e7b2070a3ffae14c654b447"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.18",
+ "redox_syscall 0.3.5",
  "smallvec",
- "windows-link 0.2.1",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -3500,18 +3497,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.11"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
+checksum = "fda4ed1c6c173e3fc7a83629421152e01d7b1f9b7f65fb301e490e8cfc656422"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.11"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
+checksum = "4359fd9c9171ec6e8c62926d6faaf553a8dc3f64e1507e76da7911b4f6a04405"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3520,9 +3517,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.17"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
 
 [[package]]
 name = "pir-client"
@@ -3590,9 +3587,9 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plotters"
-version = "0.3.7"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+checksum = "d2c224ba00d7cadd4d5c660deaf2098e5e80e07846537c51f9cfa4be50c1fd45"
 dependencies = [
  "num-traits",
  "plotters-backend",
@@ -3603,15 +3600,15 @@ dependencies = [
 
 [[package]]
 name = "plotters-backend"
-version = "0.3.7"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+checksum = "9e76628b4d3a7581389a35d5b6e2139607ad7c75b17aed325f210aa91f4a9609"
 
 [[package]]
 name = "plotters-svg"
-version = "0.3.7"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+checksum = "38f6d39893cca0701371e3c27294f09797214b86f1fb951b89ade8ec04e2abab"
 dependencies = [
  "plotters-backend",
 ]
@@ -3654,7 +3651,7 @@ dependencies = [
  "parking_lot",
  "pin-project",
  "static_assertions",
- "thiserror 1.0.69",
+ "thiserror 1.0.48",
 ]
 
 [[package]]
@@ -3686,12 +3683,9 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.21"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
-dependencies = [
- "zerocopy",
-]
+checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "prettyplease"
@@ -3842,12 +3836,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
-name = "r-efi"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
-
-[[package]]
 name = "radium"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3900,7 +3888,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.17",
+ "getrandom 0.2.10",
 ]
 
 [[package]]
@@ -3935,9 +3923,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.11.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+checksum = "1d2df5196e37bcc87abebc0053e20787d73847bb33134a69841207dd0a47f03b"
 dependencies = [
  "either",
  "rayon-core",
@@ -3945,12 +3933,14 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.13.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+checksum = "4b8f95bd6966f5c87776639160a66bd8ab9895d9d4ab01ddba9fc60661aebe8d"
 dependencies = [
+ "crossbeam-channel",
  "crossbeam-deque",
  "crossbeam-utils",
+ "num_cpus",
 ]
 
 [[package]]
@@ -3976,7 +3966,7 @@ dependencies = [
  "pasta_curves",
  "rand_core 0.6.4",
  "serde",
- "thiserror 1.0.69",
+ "thiserror 1.0.48",
  "zeroize",
 ]
 
@@ -3988,17 +3978,17 @@ checksum = "89b0ac1bc6bb3696d2c6f52cff8fba57238b81da8c0214ee6cd146eb8fde364e"
 dependencies = [
  "rand_core 0.6.4",
  "reddsa",
- "thiserror 1.0.69",
+ "thiserror 1.0.48",
  "zeroize",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.18"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -4016,7 +4006,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
- "getrandom 0.2.17",
+ "getrandom 0.2.10",
  "libredox",
  "thiserror 2.0.18",
 ]
@@ -4136,7 +4126,7 @@ checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom 0.2.17",
+ "getrandom 0.2.10",
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
@@ -4235,15 +4225,15 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.1.4"
+version = "0.38.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+checksum = "c0c3dde1fc030af041adc40e79c0e7fbcf431dd24870053d187d7c66e4b87453"
 dependencies = [
  "bitflags 2.11.0",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -4289,9 +4279,9 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
-version = "1.0.23"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
 
 [[package]]
 name = "safelog"
@@ -4399,7 +4389,7 @@ dependencies = [
  "daggy",
  "indexmap 1.9.3",
  "log",
- "thiserror 1.0.69",
+ "thiserror 1.0.48",
  "uuid",
 ]
 
@@ -4716,12 +4706,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "simd-adler32"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
-
-[[package]]
 name = "sinsemilla"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4785,9 +4769,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spki"
@@ -4843,9 +4827,9 @@ dependencies = [
 
 [[package]]
 name = "stable_deref_trait"
-version = "1.2.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "static_assertions"
@@ -4945,7 +4929,7 @@ dependencies = [
  "ntapi",
  "objc2-core-foundation",
  "objc2-io-kit",
- "windows",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -4955,7 +4939,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
  "bitflags 2.11.0",
- "core-foundation 0.9.4",
+ "core-foundation 0.9.3",
  "system-configuration-sys",
 ]
 
@@ -4977,15 +4961,15 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
-version = "3.27.0"
+version = "3.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+checksum = "cb94d2f3cc536af71caac6b6fcebf65860b347e7ce0cc9ebe8f70d3e521054ef"
 dependencies = [
+ "cfg-if",
  "fastrand",
- "getrandom 0.4.2",
- "once_cell",
+ "redox_syscall 0.3.5",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -5012,11 +4996,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.69"
+version = "1.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+checksum = "9d6d7a740b8a666a7e828dd00da9c0dc290dff53154ea77ac109281de90589b7"
 dependencies = [
- "thiserror-impl 1.0.69",
+ "thiserror-impl 1.0.48",
 ]
 
 [[package]]
@@ -5030,9 +5014,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.69"
+version = "1.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+checksum = "49922ecae66cc8a249b77e68d1d0623c1b2c514f0060c27cdc68bd62a1219d35"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6466,9 +6450,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.24"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
 
 [[package]]
 name = "unicode-segmentation"
@@ -6488,7 +6472,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
 dependencies = [
- "crypto-common 0.1.7",
+ "crypto-common 0.1.6",
  "subtle",
 ]
 
@@ -6530,14 +6514,12 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
+checksum = "79daa5ed5740825c40b389c5e50312b9c86df53fccd33f281df655642b43869d"
 dependencies = [
- "getrandom 0.4.2",
- "js-sys",
- "serde_core",
- "wasm-bindgen",
+ "getrandom 0.2.10",
+ "serde",
 ]
 
 [[package]]
@@ -6547,7 +6529,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce897de77f8b80c06e3457da2db3585333d2882f9e9f420ac8a79ab6e6a43f09"
 dependencies = [
  "fastrand",
- "getrandom 0.2.17",
+ "getrandom 0.2.10",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "serde_json",
@@ -6588,9 +6570,9 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"
-version = "0.9.5"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "visibility"
@@ -6645,7 +6627,7 @@ dependencies = [
 [[package]]
 name = "voting-circuits"
 version = "0.1.0"
-source = "git+https://github.com/valargroup/voting-circuits.git#c00f26d828cf6d2f1db24792342dff343120d4f3"
+source = "git+https://github.com/valargroup/voting-circuits.git#ecca2f0e9faf6b077920fd2a2e96020e5f1e7254"
 dependencies = [
  "blake2b_simd",
  "ff",
@@ -6663,9 +6645,9 @@ dependencies = [
 
 [[package]]
 name = "walkdir"
-version = "2.5.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+checksum = "d71d857dc86794ca4c280d616f7da00d2dbfd8cd788846559a6813e6aa4b54ee"
 dependencies = [
  "same-file",
  "winapi-util",
@@ -6682,24 +6664,15 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.11.1+wasi-snapshot-preview1"
+version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasip2"
 version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
-dependencies = [
- "wit-bindgen",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen",
 ]
@@ -6770,40 +6743,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap 2.14.0",
- "wasm-encoder",
- "wasmparser",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags 2.11.0",
- "hashbrown 0.15.5",
- "indexmap 2.14.0",
- "semver",
-]
-
-[[package]]
 name = "weak-table"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6811,9 +6750,9 @@ checksum = "323f4da9523e9a669e1eaf9c6e763892769b1d38c623913647bfdc1532fe4549"
 
 [[package]]
 name = "web-sys"
-version = "0.3.95"
+version = "0.3.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
+checksum = "9b85cbef8c220a6abc02aefd892dfc0fc23afb1c6a426316ec33253a3877249b"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6855,11 +6794,11 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.11"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
 dependencies = [
- "windows-sys 0.61.2",
+ "winapi",
 ]
 
 [[package]]
@@ -6870,12 +6809,21 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows"
 version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
 dependencies = [
  "windows-collections",
- "windows-core 0.61.2",
+ "windows-core",
  "windows-future",
  "windows-link 0.1.3",
  "windows-numerics",
@@ -6887,7 +6835,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
 dependencies = [
- "windows-core 0.61.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -6904,25 +6852,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-core"
-version = "0.62.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
-dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
- "windows-strings 0.5.1",
-]
-
-[[package]]
 name = "windows-future"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
- "windows-core 0.61.2",
+ "windows-core",
  "windows-link 0.1.3",
  "windows-threading",
 ]
@@ -6967,7 +6902,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
- "windows-core 0.61.2",
+ "windows-core",
  "windows-link 0.1.3",
 ]
 
@@ -7020,6 +6955,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -7043,6 +6987,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -7089,6 +7048,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -7101,6 +7066,12 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -7110,6 +7081,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -7137,6 +7114,12 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -7146,6 +7129,12 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -7161,6 +7150,12 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -7170,6 +7165,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -7206,88 +7207,6 @@ name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap 2.14.0",
- "prettyplease",
- "syn 2.0.117",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags 2.11.0",
- "indexmap 2.14.0",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap 2.14.0",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
-]
 
 [[package]]
 name = "writeable"
@@ -7658,26 +7577,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "zerocopy"
-version = "0.8.48"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
-dependencies = [
- "zerocopy-derive",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.8.48"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "zerofrom"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7709,9 +7608,9 @@ dependencies = [
 
 [[package]]
 name = "zeroize_derive"
-version = "1.4.3"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7754,11 +7653,10 @@ dependencies = [
 
 [[package]]
 name = "zip32"
-version = "0.2.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b64bf5186a8916f7a48f2a98ef599bf9c099e2458b36b819e393db1c0e768c4b"
+checksum = "13ff9ea444cdbce820211f91e6aa3d3a56bde7202d3c0961b7c38f793abf5637"
 dependencies = [
- "bech32",
  "blake2b_simd",
  "memuse",
  "subtle",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2809,6 +2809,7 @@ dependencies = [
  "fs-mistrust",
  "http",
  "http-body-util",
+ "incrementalmerkletree",
  "librustvoting",
  "log-panics",
  "nonempty",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1580,7 +1580,7 @@ dependencies = [
 [[package]]
 name = "equihash"
 version = "0.2.2"
-source = "git+https://github.com/valargroup/librustzcash.git?branch=shielded-voting-wallet-support#efb5f3470c69cff71a746deaff8318bc2b7e8aae"
+source = "git+https://github.com/valargroup/librustzcash.git?branch=shielded-voting-wallet-support#6858db4a523de05f7474a89c7df751510c71874d"
 dependencies = [
  "blake2b_simd",
  "core2",
@@ -1616,7 +1616,7 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.1"
-source = "git+https://github.com/valargroup/librustzcash.git?branch=shielded-voting-wallet-support#efb5f3470c69cff71a746deaff8318bc2b7e8aae"
+source = "git+https://github.com/valargroup/librustzcash.git?branch=shielded-voting-wallet-support#6858db4a523de05f7474a89c7df751510c71874d"
 dependencies = [
  "blake2b_simd",
 ]
@@ -2752,7 +2752,7 @@ dependencies = [
 [[package]]
 name = "librustvoting"
 version = "0.1.0"
-source = "git+https://github.com/valargroup/librustvoting.git#3860780a34ab37ced8a4db6752990474291d3610"
+source = "git+https://github.com/valargroup/librustvoting.git#2ca134a9cf7fb3bd2718795e6be7007d432a48da"
 dependencies = [
  "blake2b_simd",
  "ff",
@@ -2770,11 +2770,13 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
+ "shardtree",
  "subtle",
  "thiserror 2.0.18",
  "vote-commitment-tree",
  "vote-commitment-tree-client",
  "voting-circuits",
+ "zcash_client_sqlite",
  "zcash_keys",
  "zcash_primitives",
  "zcash_protocol",
@@ -3426,7 +3428,7 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 [[package]]
 name = "pczt"
 version = "0.5.1"
-source = "git+https://github.com/valargroup/librustzcash.git?branch=shielded-voting-wallet-support#efb5f3470c69cff71a746deaff8318bc2b7e8aae"
+source = "git+https://github.com/valargroup/librustzcash.git?branch=shielded-voting-wallet-support#6858db4a523de05f7474a89c7df751510c71874d"
 dependencies = [
  "blake2b_simd",
  "bls12_381",
@@ -6629,7 +6631,7 @@ checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 [[package]]
 name = "vote-commitment-tree"
 version = "0.1.0"
-source = "git+https://github.com/valargroup/librustvoting.git#3860780a34ab37ced8a4db6752990474291d3610"
+source = "git+https://github.com/valargroup/librustvoting.git#2ca134a9cf7fb3bd2718795e6be7007d432a48da"
 dependencies = [
  "anyhow",
  "ff",
@@ -6645,7 +6647,7 @@ dependencies = [
 [[package]]
 name = "vote-commitment-tree-client"
 version = "0.1.0"
-source = "git+https://github.com/valargroup/librustvoting.git#3860780a34ab37ced8a4db6752990474291d3610"
+source = "git+https://github.com/valargroup/librustvoting.git#2ca134a9cf7fb3bd2718795e6be7007d432a48da"
 dependencies = [
  "base64",
  "clap",
@@ -7383,7 +7385,7 @@ dependencies = [
 [[package]]
 name = "zcash_address"
 version = "0.10.1"
-source = "git+https://github.com/valargroup/librustzcash.git?branch=shielded-voting-wallet-support#efb5f3470c69cff71a746deaff8318bc2b7e8aae"
+source = "git+https://github.com/valargroup/librustzcash.git?branch=shielded-voting-wallet-support#6858db4a523de05f7474a89c7df751510c71874d"
 dependencies = [
  "bech32",
  "bs58",
@@ -7396,7 +7398,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_backend"
 version = "0.21.2"
-source = "git+https://github.com/valargroup/librustzcash.git?branch=shielded-voting-wallet-support#efb5f3470c69cff71a746deaff8318bc2b7e8aae"
+source = "git+https://github.com/valargroup/librustzcash.git?branch=shielded-voting-wallet-support#6858db4a523de05f7474a89c7df751510c71874d"
 dependencies = [
  "arti-client",
  "base64",
@@ -7464,7 +7466,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_sqlite"
 version = "0.19.5"
-source = "git+https://github.com/valargroup/librustzcash.git?branch=shielded-voting-wallet-support#efb5f3470c69cff71a746deaff8318bc2b7e8aae"
+source = "git+https://github.com/valargroup/librustzcash.git?branch=shielded-voting-wallet-support#6858db4a523de05f7474a89c7df751510c71874d"
 dependencies = [
  "bip32",
  "bitflags 2.11.0",
@@ -7510,7 +7512,7 @@ dependencies = [
 [[package]]
 name = "zcash_encoding"
 version = "0.3.0"
-source = "git+https://github.com/valargroup/librustzcash.git?branch=shielded-voting-wallet-support#efb5f3470c69cff71a746deaff8318bc2b7e8aae"
+source = "git+https://github.com/valargroup/librustzcash.git?branch=shielded-voting-wallet-support#6858db4a523de05f7474a89c7df751510c71874d"
 dependencies = [
  "core2",
  "nonempty",
@@ -7519,7 +7521,7 @@ dependencies = [
 [[package]]
 name = "zcash_keys"
 version = "0.12.0"
-source = "git+https://github.com/valargroup/librustzcash.git?branch=shielded-voting-wallet-support#efb5f3470c69cff71a746deaff8318bc2b7e8aae"
+source = "git+https://github.com/valargroup/librustzcash.git?branch=shielded-voting-wallet-support#6858db4a523de05f7474a89c7df751510c71874d"
 dependencies = [
  "bech32",
  "bip32",
@@ -7561,7 +7563,7 @@ dependencies = [
 [[package]]
 name = "zcash_primitives"
 version = "0.26.1"
-source = "git+https://github.com/valargroup/librustzcash.git?branch=shielded-voting-wallet-support#efb5f3470c69cff71a746deaff8318bc2b7e8aae"
+source = "git+https://github.com/valargroup/librustzcash.git?branch=shielded-voting-wallet-support#6858db4a523de05f7474a89c7df751510c71874d"
 dependencies = [
  "bip32",
  "blake2b_simd",
@@ -7626,7 +7628,7 @@ dependencies = [
 [[package]]
 name = "zcash_protocol"
 version = "0.7.1"
-source = "git+https://github.com/valargroup/librustzcash.git?branch=shielded-voting-wallet-support#efb5f3470c69cff71a746deaff8318bc2b7e8aae"
+source = "git+https://github.com/valargroup/librustzcash.git?branch=shielded-voting-wallet-support#6858db4a523de05f7474a89c7df751510c71874d"
 dependencies = [
  "core2",
  "document-features",
@@ -7663,7 +7665,7 @@ dependencies = [
 [[package]]
 name = "zcash_transparent"
 version = "0.6.1"
-source = "git+https://github.com/valargroup/librustzcash.git?branch=shielded-voting-wallet-support#efb5f3470c69cff71a746deaff8318bc2b7e8aae"
+source = "git+https://github.com/valargroup/librustzcash.git?branch=shielded-voting-wallet-support#6858db4a523de05f7474a89c7df751510c71874d"
 dependencies = [
  "bip32",
  "blake2b_simd",
@@ -7794,7 +7796,7 @@ dependencies = [
 [[package]]
 name = "zip321"
 version = "0.6.0"
-source = "git+https://github.com/valargroup/librustzcash.git?branch=shielded-voting-wallet-support#efb5f3470c69cff71a746deaff8318bc2b7e8aae"
+source = "git+https://github.com/valargroup/librustzcash.git?branch=shielded-voting-wallet-support#6858db4a523de05f7474a89c7df751510c71874d"
 dependencies = [
  "base64",
  "nom",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1256,7 +1256,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd5f2b7218a51c827a11d22d1439b598121fac94bf9b99452e4afffe512d78c9"
 dependencies = [
  "heck",
- "indexmap 1.9.3",
+ "indexmap 2.14.0",
  "itertools 0.14.0",
  "proc-macro-crate",
  "proc-macro2",
@@ -1575,7 +1575,7 @@ dependencies = [
 [[package]]
 name = "equihash"
 version = "0.2.2"
-source = "git+https://github.com/valargroup/librustzcash.git?rev=6858db4a523de05f7474a89c7df751510c71874d#6858db4a523de05f7474a89c7df751510c71874d"
+source = "git+https://github.com/valargroup/librustzcash.git?rev=1d3ac2fa9977e2118301722fb0c98b6aedde02e8#1d3ac2fa9977e2118301722fb0c98b6aedde02e8"
 dependencies = [
  "blake2b_simd",
  "core2",
@@ -1611,7 +1611,7 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.1"
-source = "git+https://github.com/valargroup/librustzcash.git?rev=6858db4a523de05f7474a89c7df751510c71874d#6858db4a523de05f7474a89c7df751510c71874d"
+source = "git+https://github.com/valargroup/librustzcash.git?rev=1d3ac2fa9977e2118301722fb0c98b6aedde02e8#1d3ac2fa9977e2118301722fb0c98b6aedde02e8"
 dependencies = [
  "blake2b_simd",
 ]
@@ -2705,7 +2705,7 @@ dependencies = [
 [[package]]
 name = "librustvoting"
 version = "0.1.0"
-source = "git+https://github.com/valargroup/librustvoting.git?rev=8ff443286d313182625cfb504061700f29130d88#8ff443286d313182625cfb504061700f29130d88"
+source = "git+https://github.com/valargroup/librustvoting.git?rev=126c11d354c28de257d75558f0d88bcee0f2e0d0#126c11d354c28de257d75558f0d88bcee0f2e0d0"
 dependencies = [
  "blake2b_simd",
  "ff",
@@ -2723,13 +2723,11 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
- "shardtree",
  "subtle",
  "thiserror 2.0.18",
  "vote-commitment-tree",
  "vote-commitment-tree-client",
  "voting-circuits",
- "zcash_client_sqlite",
  "zcash_keys",
  "zcash_primitives",
  "zcash_protocol",
@@ -3391,7 +3389,7 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 [[package]]
 name = "pczt"
 version = "0.5.1"
-source = "git+https://github.com/valargroup/librustzcash.git?rev=6858db4a523de05f7474a89c7df751510c71874d#6858db4a523de05f7474a89c7df751510c71874d"
+source = "git+https://github.com/valargroup/librustzcash.git?rev=1d3ac2fa9977e2118301722fb0c98b6aedde02e8#1d3ac2fa9977e2118301722fb0c98b6aedde02e8"
 dependencies = [
  "blake2b_simd",
  "bls12_381",
@@ -6594,7 +6592,7 @@ checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 [[package]]
 name = "vote-commitment-tree"
 version = "0.1.0"
-source = "git+https://github.com/valargroup/librustvoting.git?rev=8ff443286d313182625cfb504061700f29130d88#8ff443286d313182625cfb504061700f29130d88"
+source = "git+https://github.com/valargroup/librustvoting.git?rev=126c11d354c28de257d75558f0d88bcee0f2e0d0#126c11d354c28de257d75558f0d88bcee0f2e0d0"
 dependencies = [
  "anyhow",
  "ff",
@@ -6610,7 +6608,7 @@ dependencies = [
 [[package]]
 name = "vote-commitment-tree-client"
 version = "0.1.0"
-source = "git+https://github.com/valargroup/librustvoting.git?rev=8ff443286d313182625cfb504061700f29130d88#8ff443286d313182625cfb504061700f29130d88"
+source = "git+https://github.com/valargroup/librustvoting.git?rev=126c11d354c28de257d75558f0d88bcee0f2e0d0#126c11d354c28de257d75558f0d88bcee0f2e0d0"
 dependencies = [
  "base64",
  "clap",
@@ -7276,7 +7274,7 @@ dependencies = [
 [[package]]
 name = "zcash_address"
 version = "0.10.1"
-source = "git+https://github.com/valargroup/librustzcash.git?rev=6858db4a523de05f7474a89c7df751510c71874d#6858db4a523de05f7474a89c7df751510c71874d"
+source = "git+https://github.com/valargroup/librustzcash.git?rev=1d3ac2fa9977e2118301722fb0c98b6aedde02e8#1d3ac2fa9977e2118301722fb0c98b6aedde02e8"
 dependencies = [
  "bech32",
  "bs58",
@@ -7289,7 +7287,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_backend"
 version = "0.21.2"
-source = "git+https://github.com/valargroup/librustzcash.git?rev=6858db4a523de05f7474a89c7df751510c71874d#6858db4a523de05f7474a89c7df751510c71874d"
+source = "git+https://github.com/valargroup/librustzcash.git?rev=1d3ac2fa9977e2118301722fb0c98b6aedde02e8#1d3ac2fa9977e2118301722fb0c98b6aedde02e8"
 dependencies = [
  "arti-client",
  "base64",
@@ -7357,7 +7355,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_sqlite"
 version = "0.19.5"
-source = "git+https://github.com/valargroup/librustzcash.git?rev=6858db4a523de05f7474a89c7df751510c71874d#6858db4a523de05f7474a89c7df751510c71874d"
+source = "git+https://github.com/valargroup/librustzcash.git?rev=1d3ac2fa9977e2118301722fb0c98b6aedde02e8#1d3ac2fa9977e2118301722fb0c98b6aedde02e8"
 dependencies = [
  "bip32",
  "bitflags 2.11.0",
@@ -7403,7 +7401,7 @@ dependencies = [
 [[package]]
 name = "zcash_encoding"
 version = "0.3.0"
-source = "git+https://github.com/valargroup/librustzcash.git?rev=6858db4a523de05f7474a89c7df751510c71874d#6858db4a523de05f7474a89c7df751510c71874d"
+source = "git+https://github.com/valargroup/librustzcash.git?rev=1d3ac2fa9977e2118301722fb0c98b6aedde02e8#1d3ac2fa9977e2118301722fb0c98b6aedde02e8"
 dependencies = [
  "core2",
  "nonempty",
@@ -7412,7 +7410,7 @@ dependencies = [
 [[package]]
 name = "zcash_keys"
 version = "0.12.0"
-source = "git+https://github.com/valargroup/librustzcash.git?rev=6858db4a523de05f7474a89c7df751510c71874d#6858db4a523de05f7474a89c7df751510c71874d"
+source = "git+https://github.com/valargroup/librustzcash.git?rev=1d3ac2fa9977e2118301722fb0c98b6aedde02e8#1d3ac2fa9977e2118301722fb0c98b6aedde02e8"
 dependencies = [
  "bech32",
  "bip32",
@@ -7454,7 +7452,7 @@ dependencies = [
 [[package]]
 name = "zcash_primitives"
 version = "0.26.1"
-source = "git+https://github.com/valargroup/librustzcash.git?rev=6858db4a523de05f7474a89c7df751510c71874d#6858db4a523de05f7474a89c7df751510c71874d"
+source = "git+https://github.com/valargroup/librustzcash.git?rev=1d3ac2fa9977e2118301722fb0c98b6aedde02e8#1d3ac2fa9977e2118301722fb0c98b6aedde02e8"
 dependencies = [
  "bip32",
  "blake2b_simd",
@@ -7519,7 +7517,7 @@ dependencies = [
 [[package]]
 name = "zcash_protocol"
 version = "0.7.1"
-source = "git+https://github.com/valargroup/librustzcash.git?rev=6858db4a523de05f7474a89c7df751510c71874d#6858db4a523de05f7474a89c7df751510c71874d"
+source = "git+https://github.com/valargroup/librustzcash.git?rev=1d3ac2fa9977e2118301722fb0c98b6aedde02e8#1d3ac2fa9977e2118301722fb0c98b6aedde02e8"
 dependencies = [
  "core2",
  "document-features",
@@ -7556,7 +7554,7 @@ dependencies = [
 [[package]]
 name = "zcash_transparent"
 version = "0.6.1"
-source = "git+https://github.com/valargroup/librustzcash.git?rev=6858db4a523de05f7474a89c7df751510c71874d#6858db4a523de05f7474a89c7df751510c71874d"
+source = "git+https://github.com/valargroup/librustzcash.git?rev=1d3ac2fa9977e2118301722fb0c98b6aedde02e8#1d3ac2fa9977e2118301722fb0c98b6aedde02e8"
 dependencies = [
  "bip32",
  "blake2b_simd",
@@ -7666,7 +7664,7 @@ dependencies = [
 [[package]]
 name = "zip321"
 version = "0.6.0"
-source = "git+https://github.com/valargroup/librustzcash.git?rev=6858db4a523de05f7474a89c7df751510c71874d#6858db4a523de05f7474a89c7df751510c71874d"
+source = "git+https://github.com/valargroup/librustzcash.git?rev=1d3ac2fa9977e2118301722fb0c98b6aedde02e8#1d3ac2fa9977e2118301722fb0c98b6aedde02e8"
 dependencies = [
  "base64",
  "nom",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1575,7 +1575,7 @@ dependencies = [
 [[package]]
 name = "equihash"
 version = "0.2.2"
-source = "git+https://github.com/valargroup/librustzcash.git?rev=1d3ac2fa9977e2118301722fb0c98b6aedde02e8#1d3ac2fa9977e2118301722fb0c98b6aedde02e8"
+source = "git+https://github.com/valargroup/librustzcash.git?rev=38ef1c6c81e9b0663aedbd81f904c51a204fa72f#38ef1c6c81e9b0663aedbd81f904c51a204fa72f"
 dependencies = [
  "blake2b_simd",
  "core2",
@@ -1611,7 +1611,7 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.1"
-source = "git+https://github.com/valargroup/librustzcash.git?rev=1d3ac2fa9977e2118301722fb0c98b6aedde02e8#1d3ac2fa9977e2118301722fb0c98b6aedde02e8"
+source = "git+https://github.com/valargroup/librustzcash.git?rev=38ef1c6c81e9b0663aedbd81f904c51a204fa72f#38ef1c6c81e9b0663aedbd81f904c51a204fa72f"
 dependencies = [
  "blake2b_simd",
 ]
@@ -3389,7 +3389,7 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 [[package]]
 name = "pczt"
 version = "0.5.1"
-source = "git+https://github.com/valargroup/librustzcash.git?rev=1d3ac2fa9977e2118301722fb0c98b6aedde02e8#1d3ac2fa9977e2118301722fb0c98b6aedde02e8"
+source = "git+https://github.com/valargroup/librustzcash.git?rev=38ef1c6c81e9b0663aedbd81f904c51a204fa72f#38ef1c6c81e9b0663aedbd81f904c51a204fa72f"
 dependencies = [
  "blake2b_simd",
  "bls12_381",
@@ -7274,7 +7274,7 @@ dependencies = [
 [[package]]
 name = "zcash_address"
 version = "0.10.1"
-source = "git+https://github.com/valargroup/librustzcash.git?rev=1d3ac2fa9977e2118301722fb0c98b6aedde02e8#1d3ac2fa9977e2118301722fb0c98b6aedde02e8"
+source = "git+https://github.com/valargroup/librustzcash.git?rev=38ef1c6c81e9b0663aedbd81f904c51a204fa72f#38ef1c6c81e9b0663aedbd81f904c51a204fa72f"
 dependencies = [
  "bech32",
  "bs58",
@@ -7287,7 +7287,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_backend"
 version = "0.21.2"
-source = "git+https://github.com/valargroup/librustzcash.git?rev=1d3ac2fa9977e2118301722fb0c98b6aedde02e8#1d3ac2fa9977e2118301722fb0c98b6aedde02e8"
+source = "git+https://github.com/valargroup/librustzcash.git?rev=38ef1c6c81e9b0663aedbd81f904c51a204fa72f#38ef1c6c81e9b0663aedbd81f904c51a204fa72f"
 dependencies = [
  "arti-client",
  "base64",
@@ -7355,7 +7355,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_sqlite"
 version = "0.19.5"
-source = "git+https://github.com/valargroup/librustzcash.git?rev=1d3ac2fa9977e2118301722fb0c98b6aedde02e8#1d3ac2fa9977e2118301722fb0c98b6aedde02e8"
+source = "git+https://github.com/valargroup/librustzcash.git?rev=38ef1c6c81e9b0663aedbd81f904c51a204fa72f#38ef1c6c81e9b0663aedbd81f904c51a204fa72f"
 dependencies = [
  "bip32",
  "bitflags 2.11.0",
@@ -7401,7 +7401,7 @@ dependencies = [
 [[package]]
 name = "zcash_encoding"
 version = "0.3.0"
-source = "git+https://github.com/valargroup/librustzcash.git?rev=1d3ac2fa9977e2118301722fb0c98b6aedde02e8#1d3ac2fa9977e2118301722fb0c98b6aedde02e8"
+source = "git+https://github.com/valargroup/librustzcash.git?rev=38ef1c6c81e9b0663aedbd81f904c51a204fa72f#38ef1c6c81e9b0663aedbd81f904c51a204fa72f"
 dependencies = [
  "core2",
  "nonempty",
@@ -7410,7 +7410,7 @@ dependencies = [
 [[package]]
 name = "zcash_keys"
 version = "0.12.0"
-source = "git+https://github.com/valargroup/librustzcash.git?rev=1d3ac2fa9977e2118301722fb0c98b6aedde02e8#1d3ac2fa9977e2118301722fb0c98b6aedde02e8"
+source = "git+https://github.com/valargroup/librustzcash.git?rev=38ef1c6c81e9b0663aedbd81f904c51a204fa72f#38ef1c6c81e9b0663aedbd81f904c51a204fa72f"
 dependencies = [
  "bech32",
  "bip32",
@@ -7452,7 +7452,7 @@ dependencies = [
 [[package]]
 name = "zcash_primitives"
 version = "0.26.1"
-source = "git+https://github.com/valargroup/librustzcash.git?rev=1d3ac2fa9977e2118301722fb0c98b6aedde02e8#1d3ac2fa9977e2118301722fb0c98b6aedde02e8"
+source = "git+https://github.com/valargroup/librustzcash.git?rev=38ef1c6c81e9b0663aedbd81f904c51a204fa72f#38ef1c6c81e9b0663aedbd81f904c51a204fa72f"
 dependencies = [
  "bip32",
  "blake2b_simd",
@@ -7517,7 +7517,7 @@ dependencies = [
 [[package]]
 name = "zcash_protocol"
 version = "0.7.1"
-source = "git+https://github.com/valargroup/librustzcash.git?rev=1d3ac2fa9977e2118301722fb0c98b6aedde02e8#1d3ac2fa9977e2118301722fb0c98b6aedde02e8"
+source = "git+https://github.com/valargroup/librustzcash.git?rev=38ef1c6c81e9b0663aedbd81f904c51a204fa72f#38ef1c6c81e9b0663aedbd81f904c51a204fa72f"
 dependencies = [
  "core2",
  "document-features",
@@ -7554,7 +7554,7 @@ dependencies = [
 [[package]]
 name = "zcash_transparent"
 version = "0.6.1"
-source = "git+https://github.com/valargroup/librustzcash.git?rev=1d3ac2fa9977e2118301722fb0c98b6aedde02e8#1d3ac2fa9977e2118301722fb0c98b6aedde02e8"
+source = "git+https://github.com/valargroup/librustzcash.git?rev=38ef1c6c81e9b0663aedbd81f904c51a204fa72f#38ef1c6c81e9b0663aedbd81f904c51a204fa72f"
 dependencies = [
  "bip32",
  "blake2b_simd",
@@ -7664,7 +7664,7 @@ dependencies = [
 [[package]]
 name = "zip321"
 version = "0.6.0"
-source = "git+https://github.com/valargroup/librustzcash.git?rev=1d3ac2fa9977e2118301722fb0c98b6aedde02e8#1d3ac2fa9977e2118301722fb0c98b6aedde02e8"
+source = "git+https://github.com/valargroup/librustzcash.git?rev=38ef1c6c81e9b0663aedbd81f904c51a204fa72f#38ef1c6c81e9b0663aedbd81f904c51a204fa72f"
 dependencies = [
  "base64",
  "nom",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1575,7 +1575,7 @@ dependencies = [
 [[package]]
 name = "equihash"
 version = "0.2.2"
-source = "git+https://github.com/valargroup/librustzcash.git?rev=38ef1c6c81e9b0663aedbd81f904c51a204fa72f#38ef1c6c81e9b0663aedbd81f904c51a204fa72f"
+source = "git+https://github.com/valargroup/librustzcash.git?rev=7c8c8b0e0ce6769a4b58ea96d97fb78b9d98e1fc#7c8c8b0e0ce6769a4b58ea96d97fb78b9d98e1fc"
 dependencies = [
  "blake2b_simd",
  "core2",
@@ -1611,7 +1611,7 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.1"
-source = "git+https://github.com/valargroup/librustzcash.git?rev=38ef1c6c81e9b0663aedbd81f904c51a204fa72f#38ef1c6c81e9b0663aedbd81f904c51a204fa72f"
+source = "git+https://github.com/valargroup/librustzcash.git?rev=7c8c8b0e0ce6769a4b58ea96d97fb78b9d98e1fc#7c8c8b0e0ce6769a4b58ea96d97fb78b9d98e1fc"
 dependencies = [
  "blake2b_simd",
 ]
@@ -3389,7 +3389,7 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 [[package]]
 name = "pczt"
 version = "0.5.1"
-source = "git+https://github.com/valargroup/librustzcash.git?rev=38ef1c6c81e9b0663aedbd81f904c51a204fa72f#38ef1c6c81e9b0663aedbd81f904c51a204fa72f"
+source = "git+https://github.com/valargroup/librustzcash.git?rev=7c8c8b0e0ce6769a4b58ea96d97fb78b9d98e1fc#7c8c8b0e0ce6769a4b58ea96d97fb78b9d98e1fc"
 dependencies = [
  "blake2b_simd",
  "bls12_381",
@@ -7274,7 +7274,7 @@ dependencies = [
 [[package]]
 name = "zcash_address"
 version = "0.10.1"
-source = "git+https://github.com/valargroup/librustzcash.git?rev=38ef1c6c81e9b0663aedbd81f904c51a204fa72f#38ef1c6c81e9b0663aedbd81f904c51a204fa72f"
+source = "git+https://github.com/valargroup/librustzcash.git?rev=7c8c8b0e0ce6769a4b58ea96d97fb78b9d98e1fc#7c8c8b0e0ce6769a4b58ea96d97fb78b9d98e1fc"
 dependencies = [
  "bech32",
  "bs58",
@@ -7287,7 +7287,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_backend"
 version = "0.21.2"
-source = "git+https://github.com/valargroup/librustzcash.git?rev=38ef1c6c81e9b0663aedbd81f904c51a204fa72f#38ef1c6c81e9b0663aedbd81f904c51a204fa72f"
+source = "git+https://github.com/valargroup/librustzcash.git?rev=7c8c8b0e0ce6769a4b58ea96d97fb78b9d98e1fc#7c8c8b0e0ce6769a4b58ea96d97fb78b9d98e1fc"
 dependencies = [
  "arti-client",
  "base64",
@@ -7355,7 +7355,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_sqlite"
 version = "0.19.5"
-source = "git+https://github.com/valargroup/librustzcash.git?rev=38ef1c6c81e9b0663aedbd81f904c51a204fa72f#38ef1c6c81e9b0663aedbd81f904c51a204fa72f"
+source = "git+https://github.com/valargroup/librustzcash.git?rev=7c8c8b0e0ce6769a4b58ea96d97fb78b9d98e1fc#7c8c8b0e0ce6769a4b58ea96d97fb78b9d98e1fc"
 dependencies = [
  "bip32",
  "bitflags 2.11.0",
@@ -7401,7 +7401,7 @@ dependencies = [
 [[package]]
 name = "zcash_encoding"
 version = "0.3.0"
-source = "git+https://github.com/valargroup/librustzcash.git?rev=38ef1c6c81e9b0663aedbd81f904c51a204fa72f#38ef1c6c81e9b0663aedbd81f904c51a204fa72f"
+source = "git+https://github.com/valargroup/librustzcash.git?rev=7c8c8b0e0ce6769a4b58ea96d97fb78b9d98e1fc#7c8c8b0e0ce6769a4b58ea96d97fb78b9d98e1fc"
 dependencies = [
  "core2",
  "nonempty",
@@ -7410,7 +7410,7 @@ dependencies = [
 [[package]]
 name = "zcash_keys"
 version = "0.12.0"
-source = "git+https://github.com/valargroup/librustzcash.git?rev=38ef1c6c81e9b0663aedbd81f904c51a204fa72f#38ef1c6c81e9b0663aedbd81f904c51a204fa72f"
+source = "git+https://github.com/valargroup/librustzcash.git?rev=7c8c8b0e0ce6769a4b58ea96d97fb78b9d98e1fc#7c8c8b0e0ce6769a4b58ea96d97fb78b9d98e1fc"
 dependencies = [
  "bech32",
  "bip32",
@@ -7452,7 +7452,7 @@ dependencies = [
 [[package]]
 name = "zcash_primitives"
 version = "0.26.1"
-source = "git+https://github.com/valargroup/librustzcash.git?rev=38ef1c6c81e9b0663aedbd81f904c51a204fa72f#38ef1c6c81e9b0663aedbd81f904c51a204fa72f"
+source = "git+https://github.com/valargroup/librustzcash.git?rev=7c8c8b0e0ce6769a4b58ea96d97fb78b9d98e1fc#7c8c8b0e0ce6769a4b58ea96d97fb78b9d98e1fc"
 dependencies = [
  "bip32",
  "blake2b_simd",
@@ -7517,7 +7517,7 @@ dependencies = [
 [[package]]
 name = "zcash_protocol"
 version = "0.7.1"
-source = "git+https://github.com/valargroup/librustzcash.git?rev=38ef1c6c81e9b0663aedbd81f904c51a204fa72f#38ef1c6c81e9b0663aedbd81f904c51a204fa72f"
+source = "git+https://github.com/valargroup/librustzcash.git?rev=7c8c8b0e0ce6769a4b58ea96d97fb78b9d98e1fc#7c8c8b0e0ce6769a4b58ea96d97fb78b9d98e1fc"
 dependencies = [
  "core2",
  "document-features",
@@ -7554,7 +7554,7 @@ dependencies = [
 [[package]]
 name = "zcash_transparent"
 version = "0.6.1"
-source = "git+https://github.com/valargroup/librustzcash.git?rev=38ef1c6c81e9b0663aedbd81f904c51a204fa72f#38ef1c6c81e9b0663aedbd81f904c51a204fa72f"
+source = "git+https://github.com/valargroup/librustzcash.git?rev=7c8c8b0e0ce6769a4b58ea96d97fb78b9d98e1fc#7c8c8b0e0ce6769a4b58ea96d97fb78b9d98e1fc"
 dependencies = [
  "bip32",
  "blake2b_simd",
@@ -7664,7 +7664,7 @@ dependencies = [
 [[package]]
 name = "zip321"
 version = "0.6.0"
-source = "git+https://github.com/valargroup/librustzcash.git?rev=38ef1c6c81e9b0663aedbd81f904c51a204fa72f#38ef1c6c81e9b0663aedbd81f904c51a204fa72f"
+source = "git+https://github.com/valargroup/librustzcash.git?rev=7c8c8b0e0ce6769a4b58ea96d97fb78b9d98e1fc#7c8c8b0e0ce6769a4b58ea96d97fb78b9d98e1fc"
 dependencies = [
  "base64",
  "nom",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -160,7 +160,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -171,7 +171,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1376,7 +1376,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1599,7 +1599,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2679,7 +2679,7 @@ version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a1886916523694cd6ea3d175f03a1e5010699a2a4cc13696d83d7bea1d80638"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3077,7 +3077,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4282,7 +4282,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4819,7 +4819,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5038,7 +5038,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6881,7 +6881,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,27 +102,12 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
-version = "0.6.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
-dependencies = [
- "anstyle",
- "anstyle-parse 0.2.7",
- "anstyle-query",
- "anstyle-wincon",
- "colorchoice",
- "is_terminal_polyfill",
- "utf8parse",
-]
-
-[[package]]
-name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
- "anstyle-parse 1.0.0",
+ "anstyle-parse",
  "anstyle-query",
  "anstyle-wincon",
  "colorchoice",
@@ -135,15 +120,6 @@ name = "anstyle"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
-
-[[package]]
-name = "anstyle-parse"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
-dependencies = [
- "utf8parse",
-]
 
 [[package]]
 name = "anstyle-parse"
@@ -684,7 +660,7 @@ checksum = "befbfd072a8e81c02f8c507aefce431fe5e7d051f83d48a23ffc9b9fe5a11799"
 dependencies = [
  "clap",
  "heck",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "log",
  "proc-macro2",
  "quote",
@@ -697,9 +673,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.57"
+version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -823,7 +799,7 @@ version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
- "anstream 1.0.0",
+ "anstream",
  "anstyle",
  "clap_lex",
  "strsim 0.11.1",
@@ -1261,7 +1237,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd5f2b7218a51c827a11d22d1439b598121fac94bf9b99452e4afffe512d78c9"
 dependencies = [
  "heck",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "itertools 0.14.0",
  "proc-macro-crate",
  "proc-macro2",
@@ -1556,9 +1532,9 @@ dependencies = [
 
 [[package]]
 name = "env_filter"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a1c3cc8e57274ec99de65301228b537f1e4eedc1b8e0f9411c6caac8ae7308f"
+checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
 dependencies = [
  "log",
  "regex",
@@ -1566,11 +1542,11 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.11.9"
+version = "0.11.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2daee4ea451f429a58296525ddf28b45a3b64f1acf6587e2067437bb11e218d"
+checksum = "0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a"
 dependencies = [
- "anstream 0.6.21",
+ "anstream",
  "anstyle",
  "env_filter",
  "jiff",
@@ -1580,7 +1556,7 @@ dependencies = [
 [[package]]
 name = "equihash"
 version = "0.2.2"
-source = "git+https://github.com/valargroup/librustzcash.git?branch=shielded-voting-wallet-support#6858db4a523de05f7474a89c7df751510c71874d"
+source = "git+https://github.com/valargroup/librustzcash.git?rev=6858db4a523de05f7474a89c7df751510c71874d#6858db4a523de05f7474a89c7df751510c71874d"
 dependencies = [
  "blake2b_simd",
  "core2",
@@ -1616,7 +1592,7 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.1"
-source = "git+https://github.com/valargroup/librustzcash.git?branch=shielded-voting-wallet-support#6858db4a523de05f7474a89c7df751510c71874d"
+source = "git+https://github.com/valargroup/librustzcash.git?rev=6858db4a523de05f7474a89c7df751510c71874d#6858db4a523de05f7474a89c7df751510c71874d"
 dependencies = [
  "blake2b_simd",
 ]
@@ -1635,9 +1611,9 @@ checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "ff"
@@ -1998,7 +1974,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -2088,9 +2064,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "hashlink"
@@ -2233,9 +2209,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2248,7 +2224,6 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -2336,7 +2311,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -2350,12 +2325,13 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -2363,9 +2339,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -2376,9 +2352,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -2390,15 +2366,15 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -2410,15 +2386,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -2465,20 +2441,8 @@ dependencies = [
 [[package]]
 name = "imt-tree"
 version = "0.1.0"
-source = "git+https://github.com/valargroup/vote-nullifier-pir.git?branch=main#d6cdd4612aa1a7be82d8b6b8af3fc5a13f330d8a"
-dependencies = [
- "anyhow",
- "ff",
- "halo2_gadgets",
- "hex",
- "pasta_curves",
- "rayon",
-]
-
-[[package]]
-name = "imt-tree"
-version = "0.1.0"
-source = "git+https://github.com/valargroup/vote-nullifier-pir.git#d6cdd4612aa1a7be82d8b6b8af3fc5a13f330d8a"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d10acb863735c6c82c0c79e8752696096a86eb4d1e2fe0005ded4fae066297e"
 dependencies = [
  "anyhow",
  "ff",
@@ -2510,12 +2474,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "serde",
  "serde_core",
 ]
@@ -2551,9 +2515,9 @@ dependencies = [
 
 [[package]]
 name = "inventory"
-version = "0.3.22"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "009ae045c87e7082cb72dab0ccd01ae075dd00141ddc108f43a0ea150a9e7227"
+checksum = "a4f0c30c76f2f4ccee3fe55a2435f691ca00c0e4bd87abe4f4a851b1d4dac39b"
 dependencies = [
  "rustversion",
 ]
@@ -2566,9 +2530,9 @@ checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "iri-string"
-version = "0.7.10"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
+checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
 dependencies = [
  "memchr",
  "serde",
@@ -2640,10 +2604,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.91"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -2717,9 +2683,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.184"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
 name = "libloading"
@@ -2739,20 +2705,20 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.14"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
  "bitflags 2.11.0",
  "libc",
  "plain",
- "redox_syscall 0.7.3",
+ "redox_syscall 0.7.4",
 ]
 
 [[package]]
 name = "librustvoting"
 version = "0.1.0"
-source = "git+https://github.com/valargroup/librustvoting.git#2ca134a9cf7fb3bd2718795e6be7007d432a48da"
+source = "git+https://github.com/valargroup/librustvoting.git?rev=8ff443286d313182625cfb504061700f29130d88#8ff443286d313182625cfb504061700f29130d88"
 dependencies = [
  "blake2b_simd",
  "ff",
@@ -2854,9 +2820,9 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "litrs"
@@ -2981,9 +2947,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "log",
@@ -3428,7 +3394,7 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 [[package]]
 name = "pczt"
 version = "0.5.1"
-source = "git+https://github.com/valargroup/librustzcash.git?branch=shielded-voting-wallet-support#6858db4a523de05f7474a89c7df751510c71874d"
+source = "git+https://github.com/valargroup/librustzcash.git?rev=6858db4a523de05f7474a89c7df751510c71874d#6858db4a523de05f7474a89c7df751510c71874d"
 dependencies = [
  "blake2b_simd",
  "bls12_381",
@@ -3475,7 +3441,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
 dependencies = [
  "fixedbitset",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
 ]
 
 [[package]]
@@ -3486,7 +3452,7 @@ checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
 dependencies = [
  "fixedbitset",
  "hashbrown 0.15.5",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
 ]
 
 [[package]]
@@ -3559,38 +3525,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
 name = "pir-client"
 version = "0.1.0"
-source = "git+https://github.com/valargroup/vote-nullifier-pir.git?branch=main#d6cdd4612aa1a7be82d8b6b8af3fc5a13f330d8a"
+source = "git+https://github.com/valargroup/vote-nullifier-pir.git?rev=d976e13#d976e13e5a69e5f03f0cede235af18c1257a6895"
 dependencies = [
  "anyhow",
  "ff",
  "futures",
  "hex",
- "imt-tree 0.1.0 (git+https://github.com/valargroup/vote-nullifier-pir.git?branch=main)",
+ "imt-tree",
  "log",
  "pasta_curves",
  "pir-types",
  "reqwest",
  "serde_json",
  "tokio",
- "ypir",
+ "valar-ypir",
 ]
 
 [[package]]
 name = "pir-types"
 version = "0.1.0"
-source = "git+https://github.com/valargroup/vote-nullifier-pir.git?branch=main#d6cdd4612aa1a7be82d8b6b8af3fc5a13f330d8a"
+source = "git+https://github.com/valargroup/vote-nullifier-pir.git?rev=d976e13#d976e13e5a69e5f03f0cede235af18c1257a6895"
 dependencies = [
  "anyhow",
  "ff",
- "imt-tree 0.1.0 (git+https://github.com/valargroup/vote-nullifier-pir.git?branch=main)",
+ "imt-tree",
  "pasta_curves",
  "serde",
 ]
@@ -3711,9 +3671,9 @@ dependencies = [
 
 [[package]]
 name = "potential_utf"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
@@ -3759,7 +3719,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93980406f12d9f8140ed5abe7155acb10bb1e69ea55c88960b9c2f117445ef96"
 dependencies = [
  "equivalent",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "serde",
 ]
 
@@ -3769,7 +3729,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit 0.25.5+spec-1.1.0",
+ "toml_edit 0.25.11+spec-1.1.0",
 ]
 
 [[package]]
@@ -4043,9 +4003,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
+checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
 dependencies = [
  "bitflags 2.11.0",
 ]
@@ -4239,20 +4199,21 @@ dependencies = [
 
 [[package]]
 name = "rust_decimal"
-version = "1.40.0"
+version = "1.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61f703d19852dbf87cbc513643fa81428361eb6940f1ac14fd58155d295a3eb0"
+checksum = "2ce901f9a19d251159075a4c37af514c3b8ef99c22e02dd8c19161cf397ee94a"
 dependencies = [
  "arrayvec",
  "num-traits",
  "serde",
+ "wasm-bindgen",
 ]
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustc_version"
@@ -4311,9 +4272,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "20a6af516fea4b20eccceaf166e8aa666ac996208e8a644ce3ef5aa783bc7cd4"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -4525,9 +4486,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -4603,9 +4564,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "1.0.4"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
 ]
@@ -4632,7 +4593,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "schemars 0.9.0",
  "schemars 1.2.1",
  "serde_core",
@@ -4756,9 +4717,9 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "sinsemilla"
@@ -4827,20 +4788,6 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
-
-[[package]]
-name = "spiral-rs"
-version = "0.4.0"
-source = "git+https://github.com/valargroup/spiral-rs.git?branch=valar%2Favoid-avx512#e06c730f958ddd0717fda43ae43eb7c628290bd4"
-dependencies = [
- "fastrand",
- "getrandom 0.2.17",
- "rand 0.8.5",
- "rand_chacha 0.3.1",
- "serde_json",
- "sha2 0.10.9",
- "subtle",
-]
 
 [[package]]
 name = "spki"
@@ -5145,9 +5092,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "serde_core",
@@ -5181,9 +5128,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.50.0"
+version = "1.51.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "f66bf9585cda4b724d3e78ab34b73fb2bbaba9011b9bfdf69dc836382ea13b8c"
 dependencies = [
  "bytes",
  "libc",
@@ -5197,9 +5144,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5269,9 +5216,9 @@ version = "0.9.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "serde_core",
- "serde_spanned 1.0.4",
+ "serde_spanned 1.1.1",
  "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "toml_writer",
@@ -5298,9 +5245,9 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "1.0.1+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b320e741db58cac564e26c607d3cc1fdc4a88fd36c879568c07856ed83ff3e9"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
 ]
@@ -5311,7 +5258,7 @@ version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "serde",
  "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
@@ -5321,23 +5268,23 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.25.5+spec-1.1.0"
+version = "0.25.11+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ca1a40644a28bce036923f6a431df0b34236949d111cc07cb6dca830c9ef2e1"
+checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
 dependencies = [
- "indexmap 2.13.0",
- "toml_datetime 1.0.1+spec-1.1.0",
+ "indexmap 2.14.0",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
- "winnow 1.0.0",
+ "winnow 1.0.1",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.0.10+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7df25b4befd31c4816df190124375d5a20c6b6921e2cad937316de3fccd63420"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.0",
+ "winnow 1.0.1",
 ]
 
 [[package]]
@@ -5348,9 +5295,9 @@ checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "toml_writer"
-version = "1.0.7+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f17aaa1c6e3dc22b1da4b6bba97d066e354c7945cac2f7852d4e4e7ca7a6b56d"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tonic"
@@ -6340,7 +6287,7 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "pin-project-lite",
  "slab",
  "sync_wrapper",
@@ -6525,9 +6472,9 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.12.0"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
 name = "unicode-xid"
@@ -6583,14 +6530,48 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.22.0"
+version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
+checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
  "serde_core",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "valar-spiral-rs"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce897de77f8b80c06e3457da2db3585333d2882f9e9f420ac8a79ab6e6a43f09"
+dependencies = [
+ "fastrand",
+ "getrandom 0.2.17",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "serde_json",
+ "sha2 0.10.9",
+ "subtle",
+]
+
+[[package]]
+name = "valar-ypir"
+version = "0.1.0"
+source = "git+https://github.com/valargroup/ypir.git?branch=valar%2Fartifact#970156c297df90bb1871b39e04f0d03b8036f4f9"
+dependencies = [
+ "cc",
+ "clap",
+ "env_logger",
+ "fastrand",
+ "log",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "serde",
+ "serde_json",
+ "sha1",
+ "test-log",
+ "valar-spiral-rs",
 ]
 
 [[package]]
@@ -6631,12 +6612,12 @@ checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 [[package]]
 name = "vote-commitment-tree"
 version = "0.1.0"
-source = "git+https://github.com/valargroup/librustvoting.git#2ca134a9cf7fb3bd2718795e6be7007d432a48da"
+source = "git+https://github.com/valargroup/librustvoting.git?rev=8ff443286d313182625cfb504061700f29130d88#8ff443286d313182625cfb504061700f29130d88"
 dependencies = [
  "anyhow",
  "ff",
  "halo2_gadgets",
- "imt-tree 0.1.0 (git+https://github.com/valargroup/vote-nullifier-pir.git)",
+ "imt-tree",
  "incrementalmerkletree",
  "lazy_static",
  "libc",
@@ -6647,7 +6628,7 @@ dependencies = [
 [[package]]
 name = "vote-commitment-tree-client"
 version = "0.1.0"
-source = "git+https://github.com/valargroup/librustvoting.git#2ca134a9cf7fb3bd2718795e6be7007d432a48da"
+source = "git+https://github.com/valargroup/librustvoting.git?rev=8ff443286d313182625cfb504061700f29130d88#8ff443286d313182625cfb504061700f29130d88"
 dependencies = [
  "base64",
  "clap",
@@ -6734,36 +6715,33 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.114"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
 dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
+ "serde",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.64"
+version = "0.4.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
+checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
 dependencies = [
- "cfg-if",
- "futures-util",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.114"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -6771,9 +6749,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.114"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -6784,9 +6762,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.114"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
 dependencies = [
  "unicode-ident",
 ]
@@ -6808,7 +6786,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -6821,7 +6799,7 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags 2.11.0",
  "hashbrown 0.15.5",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "semver",
 ]
 
@@ -6833,9 +6811,9 @@ checksum = "323f4da9523e9a669e1eaf9c6e763892769b1d38c623913647bfdc1532fe4549"
 
 [[package]]
 name = "web-sys"
-version = "0.3.91"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6897,7 +6875,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
 dependencies = [
  "windows-collections",
- "windows-core",
+ "windows-core 0.61.2",
  "windows-future",
  "windows-link 0.1.3",
  "windows-numerics",
@@ -6909,7 +6887,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
 dependencies = [
- "windows-core",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -6926,12 +6904,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
+]
+
+[[package]]
 name = "windows-future"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
- "windows-core",
+ "windows-core 0.61.2",
  "windows-link 0.1.3",
  "windows-threading",
 ]
@@ -6976,7 +6967,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
- "windows-core",
+ "windows-core 0.61.2",
  "windows-link 0.1.3",
 ]
 
@@ -7203,9 +7194,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a90e88e4667264a994d34e6d1ab2d26d398dcdca8b7f52bec8668957517fc7d8"
+checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
 dependencies = [
  "memchr",
 ]
@@ -7238,7 +7229,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "prettyplease",
  "syn 2.0.117",
  "wasm-metadata",
@@ -7269,7 +7260,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags 2.11.0",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "log",
  "serde",
  "serde_derive",
@@ -7288,7 +7279,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "log",
  "semver",
  "serde",
@@ -7300,9 +7291,9 @@ dependencies = [
 
 [[package]]
 name = "writeable"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "wyz"
@@ -7342,9 +7333,9 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -7353,9 +7344,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7364,28 +7355,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "ypir"
-version = "0.1.0"
-source = "git+https://github.com/valargroup/ypir.git?branch=valar%2Fartifact#bb4d68bf0022b1b6cefc1fda8bf25ea8bce36fef"
-dependencies = [
- "cc",
- "clap",
- "env_logger",
- "fastrand",
- "log",
- "rand 0.8.5",
- "rand_chacha 0.3.1",
- "serde",
- "serde_json",
- "sha1",
- "spiral-rs",
- "test-log",
-]
-
-[[package]]
 name = "zcash_address"
 version = "0.10.1"
-source = "git+https://github.com/valargroup/librustzcash.git?branch=shielded-voting-wallet-support#6858db4a523de05f7474a89c7df751510c71874d"
+source = "git+https://github.com/valargroup/librustzcash.git?rev=6858db4a523de05f7474a89c7df751510c71874d#6858db4a523de05f7474a89c7df751510c71874d"
 dependencies = [
  "bech32",
  "bs58",
@@ -7398,7 +7370,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_backend"
 version = "0.21.2"
-source = "git+https://github.com/valargroup/librustzcash.git?branch=shielded-voting-wallet-support#6858db4a523de05f7474a89c7df751510c71874d"
+source = "git+https://github.com/valargroup/librustzcash.git?rev=6858db4a523de05f7474a89c7df751510c71874d#6858db4a523de05f7474a89c7df751510c71874d"
 dependencies = [
  "arti-client",
  "base64",
@@ -7466,7 +7438,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_sqlite"
 version = "0.19.5"
-source = "git+https://github.com/valargroup/librustzcash.git?branch=shielded-voting-wallet-support#6858db4a523de05f7474a89c7df751510c71874d"
+source = "git+https://github.com/valargroup/librustzcash.git?rev=6858db4a523de05f7474a89c7df751510c71874d#6858db4a523de05f7474a89c7df751510c71874d"
 dependencies = [
  "bip32",
  "bitflags 2.11.0",
@@ -7512,7 +7484,7 @@ dependencies = [
 [[package]]
 name = "zcash_encoding"
 version = "0.3.0"
-source = "git+https://github.com/valargroup/librustzcash.git?branch=shielded-voting-wallet-support#6858db4a523de05f7474a89c7df751510c71874d"
+source = "git+https://github.com/valargroup/librustzcash.git?rev=6858db4a523de05f7474a89c7df751510c71874d#6858db4a523de05f7474a89c7df751510c71874d"
 dependencies = [
  "core2",
  "nonempty",
@@ -7521,7 +7493,7 @@ dependencies = [
 [[package]]
 name = "zcash_keys"
 version = "0.12.0"
-source = "git+https://github.com/valargroup/librustzcash.git?branch=shielded-voting-wallet-support#6858db4a523de05f7474a89c7df751510c71874d"
+source = "git+https://github.com/valargroup/librustzcash.git?rev=6858db4a523de05f7474a89c7df751510c71874d#6858db4a523de05f7474a89c7df751510c71874d"
 dependencies = [
  "bech32",
  "bip32",
@@ -7563,7 +7535,7 @@ dependencies = [
 [[package]]
 name = "zcash_primitives"
 version = "0.26.1"
-source = "git+https://github.com/valargroup/librustzcash.git?branch=shielded-voting-wallet-support#6858db4a523de05f7474a89c7df751510c71874d"
+source = "git+https://github.com/valargroup/librustzcash.git?rev=6858db4a523de05f7474a89c7df751510c71874d#6858db4a523de05f7474a89c7df751510c71874d"
 dependencies = [
  "bip32",
  "blake2b_simd",
@@ -7628,7 +7600,7 @@ dependencies = [
 [[package]]
 name = "zcash_protocol"
 version = "0.7.1"
-source = "git+https://github.com/valargroup/librustzcash.git?branch=shielded-voting-wallet-support#6858db4a523de05f7474a89c7df751510c71874d"
+source = "git+https://github.com/valargroup/librustzcash.git?rev=6858db4a523de05f7474a89c7df751510c71874d#6858db4a523de05f7474a89c7df751510c71874d"
 dependencies = [
  "core2",
  "document-features",
@@ -7665,7 +7637,7 @@ dependencies = [
 [[package]]
 name = "zcash_transparent"
 version = "0.6.1"
-source = "git+https://github.com/valargroup/librustzcash.git?branch=shielded-voting-wallet-support#6858db4a523de05f7474a89c7df751510c71874d"
+source = "git+https://github.com/valargroup/librustzcash.git?rev=6858db4a523de05f7474a89c7df751510c71874d#6858db4a523de05f7474a89c7df751510c71874d"
 dependencies = [
  "bip32",
  "blake2b_simd",
@@ -7687,18 +7659,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.47"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efbb2a062be311f2ba113ce66f697a4dc589f85e78a4aea276200804cea0ed87"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.47"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e8bc7269b54418e7aeeef514aa68f8690b8c0489a06b0136e5f57c4c5ccab89"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7707,18 +7679,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7748,9 +7720,9 @@ dependencies = [
 
 [[package]]
 name = "zerotrie"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -7759,9 +7731,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "serde",
  "yoke",
@@ -7771,9 +7743,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7796,7 +7768,7 @@ dependencies = [
 [[package]]
 name = "zip321"
 version = "0.6.0"
-source = "git+https://github.com/valargroup/librustzcash.git?branch=shielded-voting-wallet-support#6858db4a523de05f7474a89c7df751510c71874d"
+source = "git+https://github.com/valargroup/librustzcash.git?rev=6858db4a523de05f7474a89c7df751510c71874d#6858db4a523de05f7474a89c7df751510c71874d"
 dependencies = [
  "base64",
  "nom",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,7 +48,7 @@ dependencies = [
  "amplify_derive",
  "amplify_num",
  "ascii",
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
  "getrandom 0.3.4",
  "wasm-bindgen",
 ]
@@ -107,7 +107,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
 dependencies = [
  "anstyle",
- "anstyle-parse",
+ "anstyle-parse 0.2.7",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse 1.0.0",
  "anstyle-query",
  "anstyle-wincon",
  "colorchoice",
@@ -117,15 +132,24 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
@@ -152,9 +176,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.100"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "arrayref"
@@ -191,7 +215,7 @@ dependencies = [
  "rand 0.9.2",
  "safelog",
  "serde",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "time",
  "tor-async-utils",
  "tor-basic-utils",
@@ -235,7 +259,7 @@ dependencies = [
  "nom",
  "num-traits",
  "rusticata-macros",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -246,7 +270,7 @@ checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -258,7 +282,7 @@ checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -291,7 +315,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -351,9 +375,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "axum"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b098575ebe77cb6d14fc7f32749631a6e44edbef6b796f89b020e99ba20d425"
+checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
 dependencies = [
  "axum-core",
  "bytes",
@@ -376,9 +400,9 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
-version = "0.5.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59446ce19cd142f8833f856eb31f3eb097812d1479ab224f54d72428ca21ea22"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
 dependencies = [
  "bytes",
  "futures-core",
@@ -406,15 +430,15 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64ct"
-version = "1.8.0"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bech32"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d965446196e3b7decd44aa7ee49e31d630118f90ef12f97900f262eb915c951d"
+checksum = "32637268377fc7b10a8c6d51de3e7fba1ce5dd371a96e342b34e6078db558e7f"
 
 [[package]]
 name = "bellman"
@@ -453,7 +477,7 @@ version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
@@ -464,7 +488,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -491,9 +515,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "bitvec"
@@ -509,9 +533,9 @@ dependencies = [
 
 [[package]]
 name = "blake2b_simd"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06e903a20b159e944f91ec8499fe1e55651480c541ea0a584f5d967c49ad9d99"
+checksum = "b79834656f71332577234b50bfc009996f7449e0c056884e6a02492ded0ca2f3"
 dependencies = [
  "arrayref",
  "arrayvec",
@@ -520,9 +544,9 @@ dependencies = [
 
 [[package]]
 name = "blake2s_simd"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e90f7deecfac93095eb874a40febd69427776e24e1bd7f87f33ac62d6f0174df"
+checksum = "ee29928bad1e3f94c9d1528da29e07a1d3d04817ae8332de1e8b846c8439f4b3"
 dependencies = [
  "arrayref",
  "arrayvec",
@@ -537,7 +561,7 @@ checksum = "e0b121a9fe0df916e362fb3271088d071159cdf11db0e4182d02152850756eff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -577,7 +601,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09dc0086e469182132244e9b8d313a0742e1132da43a08c24b9dd3c18e0faf3a"
 dependencies = [
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -603,9 +627,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.19.0"
+version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "by_address"
@@ -615,9 +639,9 @@ checksum = "64fa3c856b712db6612c019f14756e64e4bcea13337a6b33b696333a9eaa2d06"
 
 [[package]]
 name = "bytemuck"
-version = "1.24.0"
+version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fbdf580320f38b612e485521afda1ee26d10cc9884efaaa750d383e13e3c5f4"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 
 [[package]]
 name = "byteorder"
@@ -627,9 +651,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "caret"
@@ -660,22 +684,22 @@ checksum = "befbfd072a8e81c02f8c507aefce431fe5e7d051f83d48a23ffc9b9fe5a11799"
 dependencies = [
  "clap",
  "heck",
- "indexmap 2.12.1",
+ "indexmap 2.13.0",
  "log",
  "proc-macro2",
  "quote",
  "serde",
  "serde_json",
- "syn 2.0.111",
+ "syn 2.0.117",
  "tempfile",
- "toml 0.9.8",
+ "toml 0.9.12+spec-1.1.0",
 ]
 
 [[package]]
 name = "cc"
-version = "1.2.47"
+version = "1.2.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd405d82c84ff7f35739f175f67d8b9fb7687a0e84ccdc78bd3568839827cf07"
+checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -724,9 +748,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.42"
+version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
  "num-traits",
@@ -785,36 +809,49 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.53"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9e340e012a1bf4935f5282ed1436d1489548e8f72308207ea5df0e23d2d03f8"
+checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
 dependencies = [
  "clap_builder",
+ "clap_derive",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.53"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d76b5d13eaa18c901fd2f7fca939fefe3a0727a953561fefdf3b2922b8569d00"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
- "anstream",
+ "anstream 1.0.0",
  "anstyle",
  "clap_lex",
  "strsim 0.11.1",
 ]
 
 [[package]]
-name = "clap_lex"
-version = "0.7.6"
+name = "clap_derive"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
+checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "coarsetime"
-version = "0.1.36"
+version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91849686042de1b41cd81490edc83afbcb0abe5a9b6f2c4114f23ce8cca1bcf4"
+checksum = "e58eb270476aa4fc7843849f8a35063e8743b4dbcdf6dd0f8ea0886980c204c2"
 dependencies = [
  "libc",
  "wasix",
@@ -827,14 +864,14 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
 dependencies = [
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "colorchoice"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "concurrent-queue"
@@ -853,15 +890,15 @@ checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "constant_time_eq"
-version = "0.3.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
+checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
 name = "convert_case"
-version = "0.7.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb402b8d4c85569410425650ce3eddc7d698ed96d39a73f941b08fb63082f1e7"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
 dependencies = [
  "unicode-segmentation",
 ]
@@ -873,6 +910,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9885fa71e26b8ab7855e2ec7cae6e9b380edff76cd052e07c683a0319d51b3a2"
 dependencies = [
  "futures",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -1064,7 +1121,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1073,7 +1130,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70def8d72740e44d9f676d8dab2c933a236663d86dd24319b57a2bed4d694774"
 dependencies = [
- "petgraph",
+ "petgraph 0.7.1",
 ]
 
 [[package]]
@@ -1121,7 +1178,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.11.1",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1143,14 +1200,14 @@ checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
  "darling_core 0.21.3",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "data-encoding"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
+checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
 name = "der"
@@ -1204,14 +1261,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd5f2b7218a51c827a11d22d1439b598121fac94bf9b99452e4afffe512d78c9"
 dependencies = [
  "heck",
- "indexmap 2.12.1",
+ "indexmap 2.13.0",
  "itertools 0.14.0",
  "proc-macro-crate",
  "proc-macro2",
  "quote",
  "sha3",
  "strum",
- "syn 2.0.111",
+ "syn 2.0.117",
  "void",
 ]
 
@@ -1248,23 +1305,24 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
-version = "2.0.1"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "093242cf7570c207c83073cf82f79706fe7b8317e98620a47d5be7c3d8497678"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
 dependencies = [
  "derive_more-impl",
 ]
 
 [[package]]
 name = "derive_more-impl"
-version = "2.0.1"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
 dependencies = [
  "convert_case",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "rustc_version",
+ "syn 2.0.117",
  "unicode-xid",
 ]
 
@@ -1329,7 +1387,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1370,7 +1428,7 @@ checksum = "0b0713d5c1d52e774c5cd7bb8b043d7c0fc4f921abfb678556140bfbe6ab2364"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1463,6 +1521,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "enum-ordinalize"
 version = "3.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1472,7 +1539,7 @@ dependencies = [
  "num-traits",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1484,20 +1551,36 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
-name = "env_home"
-version = "0.1.0"
+name = "env_filter"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7f84e12ccf0a7ddc17a6c41c93326024c42920d7ee630d04950e6926645c0fe"
+checksum = "7a1c3cc8e57274ec99de65301228b537f1e4eedc1b8e0f9411c6caac8ae7308f"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2daee4ea451f429a58296525ddf28b45a3b64f1acf6587e2067437bb11e218d"
+dependencies = [
+ "anstream 0.6.21",
+ "anstyle",
+ "env_filter",
+ "jiff",
+ "log",
+]
 
 [[package]]
 name = "equihash"
 version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca4f333d4ccc9d23c06593733673026efa71a332e028b00f12cf427b9677dce9"
+source = "git+https://github.com/valargroup/librustzcash.git?branch=shielded-voting-wallet-support#efb5f3470c69cff71a746deaff8318bc2b7e8aae"
 dependencies = [
  "blake2b_simd",
  "core2",
@@ -1533,8 +1616,7 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d42773cb15447644d170be20231a3268600e0c4cea8987d013b93ac973d3cf7"
+source = "git+https://github.com/valargroup/librustzcash.git?branch=shielded-voting-wallet-support#efb5f3470c69cff71a746deaff8318bc2b7e8aae"
 dependencies = [
  "blake2b_simd",
 ]
@@ -1600,21 +1682,20 @@ dependencies = [
 
 [[package]]
 name = "filetime"
-version = "0.2.26"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc0505cd1b6fa6580283f6bdf70a73fcf4aba1184038c90902b92b3dd0df63ed"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
 dependencies = [
  "cfg-if",
  "libc",
  "libredox",
- "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.5"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a3076410a55c90011c298b04d0cfa770b00fa04e1e3c97d3f6c9de105a03844"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "fixedbitset"
@@ -1624,9 +1705,9 @@ checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flate2"
-version = "1.1.5"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfe33edd8e85a12a67454e37f8c75e730830d83e313556ab9ebf9ee7fbeb3bfb"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -1649,6 +1730,30 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
 
 [[package]]
 name = "fpe"
@@ -1675,7 +1780,7 @@ dependencies = [
  "libc",
  "pwd-grp",
  "serde",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "walkdir",
 ]
 
@@ -1697,9 +1802,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1712,9 +1817,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1722,15 +1827,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1739,19 +1844,19 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1767,21 +1872,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-util"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1791,7 +1896,6 @@ dependencies = [
  "futures-task",
  "memchr",
  "pin-project-lite",
- "pin-utils",
  "slab",
 ]
 
@@ -1808,9 +1912,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -1828,9 +1932,22 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "wasip2",
+ "wasip3",
 ]
 
 [[package]]
@@ -1842,7 +1959,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1871,9 +1988,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3c0b69cfcb4e1b9f1bf2f53f95f766e4661169728ec61cd3fe5a0166f2d1386"
+checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1881,7 +1998,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap 2.12.1",
+ "indexmap 2.13.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -1939,9 +2056,9 @@ dependencies = [
 
 [[package]]
 name = "halo2_proofs"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "019561b5f3be60731e7b72f3f7878c5badb4174362d860b03d3cf64cb47f90db"
+checksum = "05713f117155643ce10975e0bee44a274bcda2f4bb5ef29a999ad67c1fa8d4d3"
 dependencies = [
  "blake2b_simd",
  "ff",
@@ -2138,6 +2255,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-rustls"
+version = "0.27.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-timeout"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2151,31 +2284,51 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-util"
-version = "0.1.18"
+name = "hyper-tls"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52e9a2a24dc5c6821e71a7030e1e14b7b632acac55c40e9d2e082c621261bb56"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "base64",
+ "bytes",
  "futures-channel",
- "futures-core",
  "futures-util",
  "http",
  "http-body",
  "hyper",
+ "ipnet",
  "libc",
+ "percent-encoding",
  "pin-project-lite",
  "socket2",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
+ "windows-registry",
 ]
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.64"
+version = "0.1.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33e57f83510bb73707521ebaffa789ec8caf86f9657cad665b092b581d40e9fb"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -2196,10 +2349,146 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collections"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+
+[[package]]
+name = "icu_properties"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+
+[[package]]
+name = "icu_provider"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
+
+[[package]]
+name = "imt-tree"
+version = "0.1.0"
+source = "git+https://github.com/valargroup/vote-nullifier-pir.git?branch=main#fcf8db07e7188b68e5100276d0aec089f5a13b9a"
+dependencies = [
+ "anyhow",
+ "ff",
+ "halo2_gadgets",
+ "hex",
+ "pasta_curves",
+ "rayon",
+ "tracing",
+]
+
+[[package]]
+name = "imt-tree"
+version = "0.1.0"
+source = "git+https://github.com/valargroup/vote-nullifier-pir.git#fcf8db07e7188b68e5100276d0aec089f5a13b9a"
+dependencies = [
+ "anyhow",
+ "ff",
+ "halo2_gadgets",
+ "hex",
+ "pasta_curves",
+ "rayon",
+ "tracing",
+]
 
 [[package]]
 name = "incrementalmerkletree"
@@ -2223,9 +2512,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.12.1"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ad4bb2b565bca0645f4d68c5c9af97fba094e9791da685bf83cb5f3ce74acf2"
+checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
  "hashbrown 0.16.1",
@@ -2235,11 +2524,11 @@ dependencies = [
 
 [[package]]
 name = "inotify"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f37dccff2791ab604f9babef0ba14fbe0be30bd368dc541e2b08d07c8aa908f3"
+checksum = "bd5b3eaf1a28b758ac0faa5a4254e8ab2705605496f1b1f3fbbc3988ad73d199"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "inotify-sys",
  "libc",
 ]
@@ -2264,11 +2553,27 @@ dependencies = [
 
 [[package]]
 name = "inventory"
-version = "0.3.21"
+version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc61209c082fbeb19919bee74b176221b27223e27b65d781eb91af24eb1fb46e"
+checksum = "009ae045c87e7082cb72dab0ccd01ae075dd00141ddc108f43a0ea150a9e7227"
 dependencies = [
  "rustversion",
+]
+
+[[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
+name = "iri-string"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
+dependencies = [
+ "memchr",
+ "serde",
 ]
 
 [[package]]
@@ -2297,9 +2602,33 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.15"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "jiff"
+version = "0.2.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a3546dc96b6d42c5f24902af9e2538e82e39ad350b0c766eb3fbf2d8f3d8359"
+dependencies = [
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a8c8b344124222efd714b73bb41f8b5120b27a7cc1c75593a6ff768d9d05aa4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "jobserver"
@@ -2313,9 +2642,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.82"
+version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b011eec8cc36da2aab2d5cff675ec18454fad408585853910a202391cf9f8e65"
+checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -2337,18 +2666,18 @@ dependencies = [
 
 [[package]]
 name = "keccak"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654"
+checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
 dependencies = [
  "cpufeatures",
 ]
 
 [[package]]
 name = "known-folders"
-version = "1.4.0"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d463f34ca3c400fde3a054da0e0b8c6ffa21e4590922f3e18281bb5eeef4cbdc"
+checksum = "7a1886916523694cd6ea3d175f03a1e5010699a2a4cc13696d83d7bea1d80638"
 dependencies = [
  "windows-sys 0.61.2",
 ]
@@ -2383,10 +2712,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "libc"
-version = "0.2.177"
+name = "leb128fmt"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "libc"
+version = "0.2.183"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
 name = "libloading"
@@ -2400,19 +2735,52 @@ dependencies = [
 
 [[package]]
 name = "libm"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.10"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "416f7e718bdb06000964960ffa43b4335ad4012ae8b99060261aa4a8088d5ccb"
+checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "libc",
- "redox_syscall",
+ "plain",
+ "redox_syscall 0.7.3",
+]
+
+[[package]]
+name = "librustvoting"
+version = "0.1.0"
+source = "git+https://github.com/valargroup/librustvoting.git#d87a01b70a8d261ae3b65828e5088e56c3eb658d"
+dependencies = [
+ "blake2b_simd",
+ "ff",
+ "group",
+ "halo2_gadgets",
+ "halo2_proofs",
+ "hex",
+ "incrementalmerkletree",
+ "nonempty",
+ "orchard",
+ "pasta_curves",
+ "pczt",
+ "pir-client",
+ "rand 0.8.5",
+ "rusqlite",
+ "serde",
+ "serde_json",
+ "subtle",
+ "thiserror 2.0.18",
+ "vote-commitment-tree",
+ "vote-commitment-tree-client",
+ "voting-circuits",
+ "zcash_keys",
+ "zcash_primitives",
+ "zcash_protocol",
+ "zip32",
 ]
 
 [[package]]
@@ -2432,7 +2800,7 @@ version = "2.4.6"
 dependencies = [
  "anyhow",
  "bindgen",
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "bytes",
  "cbindgen",
  "cc",
@@ -2441,6 +2809,7 @@ dependencies = [
  "fs-mistrust",
  "http",
  "http-body-util",
+ "librustvoting",
  "log-panics",
  "nonempty",
  "once_cell",
@@ -2453,16 +2822,20 @@ dependencies = [
  "rust_decimal",
  "sapling-crypto",
  "secrecy",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "tonic",
  "tor-rtcompat",
  "tracing",
  "tracing-subscriber",
  "uuid",
+ "voting-circuits",
  "xz2",
  "zcash_address",
  "zcash_client_backend",
  "zcash_client_sqlite",
+ "zcash_keys",
  "zcash_note_encryption",
  "zcash_primitives",
  "zcash_proofs",
@@ -2474,9 +2847,15 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "litemap"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "litrs"
@@ -2495,9 +2874,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.28"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "log-panics"
@@ -2546,15 +2925,15 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.6"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "memmap2"
-version = "0.9.9"
+version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "744133e4a0e0a658e1374cf3bf8e415c4052a15a111acd372764c55b4177d490"
+checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
 dependencies = [
  "libc",
 ]
@@ -2601,9 +2980,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69d83b0086dc8ecf3ce9ae2874b2d1290252e2a30720bea58a5c6639b0092873"
+checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
  "log",
@@ -2616,6 +2995,23 @@ name = "multimap"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
+
+[[package]]
+name = "native-tls"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
 
 [[package]]
 name = "nom"
@@ -2645,7 +3041,7 @@ version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "inotify",
  "kqueue",
  "libc",
@@ -2658,15 +3054,18 @@ dependencies = [
 
 [[package]]
 name = "notify-types"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e0826a989adedc2a244799e823aece04662b66609d96af8dff7ac6df9a8925d"
+checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
+dependencies = [
+ "bitflags 2.11.0",
+]
 
 [[package]]
 name = "ntapi"
-version = "0.4.1"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8a3895c6391c39d7fe7ebc444a87eb2991b2a0bc718fdabd071eec617fc68e4"
+checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
 dependencies = [
  "winapi",
 ]
@@ -2754,9 +3153,9 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1207a7e20ad57b847bbddc6776b968420d38292bbfe2089accff5e19e82454c"
+checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
 dependencies = [
  "num_enum_derive",
  "rustversion",
@@ -2764,14 +3163,14 @@ dependencies = [
 
 [[package]]
 name = "num_enum_derive"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff32365de1b6743cb203b710788263c44a03de03802daf96092f2da4fe6ba4d7"
+checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2780,7 +3179,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -2795,9 +3194,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -2827,6 +3226,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
+name = "openssl"
+version = "0.10.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "951c002c75e16ea2c65b8c7e4d3d51d5530d8dfa7d060b4776828c88cfb18ecf"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.112"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57d55af3b3e226502be1526dfdba67ab0e9c96fc293004e79576b2b9edb0dbdb"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2835,8 +3278,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 [[package]]
 name = "orchard"
 version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1ef66fcf99348242a20d582d7434da381a867df8dc155b3a980eca767c56137"
+source = "git+https://github.com/valargroup/voting-circuits.git#05503e205535fce5f0d5ab393eb88f952d15640b"
 dependencies = [
  "aes",
  "bitvec",
@@ -2956,7 +3398,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
  "windows-link 0.2.1",
 ]
@@ -2984,9 +3426,8 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pczt"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20367012e2faad5dd99ad6fcb1efcc3332e8ac83a7653854c3ae3889c517197c"
+version = "0.5.1"
+source = "git+https://github.com/valargroup/librustzcash.git?branch=shielded-voting-wallet-support#efb5f3470c69cff71a746deaff8318bc2b7e8aae"
 dependencies = [
  "blake2b_simd",
  "bls12_381",
@@ -3033,7 +3474,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
 dependencies = [
  "fixedbitset",
- "indexmap 2.12.1",
+ "indexmap 2.13.0",
+]
+
+[[package]]
+name = "petgraph"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
+dependencies = [
+ "fixedbitset",
+ "hashbrown 0.15.5",
+ "indexmap 2.13.0",
 ]
 
 [[package]]
@@ -3067,7 +3519,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3081,35 +3533,66 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.10"
+version = "1.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
+checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.10"
+version = "1.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
+checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pir-client"
+version = "0.1.0"
+source = "git+https://github.com/valargroup/vote-nullifier-pir.git?branch=main#fcf8db07e7188b68e5100276d0aec089f5a13b9a"
+dependencies = [
+ "anyhow",
+ "ff",
+ "futures",
+ "hex",
+ "imt-tree 0.1.0 (git+https://github.com/valargroup/vote-nullifier-pir.git?branch=main)",
+ "log",
+ "pasta_curves",
+ "pir-types",
+ "reqwest",
+ "serde_json",
+ "tokio",
+ "ypir",
+]
+
+[[package]]
+name = "pir-types"
+version = "0.1.0"
+source = "git+https://github.com/valargroup/vote-nullifier-pir.git?branch=main#fcf8db07e7188b68e5100276d0aec089f5a13b9a"
+dependencies = [
+ "anyhow",
+ "ff",
+ "imt-tree 0.1.0 (git+https://github.com/valargroup/vote-nullifier-pir.git?branch=main)",
+ "pasta_curves",
+ "serde",
+]
 
 [[package]]
 name = "pkcs1"
@@ -3137,6 +3620,12 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plotters"
@@ -3178,6 +3667,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "091397be61a01d4be58e7841595bd4bfedb15f1cd54977d79b8271e94ed799a3"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
 name = "postage"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3205,6 +3709,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "potential_utf"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
 name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3226,7 +3739,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3245,17 +3758,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93980406f12d9f8140ed5abe7155acb10bb1e69ea55c88960b9c2f117445ef96"
 dependencies = [
  "equivalent",
- "indexmap 2.12.1",
+ "indexmap 2.13.0",
  "serde",
 ]
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit 0.23.7",
+ "toml_edit 0.25.5+spec-1.1.0",
 ]
 
 [[package]]
@@ -3277,23 +3790,23 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.103"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "prost"
-version = "0.14.1"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7231bd9b3d3d33c86b58adbac74b5ec0ad9f496b19d22801d773636feaa95f3d"
+checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -3301,42 +3814,41 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.14.1"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac6c3320f9abac597dcbc668774ef006702672474aad53c6d596b62e487b40b1"
+checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
  "heck",
  "itertools 0.14.0",
  "log",
  "multimap",
- "once_cell",
- "petgraph",
+ "petgraph 0.8.3",
  "prettyplease",
  "prost",
  "prost-types",
  "regex",
- "syn 2.0.111",
+ "syn 2.0.117",
  "tempfile",
 ]
 
 [[package]]
 name = "prost-derive"
-version = "0.14.1"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9120690fafc389a67ba3803df527d0ec9cbbc9cc45e4cc20b332996dfb672425"
+checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "prost-types"
-version = "0.14.1"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9b4db3d6da204ed77bb26ba83b6122a73aeb2e87e25fbf7ad2e84c4ccbf8f72"
+checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
 dependencies = [
  "prost",
 ]
@@ -3350,14 +3862,14 @@ dependencies = [
  "derive-deftly",
  "libc",
  "paste",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.42"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -3367,6 +3879,12 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "radium"
@@ -3392,7 +3910,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha 0.9.0",
- "rand_core 0.9.3",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -3412,7 +3930,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.9.3",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -3421,14 +3939,14 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
 ]
 
 [[package]]
 name = "rand_core"
-version = "0.9.3"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
@@ -3450,7 +3968,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b16df48f071248e67b8fc5e866d9448d45c08ad8b672baaaf796e2f15e606ff0"
 dependencies = [
  "libc",
- "rand_core 0.9.3",
+ "rand_core 0.9.5",
  "winapi",
 ]
 
@@ -3519,7 +4037,16 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
+dependencies = [
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -3528,9 +4055,9 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
  "libredox",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -3550,14 +4077,14 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "regex"
-version = "1.12.2"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3567,9 +4094,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3578,9 +4105,51 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.8"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "encoding_rs",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-tls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-native-tls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
 
 [[package]]
 name = "retry-error"
@@ -3606,7 +4175,7 @@ checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
@@ -3632,9 +4201,9 @@ dependencies = [
 
 [[package]]
 name = "rsa"
-version = "0.9.9"
+version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40a0376c50d0358279d9d643e4bf7b7be212f1f4ff1da9070a7b54d22ef75c88"
+checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
 dependencies = [
  "const-oid",
  "digest 0.10.7",
@@ -3657,7 +4226,7 @@ version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "165ca6e57b20e1351573e3729b958bc62f0e48025386970b6e4d29e7a7e71f3f"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "fallible-iterator",
  "fallible-streaming-iterator",
  "hashlink",
@@ -3669,9 +4238,9 @@ dependencies = [
 
 [[package]]
 name = "rust_decimal"
-version = "1.39.0"
+version = "1.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35affe401787a9bd846712274d97654355d21b2a2c092a3139aabe31e9022282"
+checksum = "61f703d19852dbf87cbc513643fa81428361eb6940f1ac14fd58155d295a3eb0"
 dependencies = [
  "arrayvec",
  "num-traits",
@@ -3704,11 +4273,11 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.1.2"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -3717,9 +4286,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.35"
+version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "533f54bc6a7d4f647e46ad909549eda97bf5afc1585190ef692b4286b198bd8f"
+checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
  "log",
  "once_cell",
@@ -3732,9 +4301,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.13.0"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94182ad936a0c91c324cd46c6511b9510ed16af436d7b5bab34beab0afd55f7a"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
  "zeroize",
 ]
@@ -3758,9 +4327,9 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
-version = "1.0.20"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "safelog"
@@ -3772,7 +4341,7 @@ dependencies = [
  "educe",
  "either",
  "fluid-let",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -3827,6 +4396,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "schemars"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3840,9 +4418,9 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "1.1.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9558e172d4e8533736ba97870c4b2cd63f84b382a3d6eb063da41b91cce17289"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
 dependencies = [
  "dyn-clone",
  "ref-cast",
@@ -3922,6 +4500,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.11.0",
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "semver"
 version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3964,7 +4565,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3979,15 +4580,15 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.145"
+version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
  "itoa",
  "memchr",
- "ryu",
  "serde",
  "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -4001,26 +4602,38 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e24345aa0fe688594e73770a5f6d1b216508b4f93484c0026d521acd30134392"
+checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
-name = "serde_with"
-version = "3.16.0"
+name = "serde_urlencoded"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10574371d41b0d9b2cff89418eda27da52bcaff2cc8741db26382a77c29131f1"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_with"
+version = "3.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "381b283ce7bc6b476d903296fb59d0d36633652b633b27f64db4fb46dcbfc3b9"
 dependencies = [
  "base64",
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.12.1",
+ "indexmap 2.13.0",
  "schemars 0.9.0",
- "schemars 1.1.0",
+ "schemars 1.2.1",
  "serde_core",
  "serde_json",
  "serde_with_macros",
@@ -4029,14 +4642,14 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.16.0"
+version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08a72d8216842fdd57820dc78d840bef99248e35fb2554ff923319e60f2d686b"
+checksum = "a6d4e30573c8cb306ed6ab1dca8423eec9a463ea0e155f45399455e0368b27e0"
 dependencies = [
  "darling 0.21.3",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4097,7 +4710,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "359e552886ae54d1642091645980d83f7db465fd9b5b0248e3680713c1773388"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "either",
  "incrementalmerkletree",
  "tracing",
@@ -4105,9 +4718,9 @@ dependencies = [
 
 [[package]]
 name = "shellexpand"
-version = "3.1.1"
+version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b1fdf65dd6331831494dd616b30351c38e96e45921a27745cf98490458b90bb"
+checksum = "32824fab5e16e6c4d86dc1ba84489390419a39f97699852b66480bb87d297ed8"
 dependencies = [
  "bstr",
  "dirs",
@@ -4122,10 +4735,11 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.7"
+version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7664a098b8e616bdfcc2dc0e9ac44eb231eedf41db4e9fe95d8d32ec728dedad"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
+ "errno",
  "libc",
 ]
 
@@ -4141,9 +4755,9 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
+checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
 
 [[package]]
 name = "sinsemilla"
@@ -4158,21 +4772,21 @@ dependencies = [
 
 [[package]]
 name = "siphasher"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
+checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "slab"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "slotmap"
-version = "1.0.7"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbff4acf519f630b3a3ddcfaea6c06b42174d9a44bc70c620e9ed1649d58b82a"
+checksum = "bdd58c3c93c3d278ca835519292445cb4b0d4dc59ccfdf7ceadaab3f8aeb4038"
 dependencies = [
  "serde",
  "version_check",
@@ -4187,7 +4801,7 @@ dependencies = [
  "paste",
  "serde",
  "slotmap",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "void",
 ]
 
@@ -4199,12 +4813,12 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4212,6 +4826,20 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
+name = "spiral-rs"
+version = "0.4.0"
+source = "git+https://github.com/menonsamir/spiral-rs.git?rev=f2c23c7#f2c23c7ced192e80687b52134ee861098f764769"
+dependencies = [
+ "fastrand",
+ "getrandom 0.2.17",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "serde_json",
+ "sha2 0.10.9",
+ "subtle",
+]
 
 [[package]]
 name = "spki"
@@ -4266,6 +4894,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4301,7 +4935,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4323,9 +4957,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.111"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "390cc9a294ab71bdb1aa2e99d13be9c753cd2d7bd6560c77118597410c4d2e87"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4337,6 +4971,9 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
 
 [[package]]
 name = "synstructure"
@@ -4346,7 +4983,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4364,6 +5001,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags 2.11.0",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4371,15 +5029,37 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
-version = "3.23.0"
+version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "test-log"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37d53ac171c92a39e4769491c4b4dde7022c60042254b5fc044ae409d34a24d4"
+dependencies = [
+ "env_logger",
+ "test-log-macros",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "test-log-macros"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be35209fd0781c5401458ab66e4f98accf63553e8fae7425503e92fdd319783b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4393,11 +5073,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.17",
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -4408,18 +5088,18 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4485,9 +5165,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -4500,9 +5180,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.48.0"
+version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff360e02eab121e0bc37a2d3b4d4dc622e6eda3a8e5253d5435ecf5bd4c68408"
+checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
 dependencies = [
  "bytes",
  "libc",
@@ -4516,13 +5196,23 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
 ]
 
 [[package]]
@@ -4537,9 +5227,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -4548,9 +5238,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.17"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2efa149fe76073d6e8fd97ef4f4eca7b67f599660115591483572e406e165594"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
 dependencies = [
  "bytes",
  "futures-core",
@@ -4574,17 +5264,17 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.9.8"
+version = "0.9.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0dc8b1fb61449e27716ec0e1bdf0f6b8f3e8f6b05391e8497b8b6d7804ea6d8"
+checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
- "indexmap 2.12.1",
+ "indexmap 2.13.0",
  "serde_core",
- "serde_spanned 1.0.3",
- "toml_datetime 0.7.3",
+ "serde_spanned 1.0.4",
+ "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow",
+ "winnow 0.7.15",
 ]
 
 [[package]]
@@ -4598,9 +5288,18 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.7.3"
+version = "0.7.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2cdb639ebbc97961c51720f858597f7f24c4fc295327923af55b74c3c724533"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "1.0.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b320e741db58cac564e26c607d3cc1fdc4a88fd36c879568c07856ed83ff3e9"
 dependencies = [
  "serde_core",
 ]
@@ -4611,33 +5310,33 @@ version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap 2.12.1",
+ "indexmap 2.13.0",
  "serde",
  "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
  "toml_write",
- "winnow",
+ "winnow 0.7.15",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.23.7"
+version = "0.25.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6485ef6d0d9b5d0ec17244ff7eb05310113c3f316f2d14200d4de56b3cb98f8d"
+checksum = "8ca1a40644a28bce036923f6a431df0b34236949d111cc07cb6dca830c9ef2e1"
 dependencies = [
- "indexmap 2.12.1",
- "toml_datetime 0.7.3",
+ "indexmap 2.13.0",
+ "toml_datetime 1.0.1+spec-1.1.0",
  "toml_parser",
- "winnow",
+ "winnow 1.0.0",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.0.4"
+version = "1.0.10+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0cbe268d35bdb4bb5a56a2de88d0ad0eb70af5384a99d648cd4b3d04039800e"
+checksum = "7df25b4befd31c4816df190124375d5a20c6b6921e2cad937316de3fccd63420"
 dependencies = [
- "winnow",
+ "winnow 1.0.0",
 ]
 
 [[package]]
@@ -4648,15 +5347,15 @@ checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "toml_writer"
-version = "1.0.4"
+version = "1.0.7+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df8b2b54733674ad286d16267dcfc7a71ed5c776e4ac7aa3c3e2561f7c637bf2"
+checksum = "f17aaa1c6e3dc22b1da4b6bba97d066e354c7945cac2f7852d4e4e7ca7a6b56d"
 
 [[package]]
 name = "tonic"
-version = "0.14.2"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb7613188ce9f7df5bfe185db26c5814347d110db17920415cf2fbcad85e7203"
+checksum = "fec7c61a0695dc1887c1b53952990f3ad2e3a31453e1f49f10e75424943a93ec"
 dependencies = [
  "async-trait",
  "axum",
@@ -4685,21 +5384,21 @@ dependencies = [
 
 [[package]]
 name = "tonic-build"
-version = "0.14.2"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c40aaccc9f9eccf2cd82ebc111adc13030d23e887244bc9cfa5d1d636049de3"
+checksum = "1882ac3bf5ef12877d7ed57aad87e75154c11931c2ba7e6cde5e22d63522c734"
 dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "tonic-prost"
-version = "0.14.2"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66bd50ad6ce1252d87ef024b3d64fe4c3cf54a86fb9ef4c631fdd0ded7aeaa67"
+checksum = "a55376a0bbaa4975a3f10d009ad763d8f4108f067c7c2e74f3001fb49778d309"
 dependencies = [
  "bytes",
  "prost",
@@ -4708,16 +5407,16 @@ dependencies = [
 
 [[package]]
 name = "tonic-prost-build"
-version = "0.14.2"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4a16cba4043dc3ff43fcb3f96b4c5c154c64cbd18ca8dce2ab2c6a451d058a2"
+checksum = "f3144df636917574672e93d0f56d7edec49f90305749c668df5101751bb8f95a"
 dependencies = [
  "prettyplease",
  "proc-macro2",
  "prost-build",
  "prost-types",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
  "tempfile",
  "tonic-build",
 ]
@@ -4734,7 +5433,7 @@ dependencies = [
  "oneshot-fused-workaround",
  "pin-project",
  "postage",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "void",
 ]
 
@@ -4754,7 +5453,7 @@ dependencies = [
  "serde",
  "slab",
  "smallvec",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -4769,7 +5468,7 @@ dependencies = [
  "educe",
  "getrandom 0.3.4",
  "safelog",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tor-error",
  "tor-llcrypto",
  "zeroize",
@@ -4782,7 +5481,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79ba1b43f22fab2daee3e0c902f1455b3aed8e086b2d83d8c60b36523b173d25"
 dependencies = [
  "amplify",
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "bytes",
  "caret",
  "derive-deftly",
@@ -4792,7 +5491,7 @@ dependencies = [
  "paste",
  "rand 0.9.2",
  "smallvec",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tor-basic-utils",
  "tor-bytes",
  "tor-cert",
@@ -4815,7 +5514,7 @@ dependencies = [
  "derive_builder_fork_arti",
  "derive_more",
  "digest 0.10.7",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tor-bytes",
  "tor-checkable",
  "tor-llcrypto",
@@ -4838,7 +5537,7 @@ dependencies = [
  "rand 0.9.2",
  "safelog",
  "serde",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tor-async-utils",
  "tor-basic-utils",
  "tor-cell",
@@ -4865,7 +5564,7 @@ checksum = "7c9839e9bb302f17447c350e290bb107084aca86c640882a91522f2059f6a686"
 dependencies = [
  "humantime",
  "signature",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tor-llcrypto",
 ]
 
@@ -4894,7 +5593,7 @@ dependencies = [
  "retry-error",
  "safelog",
  "serde",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tor-async-utils",
  "tor-basic-utils",
  "tor-cell",
@@ -4942,8 +5641,8 @@ dependencies = [
  "serde-value",
  "serde_ignored",
  "strum",
- "thiserror 2.0.17",
- "toml 0.9.8",
+ "thiserror 2.0.18",
+ "toml 0.9.12+spec-1.1.0",
  "tor-basic-utils",
  "tor-error",
  "tor-rtcompat",
@@ -4960,7 +5659,7 @@ dependencies = [
  "directories",
  "serde",
  "shellexpand",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tor-error",
  "tor-general-addr",
 ]
@@ -4973,7 +5672,7 @@ checksum = "c1690438c1fc778fc7c89c132e529365b1430d6afe03aeecbc2508324807bf0b"
 dependencies = [
  "digest 0.10.7",
  "hex",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tor-llcrypto",
 ]
 
@@ -4993,7 +5692,7 @@ dependencies = [
  "httpdate",
  "itertools 0.14.0",
  "memchr",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tor-circmgr",
  "tor-error",
  "tor-linkspec",
@@ -5058,7 +5757,7 @@ dependencies = [
  "signature",
  "static_assertions",
  "strum",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "time",
  "tor-async-utils",
  "tor-basic-utils",
@@ -5092,7 +5791,7 @@ dependencies = [
  "retry-error",
  "static_assertions",
  "strum",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tracing",
  "void",
 ]
@@ -5104,7 +5803,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c42cb5b5aec0584db2fba4a88c4e08fb09535ef61e4ef5674315a89e69ec31a2"
 dependencies = [
  "derive_more",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "void",
 ]
 
@@ -5133,7 +5832,7 @@ dependencies = [
  "safelog",
  "serde",
  "strum",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tor-async-utils",
  "tor-basic-utils",
  "tor-config",
@@ -5170,7 +5869,7 @@ dependencies = [
  "serde",
  "signature",
  "subtle",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tor-basic-utils",
  "tor-bytes",
  "tor-error",
@@ -5194,7 +5893,7 @@ dependencies = [
  "rsa",
  "signature",
  "ssh-key",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tor-bytes",
  "tor-cert",
  "tor-checkable",
@@ -5226,7 +5925,7 @@ dependencies = [
  "serde",
  "signature",
  "ssh-key",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tor-basic-utils",
  "tor-bytes",
  "tor-config",
@@ -5260,7 +5959,7 @@ dependencies = [
  "serde",
  "serde_with",
  "strum",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tor-basic-utils",
  "tor-bytes",
  "tor-config",
@@ -5290,7 +5989,7 @@ dependencies = [
  "rand 0.9.2",
  "rand_chacha 0.9.0",
  "rand_core 0.6.4",
- "rand_core 0.9.3",
+ "rand_core 0.9.5",
  "rand_jitter",
  "rdrand",
  "rsa",
@@ -5301,7 +6000,7 @@ dependencies = [
  "sha3",
  "signature",
  "subtle",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tor-error",
  "tor-memquota",
  "visibility",
@@ -5317,7 +6016,7 @@ checksum = "845d65304be6a614198027c4b2d1b35aaf073335c26df619d17e5f4027f2657f"
 dependencies = [
  "futures",
  "humantime",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tor-error",
  "tor-rtcompat",
  "tracing",
@@ -5343,7 +6042,7 @@ dependencies = [
  "slotmap-careful",
  "static_assertions",
  "sysinfo",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tor-async-utils",
  "tor-basic-utils",
  "tor-config",
@@ -5361,7 +6060,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "638b4e6507e3786488859d3c463fa73addbad4f788806c6972603727e527672e"
 dependencies = [
  "async-trait",
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "derive_more",
  "futures",
  "humantime",
@@ -5370,7 +6069,7 @@ dependencies = [
  "rand 0.9.2",
  "serde",
  "strum",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tor-basic-utils",
  "tor-error",
  "tor-linkspec",
@@ -5390,7 +6089,7 @@ checksum = "1dbc32d89e7ea2e2799168d0c453061647a727e39fc66f52e1bcb4c38c8dc433"
 dependencies = [
  "amplify",
  "base64ct",
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "cipher",
  "derive-deftly",
  "derive_builder_fork_arti",
@@ -5409,7 +6108,7 @@ dependencies = [
  "smallvec",
  "strum",
  "subtle",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "time",
  "tinystr",
  "tor-basic-utils",
@@ -5443,7 +6142,7 @@ dependencies = [
  "sanitize-filename",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "time",
  "tor-async-utils",
  "tor-basic-utils",
@@ -5483,14 +6182,14 @@ dependencies = [
  "pin-project",
  "postage",
  "rand 0.9.2",
- "rand_core 0.9.3",
+ "rand_core 0.9.5",
  "safelog",
  "slotmap-careful",
  "smallvec",
  "static_assertions",
  "subtle",
  "sync_wrapper",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-util",
  "tor-async-utils",
@@ -5525,7 +6224,7 @@ dependencies = [
  "caret",
  "paste",
  "serde_with",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tor-bytes",
 ]
 
@@ -5564,7 +6263,7 @@ dependencies = [
  "pin-project",
  "rustls-pki-types",
  "rustls-webpki",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-util",
  "tor-error",
@@ -5593,7 +6292,7 @@ dependencies = [
  "priority-queue",
  "slotmap-careful",
  "strum",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tor-error",
  "tor-general-addr",
  "tor-rtcompat",
@@ -5614,7 +6313,7 @@ dependencies = [
  "educe",
  "safelog",
  "subtle",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tor-bytes",
  "tor-error",
 ]
@@ -5628,19 +6327,19 @@ dependencies = [
  "derive-deftly",
  "derive_more",
  "serde",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tor-memquota",
 ]
 
 [[package]]
 name = "tower"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap 2.12.1",
+ "indexmap 2.13.0",
  "pin-project-lite",
  "slab",
  "sync_wrapper",
@@ -5649,6 +6348,24 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+dependencies = [
+ "bitflags 2.11.0",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "iri-string",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]
@@ -5665,9 +6382,9 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
-version = "0.1.41"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
  "tracing-attributes",
@@ -5676,20 +6393,20 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.30"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.34"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
  "valuable",
@@ -5708,9 +6425,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.20"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2054a14f5307d601f88daf0553e1cbf472acc4f2c51afab632431cdcd72124d5"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -5726,9 +6443,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-test"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "557b891436fe0d5e0e363427fc7f217abf9ccd510d5136549847bdcbcd011d68"
+checksum = "19a4c448db514d4f24c5ddb9f73f2ee71bfb24c526cf0c570ba142d1119e0051"
 dependencies = [
  "tracing-core",
  "tracing-subscriber",
@@ -5737,12 +6454,12 @@ dependencies = [
 
 [[package]]
 name = "tracing-test-macro"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04659ddb06c87d233c566112c1c9c5b9e98256d9af50ec3bc9c8327f873a7568"
+checksum = "ad06847b7afb65c7866a36664b75c40b895e318cea4f71299f013fb22965329d"
 dependencies = [
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5753,7 +6470,7 @@ checksum = "70977707304198400eb4835a78f6a9f928bf41bba420deb8fdb175cd965d77a7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5764,9 +6481,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typed-index-collections"
-version = "3.3.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fd393dbd1e7b23e0cab7396570309b4068aa504e9dac2cd41d827583b4e9ab7"
+checksum = "898160f1dfd383b4e92e17f0512a7d62f3c51c44937b23b6ffc3a1614a8eaccd"
 dependencies = [
  "bincode",
  "serde",
@@ -5801,9 +6518,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.22"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-segmentation"
@@ -5840,6 +6557,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
 
 [[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5847,13 +6582,13 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.18.1"
+version = "1.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f87b8aa10b915a06587d0dec516c282ff295b475d94abf425d62b57710070a2"
+checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
 dependencies = [
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "js-sys",
- "serde",
+ "serde_core",
  "wasm-bindgen",
 ]
 
@@ -5883,7 +6618,7 @@ checksum = "d674d135b4a8c1d7e813e2f8d1c9a58308aee4a680323066025e53132218bd91"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5891,6 +6626,58 @@ name = "void"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+
+[[package]]
+name = "vote-commitment-tree"
+version = "0.1.0"
+source = "git+https://github.com/valargroup/librustvoting.git#d87a01b70a8d261ae3b65828e5088e56c3eb658d"
+dependencies = [
+ "anyhow",
+ "ff",
+ "halo2_gadgets",
+ "imt-tree 0.1.0 (git+https://github.com/valargroup/vote-nullifier-pir.git)",
+ "incrementalmerkletree",
+ "lazy_static",
+ "libc",
+ "pasta_curves",
+ "shardtree",
+]
+
+[[package]]
+name = "vote-commitment-tree-client"
+version = "0.1.0"
+source = "git+https://github.com/valargroup/librustvoting.git#d87a01b70a8d261ae3b65828e5088e56c3eb658d"
+dependencies = [
+ "base64",
+ "clap",
+ "ff",
+ "hex",
+ "pasta_curves",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "vote-commitment-tree",
+]
+
+[[package]]
+name = "voting-circuits"
+version = "0.1.0"
+source = "git+https://github.com/valargroup/voting-circuits.git#05503e205535fce5f0d5ab393eb88f952d15640b"
+dependencies = [
+ "blake2b_simd",
+ "ff",
+ "group",
+ "halo2_gadgets",
+ "halo2_poseidon",
+ "halo2_proofs",
+ "incrementalmerkletree",
+ "lazy_static",
+ "orchard",
+ "pasta_curves",
+ "rand 0.8.5",
+ "sinsemilla",
+]
 
 [[package]]
 name = "walkdir"
@@ -5919,27 +6706,36 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.1+wasi-0.2.4"
+version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen",
 ]
 
 [[package]]
 name = "wasix"
-version = "0.12.21"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1fbb4ef9bbca0c1170e0b00dd28abc9e3b68669821600cad1caaed606583c6d"
+checksum = "1757e0d1f8456693c7e5c6c629bdb54884e032aa0bb53c155f6a39f94440d332"
 dependencies = [
  "wasi",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.105"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da95793dfc411fbbd93f5be7715b0578ec61fe87cb1a42b12eb625caa5c5ea60"
+checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -5949,10 +6745,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-bindgen-macro"
-version = "0.2.105"
+name = "wasm-bindgen-futures"
+version = "0.4.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04264334509e04a7bf8690f2384ef5265f05143a4bff3889ab7a3269adab59c2"
+checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5960,24 +6770,58 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.105"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "420bc339d9f322e562942d52e115d57e950d12d88983a14c79b86859ee6c7ebc"
+checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.105"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76f218a38c84bcb33c25ec7059b07847d465ce0e0a76b995e134a45adcb6af76"
+checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap 2.13.0",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags 2.11.0",
+ "hashbrown 0.15.5",
+ "indexmap 2.13.0",
+ "semver",
 ]
 
 [[package]]
@@ -5988,9 +6832,9 @@ checksum = "323f4da9523e9a669e1eaf9c6e763892769b1d38c623913647bfdc1532fe4549"
 
 [[package]]
 name = "web-sys"
-version = "0.3.82"
+version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a1f95c0d03a47f4ae1f7a64643a6bb97465d9b740f0fa8f90ea33915c99a9a1"
+checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5998,22 +6842,20 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.4"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2878ef029c47c6e8cf779119f20fcf52bde7ad42a731b2a304bc221df17571e"
+checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
 dependencies = [
  "rustls-pki-types",
 ]
 
 [[package]]
 name = "which"
-version = "8.0.0"
+version = "8.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3fabb953106c3c8eea8306e4393700d7657561cb43122571b172bbfb7c7ba1d"
+checksum = "81995fafaaaf6ae47a7d0cc83c67caf92aeb7e5331650ae6ff856f7c0c60c459"
 dependencies = [
- "env_home",
- "rustix",
- "winsafe",
+ "libc",
 ]
 
 [[package]]
@@ -6114,7 +6956,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6125,7 +6967,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6148,6 +6990,17 @@ checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
 ]
 
 [[package]]
@@ -6353,24 +7206,115 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "0.7.13"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
-name = "winsafe"
-version = "0.0.19"
+name = "winnow"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
+checksum = "a90e88e4667264a994d34e6d1ab2d26d398dcdca8b7f52bec8668957517fc7d8"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen"
-version = "0.46.0"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap 2.13.0",
+ "prettyplease",
+ "syn 2.0.117",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags 2.11.0",
+ "indexmap 2.13.0",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap 2.13.0",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
+
+[[package]]
+name = "writeable"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
 name = "wyz"
@@ -6409,10 +7353,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "yoke"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
+name = "ypir"
+version = "0.1.0"
+source = "git+https://github.com/menonsamir/ypir.git?branch=artifact#b9801521301f34502496d694b2ac034857104ebc"
+dependencies = [
+ "cc",
+ "clap",
+ "env_logger",
+ "fastrand",
+ "log",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "serde",
+ "serde_json",
+ "sha1",
+ "spiral-rs",
+ "test-log",
+]
+
+[[package]]
 name = "zcash_address"
 version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee4491dddd232de02df42481757054dc19c8bc51cf709cfec58feebfef7c3c9a"
+source = "git+https://github.com/valargroup/librustzcash.git?branch=shielded-voting-wallet-support#efb5f3470c69cff71a746deaff8318bc2b7e8aae"
 dependencies = [
  "bech32",
  "bs58",
@@ -6424,9 +7409,8 @@ dependencies = [
 
 [[package]]
 name = "zcash_client_backend"
-version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60385c0fce292b87ecff619b52b70221b2b948c341d7dd1f6bbb4fd849befead"
+version = "0.21.2"
+source = "git+https://github.com/valargroup/librustzcash.git?branch=shielded-voting-wallet-support#efb5f3470c69cff71a746deaff8318bc2b7e8aae"
 dependencies = [
  "arti-client",
  "base64",
@@ -6493,12 +7477,11 @@ dependencies = [
 
 [[package]]
 name = "zcash_client_sqlite"
-version = "0.19.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04ef4c41fe87933c996e8d77ae602ed3f7bf0f056b219c1044f6e7742d4e5cf1"
+version = "0.19.5"
+source = "git+https://github.com/valargroup/librustzcash.git?branch=shielded-voting-wallet-support#efb5f3470c69cff71a746deaff8318bc2b7e8aae"
 dependencies = [
  "bip32",
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "bs58",
  "byteorder",
  "document-features",
@@ -6541,8 +7524,7 @@ dependencies = [
 [[package]]
 name = "zcash_encoding"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bca38087e6524e5f51a5b0fb3fc18f36d7b84bf67b2056f494ca0c281590953d"
+source = "git+https://github.com/valargroup/librustzcash.git?branch=shielded-voting-wallet-support#efb5f3470c69cff71a746deaff8318bc2b7e8aae"
 dependencies = [
  "core2",
  "nonempty",
@@ -6551,8 +7533,7 @@ dependencies = [
 [[package]]
 name = "zcash_keys"
 version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c115531caa1b7ca5ccd82dc26dbe3ba44b7542e928a3f77cd04abbe3cde4a4f2"
+source = "git+https://github.com/valargroup/librustzcash.git?branch=shielded-voting-wallet-support#efb5f3470c69cff71a746deaff8318bc2b7e8aae"
 dependencies = [
  "bech32",
  "bip32",
@@ -6594,8 +7575,7 @@ dependencies = [
 [[package]]
 name = "zcash_primitives"
 version = "0.26.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0e6912efdae984166ec0dc580049699026795328dcea4fc8cc077d51fce350c"
+source = "git+https://github.com/valargroup/librustzcash.git?branch=shielded-voting-wallet-support#efb5f3470c69cff71a746deaff8318bc2b7e8aae"
 dependencies = [
  "bip32",
  "blake2b_simd",
@@ -6660,8 +7640,7 @@ dependencies = [
 [[package]]
 name = "zcash_protocol"
 version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deb4c8d0530fd7a3d65358010f1e0a1ccfe6cc5f1ad63447af089ccc82ae9edf"
+source = "git+https://github.com/valargroup/librustzcash.git?branch=shielded-voting-wallet-support#efb5f3470c69cff71a746deaff8318bc2b7e8aae"
 dependencies = [
  "core2",
  "document-features",
@@ -6671,19 +7650,19 @@ dependencies = [
 
 [[package]]
 name = "zcash_script"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bed6cf5b2b4361105d4ea06b2752f0c8af4641756c7fbc9858a80af186c234f"
+checksum = "c6ef9d04e0434a80b62ad06c5a610557be358ef60a98afa5dbc8ecaf19ad72e7"
 dependencies = [
  "bip32",
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "bounded-vec",
  "hex",
  "ripemd 0.1.3",
  "secp256k1",
  "sha1",
  "sha2 0.10.9",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -6698,8 +7677,7 @@ dependencies = [
 [[package]]
 name = "zcash_transparent"
 version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91df4a3a377d478f94e4a00ff36a4963dc641ccd8ed2455554b8cb6914721562"
+source = "git+https://github.com/valargroup/librustzcash.git?branch=shielded-voting-wallet-support#efb5f3470c69cff71a746deaff8318bc2b7e8aae"
 dependencies = [
  "bip32",
  "blake2b_simd",
@@ -6721,22 +7699,22 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.30"
+version = "0.8.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ea879c944afe8a2b25fef16bb4ba234f47c694565e97383b36f3a878219065c"
+checksum = "efbb2a062be311f2ba113ce66f697a4dc589f85e78a4aea276200804cea0ed87"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.30"
+version = "0.8.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf955aa904d6040f70dc8e9384444cb1030aed272ba3cb09bbc4ab9e7c1f34f5"
+checksum = "0e8bc7269b54418e7aeeef514aa68f8690b8c0489a06b0136e5f57c4c5ccab89"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6744,6 +7722,21 @@ name = "zerofrom"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
+]
 
 [[package]]
 name = "zeroize"
@@ -6756,13 +7749,24 @@ dependencies = [
 
 [[package]]
 name = "zeroize_derive"
-version = "1.4.2"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "zerotrie"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
 ]
 
 [[package]]
@@ -6772,7 +7776,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
 dependencies = [
  "serde",
+ "yoke",
  "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6791,8 +7808,7 @@ dependencies = [
 [[package]]
 name = "zip321"
 version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3090953750ce1d56aa213710765eb14997868f463c45dae115cf1ebe09fe39eb"
+source = "git+https://github.com/valargroup/librustzcash.git?branch=shielded-voting-wallet-support#efb5f3470c69cff71a746deaff8318bc2b7e8aae"
 dependencies = [
  "base64",
  "nom",
@@ -6800,6 +7816,12 @@ dependencies = [
  "zcash_address",
  "zcash_protocol",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
 
 [[package]]
 name = "zstd"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,13 +103,13 @@ lto = true
 #   visibility changes needed for voting delegation flows.
 [patch.crates-io]
 orchard = { git = "https://github.com/valargroup/voting-circuits.git" }
-# librustzcash crates pinned by rev to shielded-voting-wallet-support HEAD (38ef1c6).
-pczt              = { git = "https://github.com/valargroup/librustzcash.git", rev = "38ef1c6c81e9b0663aedbd81f904c51a204fa72f" }
-zcash_keys        = { git = "https://github.com/valargroup/librustzcash.git", rev = "38ef1c6c81e9b0663aedbd81f904c51a204fa72f" }
-zcash_protocol    = { git = "https://github.com/valargroup/librustzcash.git", rev = "38ef1c6c81e9b0663aedbd81f904c51a204fa72f" }
-zcash_address     = { git = "https://github.com/valargroup/librustzcash.git", rev = "38ef1c6c81e9b0663aedbd81f904c51a204fa72f" }
-zcash_encoding    = { git = "https://github.com/valargroup/librustzcash.git", rev = "38ef1c6c81e9b0663aedbd81f904c51a204fa72f" }
-zcash_transparent = { git = "https://github.com/valargroup/librustzcash.git", rev = "38ef1c6c81e9b0663aedbd81f904c51a204fa72f" }
-zcash_client_sqlite  = { git = "https://github.com/valargroup/librustzcash.git", rev = "38ef1c6c81e9b0663aedbd81f904c51a204fa72f" }
-zcash_client_backend = { git = "https://github.com/valargroup/librustzcash.git", rev = "38ef1c6c81e9b0663aedbd81f904c51a204fa72f" }
-zcash_primitives  = { git = "https://github.com/valargroup/librustzcash.git", rev = "38ef1c6c81e9b0663aedbd81f904c51a204fa72f" }
+# librustzcash crates pinned by rev to shielded-voting-wallet-support HEAD (7c8c8b0).
+pczt              = { git = "https://github.com/valargroup/librustzcash.git", rev = "7c8c8b0e0ce6769a4b58ea96d97fb78b9d98e1fc" }
+zcash_keys        = { git = "https://github.com/valargroup/librustzcash.git", rev = "7c8c8b0e0ce6769a4b58ea96d97fb78b9d98e1fc" }
+zcash_protocol    = { git = "https://github.com/valargroup/librustzcash.git", rev = "7c8c8b0e0ce6769a4b58ea96d97fb78b9d98e1fc" }
+zcash_address     = { git = "https://github.com/valargroup/librustzcash.git", rev = "7c8c8b0e0ce6769a4b58ea96d97fb78b9d98e1fc" }
+zcash_encoding    = { git = "https://github.com/valargroup/librustzcash.git", rev = "7c8c8b0e0ce6769a4b58ea96d97fb78b9d98e1fc" }
+zcash_transparent = { git = "https://github.com/valargroup/librustzcash.git", rev = "7c8c8b0e0ce6769a4b58ea96d97fb78b9d98e1fc" }
+zcash_client_sqlite  = { git = "https://github.com/valargroup/librustzcash.git", rev = "7c8c8b0e0ce6769a4b58ea96d97fb78b9d98e1fc" }
+zcash_client_backend = { git = "https://github.com/valargroup/librustzcash.git", rev = "7c8c8b0e0ce6769a4b58ea96d97fb78b9d98e1fc" }
+zcash_primitives  = { git = "https://github.com/valargroup/librustzcash.git", rev = "7c8c8b0e0ce6769a4b58ea96d97fb78b9d98e1fc" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,7 +78,7 @@ rust_decimal = { version = "1", default-features = false, features = ["c-repr"] 
 xz2 = { version = "0.1", features = ["static"] }
 
 # Voting
-librustvoting = { git = "https://github.com/valargroup/librustvoting.git", rev = "8ff443286d313182625cfb504061700f29130d88" }
+librustvoting = { git = "https://github.com/valargroup/librustvoting.git", rev = "126c11d354c28de257d75558f0d88bcee0f2e0d0" }
 voting-circuits = { git = "https://github.com/valargroup/voting-circuits.git" }
 zcash_keys = { version = "0.12", features = ["orchard"] }
 incrementalmerkletree = { version = "0.8", default-features = false }
@@ -103,13 +103,13 @@ lto = true
 #   visibility changes needed for voting delegation flows.
 [patch.crates-io]
 orchard = { git = "https://github.com/valargroup/voting-circuits.git" }
-# librustzcash crates pinned by rev to shielded-voting-wallet-support HEAD (6858db4).
-pczt              = { git = "https://github.com/valargroup/librustzcash.git", rev = "6858db4a523de05f7474a89c7df751510c71874d" }
-zcash_keys        = { git = "https://github.com/valargroup/librustzcash.git", rev = "6858db4a523de05f7474a89c7df751510c71874d" }
-zcash_protocol    = { git = "https://github.com/valargroup/librustzcash.git", rev = "6858db4a523de05f7474a89c7df751510c71874d" }
-zcash_address     = { git = "https://github.com/valargroup/librustzcash.git", rev = "6858db4a523de05f7474a89c7df751510c71874d" }
-zcash_encoding    = { git = "https://github.com/valargroup/librustzcash.git", rev = "6858db4a523de05f7474a89c7df751510c71874d" }
-zcash_transparent = { git = "https://github.com/valargroup/librustzcash.git", rev = "6858db4a523de05f7474a89c7df751510c71874d" }
-zcash_client_sqlite  = { git = "https://github.com/valargroup/librustzcash.git", rev = "6858db4a523de05f7474a89c7df751510c71874d" }
-zcash_client_backend = { git = "https://github.com/valargroup/librustzcash.git", rev = "6858db4a523de05f7474a89c7df751510c71874d" }
-zcash_primitives  = { git = "https://github.com/valargroup/librustzcash.git", rev = "6858db4a523de05f7474a89c7df751510c71874d" }
+# librustzcash crates pinned by rev to shielded-voting-wallet-support HEAD (1d3ac2f).
+pczt              = { git = "https://github.com/valargroup/librustzcash.git", rev = "1d3ac2fa9977e2118301722fb0c98b6aedde02e8" }
+zcash_keys        = { git = "https://github.com/valargroup/librustzcash.git", rev = "1d3ac2fa9977e2118301722fb0c98b6aedde02e8" }
+zcash_protocol    = { git = "https://github.com/valargroup/librustzcash.git", rev = "1d3ac2fa9977e2118301722fb0c98b6aedde02e8" }
+zcash_address     = { git = "https://github.com/valargroup/librustzcash.git", rev = "1d3ac2fa9977e2118301722fb0c98b6aedde02e8" }
+zcash_encoding    = { git = "https://github.com/valargroup/librustzcash.git", rev = "1d3ac2fa9977e2118301722fb0c98b6aedde02e8" }
+zcash_transparent = { git = "https://github.com/valargroup/librustzcash.git", rev = "1d3ac2fa9977e2118301722fb0c98b6aedde02e8" }
+zcash_client_sqlite  = { git = "https://github.com/valargroup/librustzcash.git", rev = "1d3ac2fa9977e2118301722fb0c98b6aedde02e8" }
+zcash_client_backend = { git = "https://github.com/valargroup/librustzcash.git", rev = "1d3ac2fa9977e2118301722fb0c98b6aedde02e8" }
+zcash_primitives  = { git = "https://github.com/valargroup/librustzcash.git", rev = "1d3ac2fa9977e2118301722fb0c98b6aedde02e8" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,13 +103,13 @@ lto = true
 #   visibility changes needed for voting delegation flows.
 [patch.crates-io]
 orchard = { git = "https://github.com/valargroup/voting-circuits.git" }
-# librustzcash crates pinned by rev to shielded-voting-wallet-support HEAD (1d3ac2f).
-pczt              = { git = "https://github.com/valargroup/librustzcash.git", rev = "1d3ac2fa9977e2118301722fb0c98b6aedde02e8" }
-zcash_keys        = { git = "https://github.com/valargroup/librustzcash.git", rev = "1d3ac2fa9977e2118301722fb0c98b6aedde02e8" }
-zcash_protocol    = { git = "https://github.com/valargroup/librustzcash.git", rev = "1d3ac2fa9977e2118301722fb0c98b6aedde02e8" }
-zcash_address     = { git = "https://github.com/valargroup/librustzcash.git", rev = "1d3ac2fa9977e2118301722fb0c98b6aedde02e8" }
-zcash_encoding    = { git = "https://github.com/valargroup/librustzcash.git", rev = "1d3ac2fa9977e2118301722fb0c98b6aedde02e8" }
-zcash_transparent = { git = "https://github.com/valargroup/librustzcash.git", rev = "1d3ac2fa9977e2118301722fb0c98b6aedde02e8" }
-zcash_client_sqlite  = { git = "https://github.com/valargroup/librustzcash.git", rev = "1d3ac2fa9977e2118301722fb0c98b6aedde02e8" }
-zcash_client_backend = { git = "https://github.com/valargroup/librustzcash.git", rev = "1d3ac2fa9977e2118301722fb0c98b6aedde02e8" }
-zcash_primitives  = { git = "https://github.com/valargroup/librustzcash.git", rev = "1d3ac2fa9977e2118301722fb0c98b6aedde02e8" }
+# librustzcash crates pinned by rev to shielded-voting-wallet-support HEAD (38ef1c6).
+pczt              = { git = "https://github.com/valargroup/librustzcash.git", rev = "38ef1c6c81e9b0663aedbd81f904c51a204fa72f" }
+zcash_keys        = { git = "https://github.com/valargroup/librustzcash.git", rev = "38ef1c6c81e9b0663aedbd81f904c51a204fa72f" }
+zcash_protocol    = { git = "https://github.com/valargroup/librustzcash.git", rev = "38ef1c6c81e9b0663aedbd81f904c51a204fa72f" }
+zcash_address     = { git = "https://github.com/valargroup/librustzcash.git", rev = "38ef1c6c81e9b0663aedbd81f904c51a204fa72f" }
+zcash_encoding    = { git = "https://github.com/valargroup/librustzcash.git", rev = "38ef1c6c81e9b0663aedbd81f904c51a204fa72f" }
+zcash_transparent = { git = "https://github.com/valargroup/librustzcash.git", rev = "38ef1c6c81e9b0663aedbd81f904c51a204fa72f" }
+zcash_client_sqlite  = { git = "https://github.com/valargroup/librustzcash.git", rev = "38ef1c6c81e9b0663aedbd81f904c51a204fa72f" }
+zcash_client_backend = { git = "https://github.com/valargroup/librustzcash.git", rev = "38ef1c6c81e9b0663aedbd81f904c51a204fa72f" }
+zcash_primitives  = { git = "https://github.com/valargroup/librustzcash.git", rev = "38ef1c6c81e9b0663aedbd81f904c51a204fa72f" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,7 +78,7 @@ rust_decimal = { version = "1", default-features = false, features = ["c-repr"] 
 xz2 = { version = "0.1", features = ["static"] }
 
 # Voting
-librustvoting = { git = "https://github.com/valargroup/librustvoting.git" }
+librustvoting = { git = "https://github.com/valargroup/librustvoting.git", rev = "8ff443286d313182625cfb504061700f29130d88" }
 voting-circuits = { git = "https://github.com/valargroup/voting-circuits.git" }
 zcash_keys = { version = "0.12", features = ["orchard"] }
 incrementalmerkletree = { version = "0.8", default-features = false }
@@ -103,12 +103,13 @@ lto = true
 #   visibility changes needed for voting delegation flows.
 [patch.crates-io]
 orchard = { git = "https://github.com/valargroup/voting-circuits.git" }
-pczt              = { git = "https://github.com/valargroup/librustzcash.git", branch = "shielded-voting-wallet-support" }
-zcash_keys        = { git = "https://github.com/valargroup/librustzcash.git", branch = "shielded-voting-wallet-support" }
-zcash_protocol    = { git = "https://github.com/valargroup/librustzcash.git", branch = "shielded-voting-wallet-support" }
-zcash_address     = { git = "https://github.com/valargroup/librustzcash.git", branch = "shielded-voting-wallet-support" }
-zcash_encoding    = { git = "https://github.com/valargroup/librustzcash.git", branch = "shielded-voting-wallet-support" }
-zcash_transparent = { git = "https://github.com/valargroup/librustzcash.git", branch = "shielded-voting-wallet-support" }
-zcash_client_sqlite  = { git = "https://github.com/valargroup/librustzcash.git", branch = "shielded-voting-wallet-support" }
-zcash_client_backend = { git = "https://github.com/valargroup/librustzcash.git", branch = "shielded-voting-wallet-support" }
-zcash_primitives  = { git = "https://github.com/valargroup/librustzcash.git", branch = "shielded-voting-wallet-support" }
+# librustzcash crates pinned by rev to shielded-voting-wallet-support HEAD (6858db4).
+pczt              = { git = "https://github.com/valargroup/librustzcash.git", rev = "6858db4a523de05f7474a89c7df751510c71874d" }
+zcash_keys        = { git = "https://github.com/valargroup/librustzcash.git", rev = "6858db4a523de05f7474a89c7df751510c71874d" }
+zcash_protocol    = { git = "https://github.com/valargroup/librustzcash.git", rev = "6858db4a523de05f7474a89c7df751510c71874d" }
+zcash_address     = { git = "https://github.com/valargroup/librustzcash.git", rev = "6858db4a523de05f7474a89c7df751510c71874d" }
+zcash_encoding    = { git = "https://github.com/valargroup/librustzcash.git", rev = "6858db4a523de05f7474a89c7df751510c71874d" }
+zcash_transparent = { git = "https://github.com/valargroup/librustzcash.git", rev = "6858db4a523de05f7474a89c7df751510c71874d" }
+zcash_client_sqlite  = { git = "https://github.com/valargroup/librustzcash.git", rev = "6858db4a523de05f7474a89c7df751510c71874d" }
+zcash_client_backend = { git = "https://github.com/valargroup/librustzcash.git", rev = "6858db4a523de05f7474a89c7df751510c71874d" }
+zcash_primitives  = { git = "https://github.com/valargroup/librustzcash.git", rev = "6858db4a523de05f7474a89c7df751510c71874d" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,6 +81,7 @@ xz2 = { version = "0.1", features = ["static"] }
 librustvoting = { git = "https://github.com/valargroup/librustvoting.git" }
 voting-circuits = { git = "https://github.com/valargroup/voting-circuits.git" }
 zcash_keys = { version = "0.12", features = ["orchard"] }
+incrementalmerkletree = { version = "0.8", default-features = false }
 
 [build-dependencies]
 bindgen = "0.72"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,7 +78,7 @@ rust_decimal = { version = "1", default-features = false, features = ["c-repr"] 
 xz2 = { version = "0.1", features = ["static"] }
 
 # Voting
-librustvoting = { git = "https://github.com/valargroup/librustvoting.git", rev = "126c11d354c28de257d75558f0d88bcee0f2e0d0" }
+zcash_voting = { git = "https://github.com/valargroup/zcash_voting.git", rev = "126c11d354c28de257d75558f0d88bcee0f2e0d0" }
 voting-circuits = { git = "https://github.com/valargroup/voting-circuits.git" }
 zcash_keys = { version = "0.12", features = ["orchard"] }
 incrementalmerkletree = { version = "0.8", default-features = false }
@@ -96,7 +96,7 @@ crate-type = ["staticlib"]
 [profile.release]
 lto = true
 
-# Patches to align librustvoting's dependencies with the SDK's.
+# Patches to align zcash_voting's dependencies with the SDK's.
 # orchard: voting-circuits fork (upstream 0.11 + pub visibility for
 #   constants/spec + shared_primitives gadget for voting ZKPs).
 # librustzcash crates: governance extensions branch with PCZT/key

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,8 @@ anyhow = "1.0"
 ffi_helpers = "0.3"
 uuid = "1.1"
 bitflags = "2"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 
 # HTTP
 bytes = "1"
@@ -75,6 +77,11 @@ rust_decimal = { version = "1", default-features = false, features = ["c-repr"] 
 # - The "static" feature is required for the "compression" default feature of arti-client.
 xz2 = { version = "0.1", features = ["static"] }
 
+# Voting
+librustvoting = { git = "https://github.com/valargroup/librustvoting.git" }
+voting-circuits = { git = "https://github.com/valargroup/voting-circuits.git" }
+zcash_keys = { version = "0.12", features = ["orchard"] }
+
 [build-dependencies]
 bindgen = "0.72"
 cbindgen = "0.29"
@@ -87,3 +94,20 @@ crate-type = ["staticlib"]
 
 [profile.release]
 lto = true
+
+# Patches to align librustvoting's dependencies with the SDK's.
+# orchard: voting-circuits fork (upstream 0.11 + pub visibility for
+#   constants/spec + shared_primitives gadget for voting ZKPs).
+# librustzcash crates: governance extensions branch with PCZT/key
+#   visibility changes needed for voting delegation flows.
+[patch.crates-io]
+orchard = { git = "https://github.com/valargroup/voting-circuits.git" }
+pczt              = { git = "https://github.com/valargroup/librustzcash.git", branch = "shielded-voting-wallet-support" }
+zcash_keys        = { git = "https://github.com/valargroup/librustzcash.git", branch = "shielded-voting-wallet-support" }
+zcash_protocol    = { git = "https://github.com/valargroup/librustzcash.git", branch = "shielded-voting-wallet-support" }
+zcash_address     = { git = "https://github.com/valargroup/librustzcash.git", branch = "shielded-voting-wallet-support" }
+zcash_encoding    = { git = "https://github.com/valargroup/librustzcash.git", branch = "shielded-voting-wallet-support" }
+zcash_transparent = { git = "https://github.com/valargroup/librustzcash.git", branch = "shielded-voting-wallet-support" }
+zcash_client_sqlite  = { git = "https://github.com/valargroup/librustzcash.git", branch = "shielded-voting-wallet-support" }
+zcash_client_backend = { git = "https://github.com/valargroup/librustzcash.git", branch = "shielded-voting-wallet-support" }
+zcash_primitives  = { git = "https://github.com/valargroup/librustzcash.git", branch = "shielded-voting-wallet-support" }

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,12 +1,30 @@
 {
   "pins" : [
     {
+      "identity" : "csqlite",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/stephencelis/CSQLite",
+      "state" : {
+        "revision" : "bdb5580e54cdf49251b365ea34e2651199473240",
+        "version" : "3.50.4"
+      }
+    },
+    {
       "identity" : "grpc-swift",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/grpc/grpc-swift.git",
       "state" : {
         "revision" : "956259f65a34c58dd76ae5df4511712e1087726b",
         "version" : "1.27.3"
+      }
+    },
+    {
+      "identity" : "sqlcipher.swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/sqlcipher/SQLCipher.swift",
+      "state" : {
+        "revision" : "180be9a4dd130d838765a156b709e02f3bc3e7cd",
+        "version" : "4.14.0"
       }
     },
     {
@@ -187,6 +205,15 @@
       "state" : {
         "revision" : "7c6ad0fc39d0763e0b699210e4124afd5041c5df",
         "version" : "1.6.4"
+      }
+    },
+    {
+      "identity" : "swift-toolchain-sqlite",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-toolchain-sqlite",
+      "state" : {
+        "revision" : "b45b80b943e88db3cb8ddea798fa3fa9912375ff",
+        "version" : "1.0.7"
       }
     }
   ],

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,30 +1,12 @@
 {
   "pins" : [
     {
-      "identity" : "csqlite",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/stephencelis/CSQLite",
-      "state" : {
-        "revision" : "bdb5580e54cdf49251b365ea34e2651199473240",
-        "version" : "3.50.4"
-      }
-    },
-    {
       "identity" : "grpc-swift",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/grpc/grpc-swift.git",
       "state" : {
         "revision" : "956259f65a34c58dd76ae5df4511712e1087726b",
         "version" : "1.27.3"
-      }
-    },
-    {
-      "identity" : "sqlcipher.swift",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/sqlcipher/SQLCipher.swift",
-      "state" : {
-        "revision" : "180be9a4dd130d838765a156b709e02f3bc3e7cd",
-        "version" : "4.14.0"
       }
     },
     {
@@ -205,15 +187,6 @@
       "state" : {
         "revision" : "7c6ad0fc39d0763e0b699210e4124afd5041c5df",
         "version" : "1.6.4"
-      }
-    },
-    {
-      "identity" : "swift-toolchain-sqlite",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/swiftlang/swift-toolchain-sqlite",
-      "state" : {
-        "revision" : "b45b80b943e88db3cb8ddea798fa3fa9912375ff",
-        "version" : "1.0.7"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -30,8 +30,8 @@ if useLocalFFI {
     targets.append(
         .binaryTarget(
             name: "libzcashlc",
-            url: "https://github.com/valargroup/zcash-swift-wallet-sdk/releases/download/0.2.0-voting/libzcashlc.xcframework.zip",
-            checksum: "ea7bf3ae8850268274c1f0c66fc5729ef22991d0761eddbc0a04239fdf86068e"
+            url: "https://github.com/valargroup/zcash-swift-wallet-sdk/releases/download/0.3.0-voting/libzcashlc.xcframework.zip",
+            checksum: "1637dfdea7c25bec49017f23dc264fe4e6d7b4d31fdc7403a9e8d134fa494a8a"
         )
     )
     sdkDependencies.append("libzcashlc")

--- a/Package.swift
+++ b/Package.swift
@@ -30,8 +30,8 @@ if useLocalFFI {
     targets.append(
         .binaryTarget(
             name: "libzcashlc",
-            url: "https://github.com/valargroup/zcash-swift-wallet-sdk/releases/download/0.1.0-voting/libzcashlc.xcframework.zip",
-            checksum: "188ef46c2ad2eb1d9a457cdaded2cd4c60a1d80d8217d7752efc125dae1ae90e"
+            url: "https://github.com/valargroup/zcash-swift-wallet-sdk/releases/download/0.2.0-voting/libzcashlc.xcframework.zip",
+            checksum: "ea7bf3ae8850268274c1f0c66fc5729ef22991d0761eddbc0a04239fdf86068e"
         )
     )
     sdkDependencies.append("libzcashlc")

--- a/Package.swift
+++ b/Package.swift
@@ -30,8 +30,8 @@ if useLocalFFI {
     targets.append(
         .binaryTarget(
             name: "libzcashlc",
-            url: "https://github.com/zcash/zcash-swift-wallet-sdk/releases/download/2.4.6/libzcashlc.xcframework.zip",
-            checksum: "18beb8387d8538100638c474b46396b7c857f2dc196e4edda027c59b8d521406"
+            url: "https://github.com/valargroup/zcash-swift-wallet-sdk/releases/download/0.1.0-voting/libzcashlc.xcframework.zip",
+            checksum: "188ef46c2ad2eb1d9a457cdaded2cd4c60a1d80d8217d7752efc125dae1ae90e"
         )
     )
     sdkDependencies.append("libzcashlc")

--- a/Package.swift
+++ b/Package.swift
@@ -30,8 +30,8 @@ if useLocalFFI {
     targets.append(
         .binaryTarget(
             name: "libzcashlc",
-            url: "https://github.com/valargroup/zcash-swift-wallet-sdk/releases/download/0.3.0-voting/libzcashlc.xcframework.zip",
-            checksum: "1637dfdea7c25bec49017f23dc264fe4e6d7b4d31fdc7403a9e8d134fa494a8a"
+            url: "https://github.com/valargroup/zcash-swift-wallet-sdk/releases/download/0.4.0-voting/libzcashlc.xcframework.zip",
+            checksum: "828f24ecab17580149c1be2ba2baf7aebc938c08781d9db06ea438dac70e691e"
         )
     )
     sdkDependencies.append("libzcashlc")

--- a/Package.swift
+++ b/Package.swift
@@ -30,8 +30,8 @@ if useLocalFFI {
     targets.append(
         .binaryTarget(
             name: "libzcashlc",
-            url: "https://github.com/valargroup/zcash-swift-wallet-sdk/releases/download/0.4.0-voting/libzcashlc.xcframework.zip",
-            checksum: "828f24ecab17580149c1be2ba2baf7aebc938c08781d9db06ea438dac70e691e"
+            url: "https://github.com/valargroup/zcash-swift-wallet-sdk/releases/download/0.0.25-voting/libzcashlc.xcframework.zip",
+            checksum: "4ad1b94b5155df8f8d8ebc553cfd9387e2349593254d596badfef91496eaa1a2"
         )
     )
     sdkDependencies.append("libzcashlc")

--- a/Package.swift
+++ b/Package.swift
@@ -30,8 +30,8 @@ if useLocalFFI {
     targets.append(
         .binaryTarget(
             name: "libzcashlc",
-            url: "https://github.com/valargroup/zcash-swift-wallet-sdk/releases/download/0.0.25-voting/libzcashlc.xcframework.zip",
-            checksum: "4ad1b94b5155df8f8d8ebc553cfd9387e2349593254d596badfef91496eaa1a2"
+            url: "https://github.com/valargroup/zcash-swift-wallet-sdk/releases/download/0.5.0-voting/libzcashlc.xcframework.zip",
+            checksum: "75cb9c1d76efd39ffaddb96b8690021e37bd5202727decdadda339ec0ce4e775"
         )
     )
     sdkDependencies.append("libzcashlc")

--- a/Package.swift
+++ b/Package.swift
@@ -30,8 +30,8 @@ if useLocalFFI {
     targets.append(
         .binaryTarget(
             name: "libzcashlc",
-            url: "https://github.com/valargroup/zcash-swift-wallet-sdk/releases/download/0.5.0-voting/libzcashlc.xcframework.zip",
-            checksum: "75cb9c1d76efd39ffaddb96b8690021e37bd5202727decdadda339ec0ce4e775"
+            url: "https://github.com/valargroup/zcash-swift-wallet-sdk/releases/download/0.6.0-voting/libzcashlc.xcframework.zip",
+            checksum: "59343421f494664ffd0fb1ca5aba2ff16f27417d13b8b41fdcd0cc509dfecfc2"
         )
     )
     sdkDependencies.append("libzcashlc")

--- a/Package.swift
+++ b/Package.swift
@@ -49,6 +49,9 @@ targets.append(contentsOf: [
         ],
         resources: [
             .copy("Resources/checkpoints")
+        ],
+        linkerSettings: [
+            .linkedFramework("SystemConfiguration", .when(platforms: [.macOS]))
         ]
     ),
     .target(

--- a/Scripts/prepare-fork-release.sh
+++ b/Scripts/prepare-fork-release.sh
@@ -1,0 +1,157 @@
+#!/bin/bash
+# Build and upload xcframework to the valargroup fork
+#
+# This is a lightweight version of prepare-release.sh for the fork.
+# It builds only iOS device + iOS simulator (arm64 only, no x86_64/macOS)
+# to keep build times short during development.
+#
+# NOTE: Before upstreaming, all scripts and Package.swift changes need to be
+# reviewed against the upstream contributing guidelines and the full
+# prepare-release.sh / release.sh workflow restored.
+#
+# Usage: ./Scripts/prepare-fork-release.sh <version>
+# Example: ./Scripts/prepare-fork-release.sh 0.1.0-voting
+
+set -e
+cd "$(dirname "$0")/.."
+
+if [[ -f "$HOME/.cargo/env" ]]; then
+    source "$HOME/.cargo/env"
+fi
+
+if [[ -z "$1" ]]; then
+    echo "Usage: $0 <version>"
+    echo "Example: $0 0.1.0-voting"
+    exit 1
+fi
+
+VERSION="$1"
+REPO="valargroup/zcash-swift-wallet-sdk"
+PRODUCTS_DIR="BuildSupport/products"
+ZIP_FILE="libzcashlc.xcframework.zip"
+
+echo "=== Fork release ${VERSION} (iOS only, arm64) ==="
+echo ""
+
+# --- Build ---
+
+TARGETS="aarch64-apple-ios aarch64-apple-ios-sim"
+for TARGET in $TARGETS; do
+    if ! rustup target list --installed | grep -q "^${TARGET}$"; then
+        echo "Installing Rust target ${TARGET}..."
+        rustup target add "$TARGET"
+    fi
+    echo "Building ${TARGET} (release)..."
+    cargo build --target "$TARGET" --release
+done
+
+# --- Assemble xcframework ---
+
+echo ""
+echo "Assembling xcframework..."
+
+XCFW="$PRODUCTS_DIR/libzcashlc.xcframework"
+rm -rf "$XCFW"
+
+# iOS device slice (arm64)
+DEVICE_FW="$XCFW/ios-arm64/libzcashlc.framework"
+mkdir -p "$DEVICE_FW/Modules" "$DEVICE_FW/Headers"
+cp target/aarch64-apple-ios/release/libzcashlc.a "$DEVICE_FW/libzcashlc"
+cp -R target/Headers/* "$DEVICE_FW/Headers/"
+cp BuildSupport/module.modulemap "$DEVICE_FW/Modules/"
+cp BuildSupport/platform-Info.plist "$DEVICE_FW/Info.plist"
+
+# iOS simulator slice (arm64 only — sufficient for Apple Silicon dev)
+SIM_FW="$XCFW/ios-arm64-simulator/libzcashlc.framework"
+mkdir -p "$SIM_FW/Modules" "$SIM_FW/Headers"
+cp target/aarch64-apple-ios-sim/release/libzcashlc.a "$SIM_FW/libzcashlc"
+cp -R target/Headers/* "$SIM_FW/Headers/"
+cp BuildSupport/module.modulemap "$SIM_FW/Modules/"
+cp BuildSupport/platform-Info.plist "$SIM_FW/Info.plist"
+
+# xcframework Info.plist (iOS device + arm64 simulator only)
+cat > "$XCFW/Info.plist" << 'PLISTEOF'
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>AvailableLibraries</key>
+	<array>
+		<dict>
+			<key>LibraryIdentifier</key>
+			<string>ios-arm64</string>
+			<key>LibraryPath</key>
+			<string>libzcashlc.framework</string>
+			<key>SupportedArchitectures</key>
+			<array>
+				<string>arm64</string>
+			</array>
+			<key>SupportedPlatform</key>
+			<string>ios</string>
+		</dict>
+		<dict>
+			<key>LibraryIdentifier</key>
+			<string>ios-arm64-simulator</string>
+			<key>LibraryPath</key>
+			<string>libzcashlc.framework</string>
+			<key>SupportedArchitectures</key>
+			<array>
+				<string>arm64</string>
+			</array>
+			<key>SupportedPlatform</key>
+			<string>ios</string>
+			<key>SupportedPlatformVariant</key>
+			<string>simulator</string>
+		</dict>
+	</array>
+	<key>CFBundlePackageType</key>
+	<string>XFWK</string>
+	<key>XCFrameworkFormatVersion</key>
+	<string>1.0</string>
+</dict>
+</plist>
+PLISTEOF
+
+# --- Zip and checksum ---
+
+echo ""
+echo "Creating archive..."
+
+cd "$PRODUCTS_DIR"
+rm -f "$ZIP_FILE"
+zip -r "$ZIP_FILE" libzcashlc.xcframework
+CHECKSUM=$(shasum -a 256 "$ZIP_FILE" | awk '{print $1}')
+cd ../..
+
+DOWNLOAD_URL="https://github.com/${REPO}/releases/download/${VERSION}/${ZIP_FILE}"
+
+# --- Upload to GitHub ---
+
+echo ""
+echo "Uploading to GitHub..."
+
+if gh release view "$VERSION" --repo "$REPO" &>/dev/null; then
+    echo "Release $VERSION exists, updating assets..."
+    gh release upload "$VERSION" \
+        "$PRODUCTS_DIR/$ZIP_FILE" \
+        --repo "$REPO" \
+        --clobber
+else
+    gh release create "$VERSION" \
+        "$PRODUCTS_DIR/$ZIP_FILE" \
+        --repo "$REPO" \
+        --title "$VERSION" \
+        --notes "Development build for voting FFI integration" \
+        --prerelease
+fi
+
+echo ""
+echo "=========================================="
+echo "  Release uploaded: ${DOWNLOAD_URL}"
+echo "=========================================="
+echo ""
+echo "Update Package.swift binaryTarget:"
+echo ""
+echo "    url: \"${DOWNLOAD_URL}\","
+echo "    checksum: \"${CHECKSUM}\""
+echo ""

--- a/Sources/ZcashLightClientKit/Rust/Voting/VotingRustBackend.swift
+++ b/Sources/ZcashLightClientKit/Rust/Voting/VotingRustBackend.swift
@@ -1,0 +1,1137 @@
+// swiftlint:disable file_length
+// VotingRustBackend.swift
+// Swift wrapper for the hand-rolled voting C FFI in voting.rs.
+// Manages the opaque VotingDatabaseHandle and bridges all voting operations.
+
+import Foundation
+import libzcashlc
+
+// MARK: - Error
+
+public enum VotingRustBackendError: Error, Equatable {
+    case databaseAlreadyOpen
+    case databaseNotOpen
+    case rustError(String)
+    case invalidData(String)
+}
+
+// MARK: - Progress callback
+
+/// Closure type for proof progress reporting.
+public typealias VotingProgressHandler = @Sendable (Double) -> Void
+
+// MARK: - VotingRustBackend
+
+/// Wraps the voting C FFI. Manages an opaque VotingDatabaseHandle pointer.
+///
+/// Thread safety: all methods that touch the database handle are isolated to a
+/// private serial actor. The handle is opened once and freed on `close()` or deinit.
+public final class VotingRustBackend: @unchecked Sendable {
+    private let lock = NSLock()
+    private var handle: OpaquePointer?
+
+    public init() {}
+
+    deinit {
+        if let handle {
+            zcashlc_voting_db_free(handle)
+        }
+    }
+
+    // MARK: - Database lifecycle
+
+    /// Open the voting database at `path`.
+    public func open(path: String) throws {
+        lock.lock()
+        defer { lock.unlock() }
+
+        guard handle == nil else {
+            throw VotingRustBackendError.databaseAlreadyOpen
+        }
+
+        let pathBytes = [UInt8](path.utf8)
+        guard let ptr = pathBytes.withUnsafeBufferPointer({ buf in
+            zcashlc_voting_db_open(buf.baseAddress, UInt(buf.count))
+        }) else {
+            throw VotingRustBackendError.rustError(lastErrorMessage(fallback: "`voting_db_open` failed"))
+        }
+        handle = ptr
+    }
+
+    /// Close the voting database, freeing the handle.
+    public func close() {
+        lock.lock()
+        defer { lock.unlock() }
+        if let dbh = handle {
+            zcashlc_voting_db_free(dbh)
+            handle = nil
+        }
+    }
+}
+
+// MARK: - Round management
+
+extension VotingRustBackend {
+    /// Initialize a voting round.
+    // swiftlint:disable:next function_parameter_count
+    public func initRound(
+        roundId: String,
+        snapshotHeight: UInt64,
+        eaPk: [UInt8],
+        ncRoot: [UInt8],
+        nullifierImtRoot: [UInt8],
+        sessionJson: String?
+    ) throws {
+        let dbh = try requireHandle()
+        let roundIdBytes = [UInt8](roundId.utf8)
+        let sessionBytes: [UInt8]? = sessionJson.map { [UInt8]($0.utf8) }
+
+        let result = roundIdBytes.withUnsafeBufferPointer { ridBuf in
+            eaPk.withUnsafeBufferPointer { eaBuf in
+                ncRoot.withUnsafeBufferPointer { ncBuf in
+                    nullifierImtRoot.withUnsafeBufferPointer { nfBuf in
+                        if let sessionBytes {
+                            return sessionBytes.withUnsafeBufferPointer { sjBuf in
+                                zcashlc_voting_init_round(
+                                    dbh,
+                                    ridBuf.baseAddress,
+                                    UInt(ridBuf.count),
+                                    snapshotHeight,
+                                    eaBuf.baseAddress,
+                                    UInt(eaBuf.count),
+                                    ncBuf.baseAddress,
+                                    UInt(ncBuf.count),
+                                    nfBuf.baseAddress,
+                                    UInt(nfBuf.count),
+                                    sjBuf.baseAddress,
+                                    UInt(sjBuf.count)
+                                )
+                            }
+                        } else {
+                            return zcashlc_voting_init_round(
+                                dbh,
+                                ridBuf.baseAddress,
+                                UInt(ridBuf.count),
+                                snapshotHeight,
+                                eaBuf.baseAddress,
+                                UInt(eaBuf.count),
+                                ncBuf.baseAddress,
+                                UInt(ncBuf.count),
+                                nfBuf.baseAddress,
+                                UInt(nfBuf.count),
+                                nil,
+                                0
+                            )
+                        }
+                    }
+                }
+            }
+        }
+
+        guard result == 0 else {
+            throw VotingRustBackendError.rustError(lastErrorMessage(fallback: "`init_round` failed"))
+        }
+    }
+
+    /// Get the state of a voting round.
+    public func getRoundState(roundId: String) throws -> VotingRoundState {
+        let dbh = try requireHandle()
+        let roundIdBytes = [UInt8](roundId.utf8)
+
+        guard let ptr = roundIdBytes.withUnsafeBufferPointer({ buf in
+            zcashlc_voting_get_round_state(dbh, buf.baseAddress, UInt(buf.count))
+        }) else {
+            throw VotingRustBackendError.rustError(lastErrorMessage(fallback: "`get_round_state` failed"))
+        }
+
+        defer { zcashlc_voting_free_round_state(ptr) }
+
+        let state = ptr.pointee
+        let phase = VotingRoundPhase(rawValue: state.phase) ?? .initialized
+
+        let roundIdStr: String
+        if let rid = state.round_id {
+            roundIdStr = String(cString: rid)
+        } else {
+            roundIdStr = roundId
+        }
+
+        let hotkeyAddr: String?
+        if let addr = state.hotkey_address {
+            hotkeyAddr = String(cString: addr)
+        } else {
+            hotkeyAddr = nil
+        }
+
+        let weight: UInt64? = state.delegated_weight >= 0 ? UInt64(state.delegated_weight) : nil
+
+        return VotingRoundState(
+            roundId: roundIdStr,
+            phase: phase,
+            snapshotHeight: state.snapshot_height,
+            hotkeyAddress: hotkeyAddr,
+            delegatedWeight: weight,
+            proofGenerated: state.proof_generated
+        )
+    }
+
+    /// List all voting rounds.
+    public func listRounds() throws -> [VotingRoundSummary] {
+        let dbh = try requireHandle()
+
+        guard let ptr = zcashlc_voting_list_rounds(dbh) else {
+            throw VotingRustBackendError.rustError(lastErrorMessage(fallback: "`list_rounds` failed"))
+        }
+
+        defer { zcashlc_voting_free_round_summaries(ptr) }
+
+        let summaries = ptr.pointee
+        var roundSummaries: [VotingRoundSummary] = []
+        for i in 0..<Int(summaries.len) {
+            let entry = summaries.ptr.advanced(by: i).pointee
+            let rid = entry.round_id != nil ? String(cString: entry.round_id) : ""
+            let phase = VotingRoundPhase(rawValue: entry.phase) ?? .initialized
+            roundSummaries.append(VotingRoundSummary(
+                roundId: rid,
+                phase: phase,
+                snapshotHeight: entry.snapshot_height,
+                createdAt: entry.created_at
+            ))
+        }
+        return roundSummaries
+    }
+
+    /// Get vote records for a round.
+    public func getVotes(roundId: String) throws -> [VotingVoteRecord] {
+        let dbh = try requireHandle()
+        let roundIdBytes = [UInt8](roundId.utf8)
+
+        guard let ptr = roundIdBytes.withUnsafeBufferPointer({ buf in
+            zcashlc_voting_get_votes(dbh, buf.baseAddress, UInt(buf.count))
+        }) else {
+            throw VotingRustBackendError.rustError(lastErrorMessage(fallback: "`get_votes` failed"))
+        }
+
+        defer { zcashlc_voting_free_vote_records(ptr) }
+
+        let records = ptr.pointee
+        var result: [VotingVoteRecord] = []
+        for i in 0..<Int(records.len) {
+            let record = records.ptr.advanced(by: i).pointee
+            result.append(VotingVoteRecord(
+                proposalId: record.proposal_id,
+                bundleIndex: record.bundle_index,
+                choice: record.choice,
+                submitted: record.submitted
+            ))
+        }
+        return result
+    }
+
+    /// Clear all data for a voting round.
+    public func clearRound(roundId: String) throws {
+        let dbh = try requireHandle()
+        let roundIdBytes = [UInt8](roundId.utf8)
+
+        let result = roundIdBytes.withUnsafeBufferPointer { buf in
+            zcashlc_voting_clear_round(dbh, buf.baseAddress, UInt(buf.count))
+        }
+
+        guard result == 0 else {
+            throw VotingRustBackendError.rustError(lastErrorMessage(fallback: "`clear_round` failed"))
+        }
+    }
+
+    /// Delete skipped bundles (bundle_index >= keepCount).
+    /// Returns the number of deleted rows.
+    public func deleteSkippedBundles(roundId: String, keepCount: UInt32) throws -> Int64 {
+        let dbh = try requireHandle()
+        let roundIdBytes = [UInt8](roundId.utf8)
+
+        let result = roundIdBytes.withUnsafeBufferPointer { buf in
+            zcashlc_voting_delete_skipped_bundles(dbh, buf.baseAddress, UInt(buf.count), keepCount)
+        }
+
+        guard result >= 0 else {
+            throw VotingRustBackendError.rustError(lastErrorMessage(fallback: "`delete_skipped_bundles` failed"))
+        }
+        return result
+    }
+}
+
+// MARK: - Wallet notes
+
+extension VotingRustBackend {
+    /// Get wallet notes eligible for voting at the snapshot height.
+    public func getWalletNotes(
+        walletDbPath: String,
+        snapshotHeight: UInt64,
+        networkId: UInt32,
+        seedFingerprint: [UInt8]?,
+        accountIndex: Int64
+    ) throws -> [VotingNoteInfo] {
+        let dbh = try requireHandle()
+        let pathBytes = [UInt8](walletDbPath.utf8)
+
+        let ptr: UnsafeMutablePointer<FfiBoxedSlice>? = pathBytes.withUnsafeBufferPointer { pathBuf in
+            if let sfp = seedFingerprint {
+                return sfp.withUnsafeBufferPointer { sfpBuf in
+                    zcashlc_voting_get_wallet_notes(
+                        dbh,
+                        pathBuf.baseAddress,
+                        UInt(pathBuf.count),
+                        snapshotHeight,
+                        networkId,
+                        sfpBuf.baseAddress,
+                        UInt(sfpBuf.count),
+                        accountIndex
+                    )
+                }
+            } else {
+                return zcashlc_voting_get_wallet_notes(
+                    dbh,
+                    pathBuf.baseAddress,
+                    UInt(pathBuf.count),
+                    snapshotHeight,
+                    networkId,
+                    nil,
+                    0,
+                    accountIndex
+                )
+            }
+        }
+
+        guard let ptr else {
+            throw VotingRustBackendError.rustError(lastErrorMessage(fallback: "`get_wallet_notes` failed"))
+        }
+        defer { zcashlc_free_boxed_slice(ptr) }
+        return try decodeJSON(from: ptr)
+    }
+}
+
+// MARK: - Hotkey & delegation setup
+
+extension VotingRustBackend {
+    /// Generate a voting hotkey for a round.
+    public func generateHotkey(roundId: String, seed: [UInt8]) throws -> VotingHotkey {
+        let dbh = try requireHandle()
+        let roundIdBytes = [UInt8](roundId.utf8)
+
+        let ptr = roundIdBytes.withUnsafeBufferPointer { ridBuf in
+            seed.withUnsafeBufferPointer { seedBuf in
+                zcashlc_voting_generate_hotkey(
+                    dbh,
+                    ridBuf.baseAddress,
+                    UInt(ridBuf.count),
+                    seedBuf.baseAddress,
+                    UInt(seedBuf.count)
+                )
+            }
+        }
+
+        guard let ptr else {
+            throw VotingRustBackendError.rustError(lastErrorMessage(fallback: "`generate_hotkey` failed"))
+        }
+        defer { zcashlc_voting_free_hotkey(ptr) }
+        return hotkeyFromFfi(ptr.pointee)
+    }
+
+    /// Set up note bundles for a voting round.
+    public func setupBundles(roundId: String, notes: [VotingNoteInfo]) throws -> VotingBundleSetupResult {
+        let dbh = try requireHandle()
+        let roundIdBytes = [UInt8](roundId.utf8)
+        let notesJson = try JSONEncoder().encode(notes)
+
+        let ptr = roundIdBytes.withUnsafeBufferPointer { ridBuf in
+            notesJson.withUnsafeBytes { notesBuf in
+                zcashlc_voting_setup_bundles(
+                    dbh,
+                    ridBuf.baseAddress,
+                    UInt(ridBuf.count),
+                    notesBuf.baseAddress?.assumingMemoryBound(to: UInt8.self),
+                    UInt(notesBuf.count)
+                )
+            }
+        }
+
+        guard let ptr else {
+            throw VotingRustBackendError.rustError(lastErrorMessage(fallback: "`setup_bundles` failed"))
+        }
+        defer { zcashlc_voting_free_bundle_setup_result(ptr) }
+
+        return VotingBundleSetupResult(
+            bundleCount: ptr.pointee.bundle_count,
+            eligibleWeight: ptr.pointee.eligible_weight
+        )
+    }
+
+    /// Get the number of bundles for a round.
+    public func getBundleCount(roundId: String) throws -> UInt32 {
+        let dbh = try requireHandle()
+        let roundIdBytes = [UInt8](roundId.utf8)
+
+        let result = roundIdBytes.withUnsafeBufferPointer { buf in
+            zcashlc_voting_get_bundle_count(dbh, buf.baseAddress, UInt(buf.count))
+        }
+
+        guard result >= 0 else {
+            throw VotingRustBackendError.rustError(lastErrorMessage(fallback: "`get_bundle_count` failed"))
+        }
+        return UInt32(result)
+    }
+
+    /// Build a governance PCZT for a bundle.
+    // swiftlint:disable:next function_parameter_count
+    public func buildGovernancePczt(
+        roundId: String,
+        bundleIndex: UInt32,
+        notes: [VotingNoteInfo],
+        fvkBytes: [UInt8],
+        hotkeyRawAddress: [UInt8],
+        consensusBranchId: UInt32,
+        coinType: UInt32,
+        seedFingerprint: [UInt8],
+        accountIndex: UInt32,
+        roundName: String,
+        addressIndex: UInt32
+    ) throws -> VotingGovernancePczt {
+        let dbh = try requireHandle()
+        let roundIdBytes = [UInt8](roundId.utf8)
+        let notesJson = try JSONEncoder().encode(notes)
+        let roundNameBytes = [UInt8](roundName.utf8)
+
+        let ptr: UnsafeMutablePointer<FfiBoxedSlice>? = roundIdBytes.withUnsafeBufferPointer { ridBuf in
+            notesJson.withUnsafeBytes { notesBuf in
+                fvkBytes.withUnsafeBufferPointer { fvkBuf in
+                    hotkeyRawAddress.withUnsafeBufferPointer { hkBuf in
+                        seedFingerprint.withUnsafeBufferPointer { sfBuf in
+                            roundNameBytes.withUnsafeBufferPointer { rnBuf in
+                                zcashlc_voting_build_governance_pczt(
+                                    dbh,
+                                    ridBuf.baseAddress,
+                                    UInt(ridBuf.count),
+                                    bundleIndex,
+                                    notesBuf.baseAddress?.assumingMemoryBound(to: UInt8.self),
+                                    UInt(notesBuf.count),
+                                    fvkBuf.baseAddress,
+                                    UInt(fvkBuf.count),
+                                    hkBuf.baseAddress,
+                                    UInt(hkBuf.count),
+                                    consensusBranchId,
+                                    coinType,
+                                    sfBuf.baseAddress,
+                                    UInt(sfBuf.count),
+                                    accountIndex,
+                                    rnBuf.baseAddress,
+                                    UInt(rnBuf.count),
+                                    addressIndex
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        guard let ptr else {
+            throw VotingRustBackendError.rustError(lastErrorMessage(fallback: "`build_governance_pczt` failed"))
+        }
+        defer { zcashlc_free_boxed_slice(ptr) }
+        return try decodeJSON(from: ptr)
+    }
+
+    /// Store a tree state for witness generation.
+    public func storeTreeState(roundId: String, treeStateBytes: [UInt8]) throws {
+        let dbh = try requireHandle()
+        let roundIdBytes = [UInt8](roundId.utf8)
+
+        let result = roundIdBytes.withUnsafeBufferPointer { ridBuf in
+            treeStateBytes.withUnsafeBufferPointer { tsBuf in
+                zcashlc_voting_store_tree_state(
+                    dbh,
+                    ridBuf.baseAddress,
+                    UInt(ridBuf.count),
+                    tsBuf.baseAddress,
+                    UInt(tsBuf.count)
+                )
+            }
+        }
+
+        guard result == 0 else {
+            throw VotingRustBackendError.rustError(lastErrorMessage(fallback: "`store_tree_state` failed"))
+        }
+    }
+
+    /// Generate Merkle inclusion witnesses for notes in a bundle.
+    public func generateNoteWitnesses(
+        roundId: String,
+        bundleIndex: UInt32,
+        walletDbPath: String,
+        notes: [VotingNoteInfo]
+    ) throws -> [VotingWitnessData] {
+        let dbh = try requireHandle()
+        let roundIdBytes = [UInt8](roundId.utf8)
+        let pathBytes = [UInt8](walletDbPath.utf8)
+        let notesJson = try JSONEncoder().encode(notes)
+
+        let ptr: UnsafeMutablePointer<FfiBoxedSlice>? = roundIdBytes.withUnsafeBufferPointer { ridBuf in
+            pathBytes.withUnsafeBufferPointer { pathBuf in
+                notesJson.withUnsafeBytes { notesBuf in
+                    zcashlc_voting_generate_note_witnesses(
+                        dbh,
+                        ridBuf.baseAddress,
+                        UInt(ridBuf.count),
+                        bundleIndex,
+                        pathBuf.baseAddress,
+                        UInt(pathBuf.count),
+                        notesBuf.baseAddress?.assumingMemoryBound(to: UInt8.self),
+                        UInt(notesBuf.count)
+                    )
+                }
+            }
+        }
+
+        guard let ptr else {
+            throw VotingRustBackendError.rustError(lastErrorMessage(fallback: "`generate_note_witnesses` failed"))
+        }
+        defer { zcashlc_free_boxed_slice(ptr) }
+        return try decodeJSON(from: ptr)
+    }
+}
+
+// MARK: - Delegation proof
+
+extension VotingRustBackend {
+    /// Build and prove the delegation ZKP. Long-running; reports progress via callback.
+    // swiftlint:disable:next function_parameter_count
+    public func buildAndProveDelegation(
+        roundId: String,
+        bundleIndex: UInt32,
+        walletDbPath: String,
+        hotkeyRawAddress: [UInt8],
+        pirServerUrl: String,
+        networkId: UInt32,
+        progress: VotingProgressHandler?
+    ) throws -> VotingDelegationProofResult {
+        let dbh = try requireHandle()
+        let roundIdBytes = [UInt8](roundId.utf8)
+        let pathBytes = [UInt8](walletDbPath.utf8)
+        let urlBytes = [UInt8](pirServerUrl.utf8)
+
+        var context = ProgressContext(handler: progress)
+
+        let ptr: UnsafeMutablePointer<FfiBoxedSlice>? = roundIdBytes.withUnsafeBufferPointer { ridBuf in
+            pathBytes.withUnsafeBufferPointer { pathBuf in
+                hotkeyRawAddress.withUnsafeBufferPointer { hkBuf in
+                    urlBytes.withUnsafeBufferPointer { urlBuf in
+                        withUnsafeMutablePointer(to: &context) { ctxPtr in
+                            let callback: (@convention(c) (Double, UnsafeMutableRawPointer?) -> Void)? =
+                                progress != nil ? votingProgressTrampoline : nil
+                            return zcashlc_voting_build_and_prove_delegation(
+                                dbh,
+                                ridBuf.baseAddress,
+                                UInt(ridBuf.count),
+                                bundleIndex,
+                                pathBuf.baseAddress,
+                                UInt(pathBuf.count),
+                                hkBuf.baseAddress,
+                                UInt(hkBuf.count),
+                                urlBuf.baseAddress,
+                                UInt(urlBuf.count),
+                                networkId,
+                                callback,
+                                UnsafeMutableRawPointer(ctxPtr)
+                            )
+                        }
+                    }
+                }
+            }
+        }
+
+        guard let ptr else {
+            throw VotingRustBackendError.rustError(lastErrorMessage(fallback: "`build_and_prove_delegation` failed"))
+        }
+        defer { zcashlc_free_boxed_slice(ptr) }
+        return try decodeJSON(from: ptr)
+    }
+
+    /// Get delegation submission using a seed-derived signing key.
+    public func getDelegationSubmission(
+        roundId: String,
+        bundleIndex: UInt32,
+        senderSeed: [UInt8],
+        networkId: UInt32,
+        accountIndex: UInt32
+    ) throws -> VotingDelegationSubmission {
+        let dbh = try requireHandle()
+        let roundIdBytes = [UInt8](roundId.utf8)
+
+        let ptr: UnsafeMutablePointer<FfiBoxedSlice>? = roundIdBytes.withUnsafeBufferPointer { ridBuf in
+            senderSeed.withUnsafeBufferPointer { seedBuf in
+                zcashlc_voting_get_delegation_submission(
+                    dbh,
+                    ridBuf.baseAddress,
+                    UInt(ridBuf.count),
+                    bundleIndex,
+                    seedBuf.baseAddress,
+                    UInt(seedBuf.count),
+                    networkId,
+                    accountIndex
+                )
+            }
+        }
+
+        guard let ptr else {
+            throw VotingRustBackendError.rustError(lastErrorMessage(fallback: "`get_delegation_submission` failed"))
+        }
+        defer { zcashlc_free_boxed_slice(ptr) }
+        return try decodeJSON(from: ptr)
+    }
+
+    /// Get delegation submission using a Keystone-provided signature.
+    public func getDelegationSubmissionWithKeystoneSig(
+        roundId: String,
+        bundleIndex: UInt32,
+        sig: [UInt8],
+        sighash: [UInt8]
+    ) throws -> VotingDelegationSubmission {
+        let dbh = try requireHandle()
+        let roundIdBytes = [UInt8](roundId.utf8)
+
+        let ptr: UnsafeMutablePointer<FfiBoxedSlice>? = roundIdBytes.withUnsafeBufferPointer { ridBuf in
+            sig.withUnsafeBufferPointer { sigBuf in
+                sighash.withUnsafeBufferPointer { shBuf in
+                    zcashlc_voting_get_delegation_submission_with_keystone_sig(
+                        dbh,
+                        ridBuf.baseAddress,
+                        UInt(ridBuf.count),
+                        bundleIndex,
+                        sigBuf.baseAddress,
+                        UInt(sigBuf.count),
+                        shBuf.baseAddress,
+                        UInt(shBuf.count)
+                    )
+                }
+            }
+        }
+
+        guard let ptr else {
+            throw VotingRustBackendError.rustError(
+                lastErrorMessage(fallback: "`get_delegation_submission_with_keystone_sig` failed")
+            )
+        }
+        defer { zcashlc_free_boxed_slice(ptr) }
+        return try decodeJSON(from: ptr)
+    }
+
+    /// Store the VAN leaf position after delegation TX is confirmed.
+    public func storeVanPosition(roundId: String, bundleIndex: UInt32, position: UInt32) throws {
+        let dbh = try requireHandle()
+        let roundIdBytes = [UInt8](roundId.utf8)
+
+        let result = roundIdBytes.withUnsafeBufferPointer { buf in
+            zcashlc_voting_store_van_position(dbh, buf.baseAddress, UInt(buf.count), bundleIndex, position)
+        }
+
+        guard result == 0 else {
+            throw VotingRustBackendError.rustError(lastErrorMessage(fallback: "`store_van_position` failed"))
+        }
+    }
+}
+
+// MARK: - Vote & commitment
+
+extension VotingRustBackend {
+    /// Encrypt voting shares for a round.
+    public func encryptShares(roundId: String, shares: [UInt64]) throws -> [VotingEncryptedShare] {
+        let dbh = try requireHandle()
+        let roundIdBytes = [UInt8](roundId.utf8)
+        let sharesJson = try JSONEncoder().encode(shares)
+
+        let ptr: UnsafeMutablePointer<FfiBoxedSlice>? = roundIdBytes.withUnsafeBufferPointer { ridBuf in
+            sharesJson.withUnsafeBytes { sjBuf in
+                zcashlc_voting_encrypt_shares(
+                    dbh,
+                    ridBuf.baseAddress,
+                    UInt(ridBuf.count),
+                    sjBuf.baseAddress?.assumingMemoryBound(to: UInt8.self),
+                    UInt(sjBuf.count)
+                )
+            }
+        }
+
+        guard let ptr else {
+            throw VotingRustBackendError.rustError(lastErrorMessage(fallback: "`encrypt_shares` failed"))
+        }
+        defer { zcashlc_free_boxed_slice(ptr) }
+        return try decodeJSON(from: ptr)
+    }
+
+    /// Build a vote commitment (ZKP #2) for a proposal.
+    // swiftlint:disable:next function_parameter_count
+    public func buildVoteCommitment(
+        roundId: String,
+        bundleIndex: UInt32,
+        hotkeySeed: [UInt8],
+        networkId: UInt32,
+        proposalId: UInt32,
+        choice: UInt32,
+        numOptions: UInt32,
+        vanAuthPath: [[UInt8]],
+        vanPosition: UInt32,
+        anchorHeight: UInt32,
+        progress: VotingProgressHandler?
+    ) throws -> VotingVoteCommitmentBundle {
+        let dbh = try requireHandle()
+        let roundIdBytes = [UInt8](roundId.utf8)
+        let authPathJson = try JSONEncoder().encode(vanAuthPath)
+
+        var context = ProgressContext(handler: progress)
+
+        let ptr: UnsafeMutablePointer<FfiBoxedSlice>? = roundIdBytes.withUnsafeBufferPointer { ridBuf in
+            hotkeySeed.withUnsafeBufferPointer { seedBuf in
+                authPathJson.withUnsafeBytes { apBuf in
+                    withUnsafeMutablePointer(to: &context) { ctxPtr in
+                        let callback: (@convention(c) (Double, UnsafeMutableRawPointer?) -> Void)? =
+                            progress != nil ? votingProgressTrampoline : nil
+                        return zcashlc_voting_build_vote_commitment(
+                            dbh,
+                            ridBuf.baseAddress,
+                            UInt(ridBuf.count),
+                            bundleIndex,
+                            seedBuf.baseAddress,
+                            UInt(seedBuf.count),
+                            networkId,
+                            proposalId,
+                            choice,
+                            numOptions,
+                            apBuf.baseAddress?.assumingMemoryBound(to: UInt8.self),
+                            UInt(apBuf.count),
+                            vanPosition,
+                            anchorHeight,
+                            callback,
+                            UnsafeMutableRawPointer(ctxPtr)
+                        )
+                    }
+                }
+            }
+        }
+
+        guard let ptr else {
+            throw VotingRustBackendError.rustError(lastErrorMessage(fallback: "`build_vote_commitment` failed"))
+        }
+        defer { zcashlc_free_boxed_slice(ptr) }
+        return try decodeJSON(from: ptr)
+    }
+
+    /// Build share payloads for delegated share submission.
+    public func buildSharePayloads(
+        encShares: [VotingEncryptedShare],
+        commitment: VotingVoteCommitmentBundle,
+        voteDecision: UInt32,
+        numOptions: UInt32,
+        vcTreePosition: UInt64
+    ) throws -> [VotingSharePayload] {
+        let dbh = try requireHandle()
+        let sharesJson = try JSONEncoder().encode(encShares)
+        let commitmentJson = try JSONEncoder().encode(commitment)
+
+        let ptr: UnsafeMutablePointer<FfiBoxedSlice>? = sharesJson.withUnsafeBytes { sjBuf in
+            commitmentJson.withUnsafeBytes { cjBuf in
+                zcashlc_voting_build_share_payloads(
+                    dbh,
+                    sjBuf.baseAddress?.assumingMemoryBound(to: UInt8.self),
+                    UInt(sjBuf.count),
+                    cjBuf.baseAddress?.assumingMemoryBound(to: UInt8.self),
+                    UInt(cjBuf.count),
+                    voteDecision,
+                    numOptions,
+                    vcTreePosition
+                )
+            }
+        }
+
+        guard let ptr else {
+            throw VotingRustBackendError.rustError(lastErrorMessage(fallback: "`build_share_payloads` failed"))
+        }
+        defer { zcashlc_free_boxed_slice(ptr) }
+        return try decodeJSON(from: ptr)
+    }
+
+    /// Mark a vote as submitted.
+    public func markVoteSubmitted(roundId: String, bundleIndex: UInt32, proposalId: UInt32) throws {
+        let dbh = try requireHandle()
+        let roundIdBytes = [UInt8](roundId.utf8)
+
+        let result = roundIdBytes.withUnsafeBufferPointer { buf in
+            zcashlc_voting_mark_vote_submitted(dbh, buf.baseAddress, UInt(buf.count), bundleIndex, proposalId)
+        }
+
+        guard result == 0 else {
+            throw VotingRustBackendError.rustError(lastErrorMessage(fallback: "`mark_vote_submitted` failed"))
+        }
+    }
+}
+
+// MARK: - Tree sync
+
+extension VotingRustBackend {
+    /// Sync the vote commitment tree from a chain node.
+    /// Returns the latest synced block height.
+    public func syncVoteTree(roundId: String, nodeUrl: String) throws -> UInt32 {
+        let dbh = try requireHandle()
+        let roundIdBytes = [UInt8](roundId.utf8)
+        let urlBytes = [UInt8](nodeUrl.utf8)
+
+        let result = roundIdBytes.withUnsafeBufferPointer { ridBuf in
+            urlBytes.withUnsafeBufferPointer { urlBuf in
+                zcashlc_voting_sync_vote_tree(
+                    dbh,
+                    ridBuf.baseAddress,
+                    UInt(ridBuf.count),
+                    urlBuf.baseAddress,
+                    UInt(urlBuf.count)
+                )
+            }
+        }
+
+        guard result >= 0 else {
+            throw VotingRustBackendError.rustError(lastErrorMessage(fallback: "`sync_vote_tree` failed"))
+        }
+        return UInt32(result)
+    }
+
+    /// Generate a VAN Merkle witness for ZKP #2.
+    public func generateVanWitness(
+        roundId: String,
+        bundleIndex: UInt32,
+        anchorHeight: UInt32
+    ) throws -> VotingVanWitness {
+        let dbh = try requireHandle()
+        let roundIdBytes = [UInt8](roundId.utf8)
+
+        let ptr: UnsafeMutablePointer<FfiBoxedSlice>? = roundIdBytes.withUnsafeBufferPointer { buf in
+            zcashlc_voting_generate_van_witness(dbh, buf.baseAddress, UInt(buf.count), bundleIndex, anchorHeight)
+        }
+
+        guard let ptr else {
+            throw VotingRustBackendError.rustError(lastErrorMessage(fallback: "`generate_van_witness` failed"))
+        }
+        defer { zcashlc_free_boxed_slice(ptr) }
+        return try decodeJSON(from: ptr)
+    }
+
+    /// Reset the in-memory TreeClient.
+    public func resetTreeClient() throws {
+        let dbh = try requireHandle()
+
+        let result = zcashlc_voting_reset_tree_client(dbh)
+        guard result == 0 else {
+            throw VotingRustBackendError.rustError(lastErrorMessage(fallback: "`reset_tree_client` failed"))
+        }
+    }
+}
+
+// MARK: - Static / free functions (no database needed)
+
+extension VotingRustBackend {
+    /// Generate a standalone voting hotkey (no database).
+    public static func generateHotkeyStandalone(seed: [UInt8]) throws -> VotingHotkey {
+        let ptr = seed.withUnsafeBufferPointer { buf in
+            zcashlc_voting_generate_hotkey_standalone(buf.baseAddress, UInt(buf.count))
+        }
+
+        guard let ptr else {
+            throw VotingRustBackendError.rustError(staticLastErrorMessage(fallback: "`generate_hotkey_standalone` failed"))
+        }
+        defer { zcashlc_voting_free_hotkey(ptr) }
+        return hotkeyFromFfi(ptr.pointee)
+    }
+
+    /// Decompose a weight into power-of-two components.
+    public static func decomposeWeight(_ weight: UInt64) throws -> [UInt64] {
+        guard let ptr = zcashlc_voting_decompose_weight(weight) else {
+            throw VotingRustBackendError.rustError(staticLastErrorMessage(fallback: "`decompose_weight` failed"))
+        }
+        defer { zcashlc_free_boxed_slice(ptr) }
+        return try decodeJSONStatic(from: ptr)
+    }
+
+    /// Generate delegation inputs from sender seed and hotkey seed.
+    public static func generateDelegationInputs(
+        senderSeed: [UInt8],
+        hotkeySeed: [UInt8],
+        networkId: UInt32,
+        accountIndex: UInt32
+    ) throws -> VotingDelegationInputs {
+        let ptr = senderSeed.withUnsafeBufferPointer { sBuf in
+            hotkeySeed.withUnsafeBufferPointer { hBuf in
+                zcashlc_voting_generate_delegation_inputs(
+                    sBuf.baseAddress,
+                    UInt(sBuf.count),
+                    hBuf.baseAddress,
+                    UInt(hBuf.count),
+                    networkId,
+                    accountIndex
+                )
+            }
+        }
+
+        guard let ptr else {
+            throw VotingRustBackendError.rustError(staticLastErrorMessage(fallback: "`generate_delegation_inputs` failed"))
+        }
+        defer { zcashlc_free_boxed_slice(ptr) }
+        return try decodeJSONStatic(from: ptr)
+    }
+
+    /// Generate delegation inputs using an explicit FVK.
+    public static func generateDelegationInputsWithFvk(
+        fvkBytes: [UInt8],
+        hotkeySeed: [UInt8],
+        networkId: UInt32,
+        accountIndex: UInt32,
+        seedFingerprint: [UInt8]
+    ) throws -> VotingDelegationInputs {
+        let ptr = fvkBytes.withUnsafeBufferPointer { fvkBuf in
+            hotkeySeed.withUnsafeBufferPointer { hBuf in
+                seedFingerprint.withUnsafeBufferPointer { sfBuf in
+                    zcashlc_voting_generate_delegation_inputs_with_fvk(
+                        fvkBuf.baseAddress,
+                        UInt(fvkBuf.count),
+                        hBuf.baseAddress,
+                        UInt(hBuf.count),
+                        networkId,
+                        accountIndex,
+                        sfBuf.baseAddress,
+                        UInt(sfBuf.count)
+                    )
+                }
+            }
+        }
+
+        guard let ptr else {
+            throw VotingRustBackendError.rustError(
+                staticLastErrorMessage(fallback: "`generate_delegation_inputs_with_fvk` failed")
+            )
+        }
+        defer { zcashlc_free_boxed_slice(ptr) }
+        return try decodeJSONStatic(from: ptr)
+    }
+
+    /// Extract the sighash from PCZT bytes.
+    public static func extractPcztSighash(pcztBytes: [UInt8]) throws -> [UInt8] {
+        let ptr = pcztBytes.withUnsafeBufferPointer { buf in
+            zcashlc_voting_extract_pczt_sighash(buf.baseAddress, UInt(buf.count))
+        }
+
+        guard let ptr else {
+            throw VotingRustBackendError.rustError(staticLastErrorMessage(fallback: "`extract_pczt_sighash` failed"))
+        }
+        defer { zcashlc_free_boxed_slice(ptr) }
+        return bytesFromBoxedSlice(ptr)
+    }
+
+    /// Extract a spend auth signature from a signed PCZT.
+    public static func extractSpendAuthSig(signedPcztBytes: [UInt8], actionIndex: UInt32) throws -> [UInt8] {
+        let ptr = signedPcztBytes.withUnsafeBufferPointer { buf in
+            zcashlc_voting_extract_spend_auth_sig(buf.baseAddress, UInt(buf.count), actionIndex)
+        }
+
+        guard let ptr else {
+            throw VotingRustBackendError.rustError(staticLastErrorMessage(fallback: "`extract_spend_auth_sig` failed"))
+        }
+        defer { zcashlc_free_boxed_slice(ptr) }
+        return bytesFromBoxedSlice(ptr)
+    }
+
+    /// Extract the Orchard FVK from a UFVK string.
+    public static func extractOrchardFvkFromUfvk(ufvkStr: String, networkId: UInt32) throws -> [UInt8] {
+        let ufvkBytes = [UInt8](ufvkStr.utf8)
+
+        let ptr = ufvkBytes.withUnsafeBufferPointer { buf in
+            zcashlc_voting_extract_orchard_fvk_from_ufvk(buf.baseAddress, UInt(buf.count), networkId)
+        }
+
+        guard let ptr else {
+            throw VotingRustBackendError.rustError(
+                staticLastErrorMessage(fallback: "`extract_orchard_fvk_from_ufvk` failed")
+            )
+        }
+        defer { zcashlc_free_boxed_slice(ptr) }
+        return bytesFromBoxedSlice(ptr)
+    }
+
+    /// Extract the nc_root from a protobuf-encoded TreeState.
+    public static func extractNcRoot(treeStateBytes: [UInt8]) throws -> [UInt8] {
+        let ptr = treeStateBytes.withUnsafeBufferPointer { buf in
+            zcashlc_voting_extract_nc_root(buf.baseAddress, UInt(buf.count))
+        }
+
+        guard let ptr else {
+            throw VotingRustBackendError.rustError(staticLastErrorMessage(fallback: "`extract_nc_root` failed"))
+        }
+        defer { zcashlc_free_boxed_slice(ptr) }
+        return bytesFromBoxedSlice(ptr)
+    }
+
+    /// Sign a cast-vote transaction.
+    // swiftlint:disable:next function_parameter_count
+    public static func signCastVote(
+        hotkeySeed: [UInt8],
+        networkId: UInt32,
+        voteRoundIdHex: String,
+        rVpkBytes: [UInt8],
+        vanNullifier: [UInt8],
+        voteAuthorityNoteNew: [UInt8],
+        voteCommitment: [UInt8],
+        proposalId: UInt32,
+        anchorHeight: UInt32,
+        alphaV: [UInt8]
+    ) throws -> VotingCastVoteSignature {
+        let roundIdBytes = [UInt8](voteRoundIdHex.utf8)
+
+        let ptr: UnsafeMutablePointer<FfiBoxedSlice>? = hotkeySeed.withUnsafeBufferPointer { seedBuf in
+            roundIdBytes.withUnsafeBufferPointer { ridBuf in
+                rVpkBytes.withUnsafeBufferPointer { rvBuf in
+                    vanNullifier.withUnsafeBufferPointer { vnBuf in
+                        voteAuthorityNoteNew.withUnsafeBufferPointer { vanBuf in
+                            voteCommitment.withUnsafeBufferPointer { vcBuf in
+                                alphaV.withUnsafeBufferPointer { avBuf in
+                                    zcashlc_voting_sign_cast_vote(
+                                        seedBuf.baseAddress,
+                                        UInt(seedBuf.count),
+                                        networkId,
+                                        ridBuf.baseAddress,
+                                        UInt(ridBuf.count),
+                                        rvBuf.baseAddress,
+                                        UInt(rvBuf.count),
+                                        vnBuf.baseAddress,
+                                        UInt(vnBuf.count),
+                                        vanBuf.baseAddress,
+                                        UInt(vanBuf.count),
+                                        vcBuf.baseAddress,
+                                        UInt(vcBuf.count),
+                                        proposalId,
+                                        anchorHeight,
+                                        avBuf.baseAddress,
+                                        UInt(avBuf.count)
+                                    )
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        guard let ptr else {
+            throw VotingRustBackendError.rustError(staticLastErrorMessage(fallback: "`sign_cast_vote` failed"))
+        }
+        defer { zcashlc_free_boxed_slice(ptr) }
+        return try decodeJSONStatic(from: ptr)
+    }
+
+    /// Verify a Merkle witness.
+    public static func verifyWitness(_ witness: VotingWitnessData) throws -> Bool {
+        let witnessJson = try JSONEncoder().encode(witness)
+
+        let result = witnessJson.withUnsafeBytes { buf in
+            zcashlc_voting_verify_witness(
+                buf.baseAddress?.assumingMemoryBound(to: UInt8.self),
+                UInt(buf.count)
+            )
+        }
+
+        guard result >= 0 else {
+            throw VotingRustBackendError.rustError(staticLastErrorMessage(fallback: "`verify_witness` failed"))
+        }
+        return result == 1
+    }
+
+    /// Get the voting FFI version string.
+    public static func version() -> String? {
+        guard let cStr = zcashlc_voting_version() else { return nil }
+        defer { zcashlc_string_free(cStr) }
+        return String(validatingUTF8: cStr)
+    }
+}
+
+// MARK: - Private helpers
+
+private extension VotingRustBackend {
+    func requireHandle() throws -> OpaquePointer {
+        lock.lock()
+        defer { lock.unlock() }
+        guard let dbh = handle else {
+            throw VotingRustBackendError.databaseNotOpen
+        }
+        return dbh
+    }
+
+    func lastErrorMessage(fallback: String) -> String {
+        Self.staticLastErrorMessage(fallback: fallback)
+    }
+
+    func decodeJSON<T: Decodable>(from ptr: UnsafeMutablePointer<FfiBoxedSlice>) throws -> T {
+        let data = Data(bytes: ptr.pointee.ptr, count: Int(ptr.pointee.len))
+        return try JSONDecoder().decode(T.self, from: data)
+    }
+
+    static func staticLastErrorMessage(fallback: String) -> String {
+        let errorLen = zcashlc_last_error_length()
+        defer { zcashlc_clear_last_error() }
+
+        if errorLen > 0 {
+            let error = UnsafeMutablePointer<Int8>.allocate(capacity: Int(errorLen))
+            defer { error.deallocate() }
+            zcashlc_error_message_utf8(error, errorLen)
+            if let msg = String(validatingUTF8: error) {
+                return msg
+            }
+        }
+        return fallback
+    }
+
+    static func decodeJSONStatic<T: Decodable>(from ptr: UnsafeMutablePointer<FfiBoxedSlice>) throws -> T {
+        let data = Data(bytes: ptr.pointee.ptr, count: Int(ptr.pointee.len))
+        return try JSONDecoder().decode(T.self, from: data)
+    }
+
+    static func bytesFromBoxedSlice(_ ptr: UnsafeMutablePointer<FfiBoxedSlice>) -> [UInt8] {
+        let len = Int(ptr.pointee.len)
+        var bytes = [UInt8](repeating: 0, count: len)
+        for i in 0..<len {
+            bytes[i] = ptr.pointee.ptr.advanced(by: i).pointee
+        }
+        return bytes
+    }
+}
+
+/// Convert FfiVotingHotkey to VotingHotkey.
+private func hotkeyFromFfi(_ ffi: FfiVotingHotkey) -> VotingHotkey {
+    var secretKey = [UInt8](repeating: 0, count: Int(ffi.secret_key_len))
+    for i in 0..<Int(ffi.secret_key_len) {
+        secretKey[i] = ffi.secret_key.advanced(by: i).pointee
+    }
+
+    var publicKey = [UInt8](repeating: 0, count: Int(ffi.public_key_len))
+    for i in 0..<Int(ffi.public_key_len) {
+        publicKey[i] = ffi.public_key.advanced(by: i).pointee
+    }
+
+    let address = ffi.address != nil ? String(cString: ffi.address) : ""
+
+    return VotingHotkey(secretKey: secretKey, publicKey: publicKey, address: address)
+}
+
+// MARK: - Progress callback trampoline
+
+private struct ProgressContext {
+    let handler: VotingProgressHandler?
+}
+
+private func votingProgressTrampoline(progress: Double, context: UnsafeMutableRawPointer?) {
+    guard let context else { return }
+    let ctx = context.assumingMemoryBound(to: ProgressContext.self).pointee
+    ctx.handler?(progress)
+}

--- a/Sources/ZcashLightClientKit/Rust/Voting/VotingRustBackend.swift
+++ b/Sources/ZcashLightClientKit/Rust/Voting/VotingRustBackend.swift
@@ -717,6 +717,7 @@ extension VotingRustBackend {
         vanAuthPath: [[UInt8]],
         vanPosition: UInt32,
         anchorHeight: UInt32,
+        singleShare: UInt8 = 0,
         progress: VotingProgressHandler?
     ) throws -> VotingVoteCommitmentBundle {
         let dbh = try requireHandle()
@@ -747,7 +748,8 @@ extension VotingRustBackend {
                             vanPosition,
                             anchorHeight,
                             callback,
-                            UnsafeMutableRawPointer(ctxPtr)
+                            UnsafeMutableRawPointer(ctxPtr),
+                            singleShare
                         )
                     }
                 }
@@ -767,7 +769,8 @@ extension VotingRustBackend {
         commitment: VotingVoteCommitmentBundle,
         voteDecision: UInt32,
         numOptions: UInt32,
-        vcTreePosition: UInt64
+        vcTreePosition: UInt64,
+        singleShare: UInt8 = 0
     ) throws -> [VotingSharePayload] {
         let dbh = try requireHandle()
         let sharesJson = try JSONEncoder().encode(encShares)
@@ -783,7 +786,8 @@ extension VotingRustBackend {
                     UInt(cjBuf.count),
                     voteDecision,
                     numOptions,
-                    vcTreePosition
+                    vcTreePosition,
+                    singleShare
                 )
             }
         }

--- a/Sources/ZcashLightClientKit/Rust/Voting/VotingRustBackend.swift
+++ b/Sources/ZcashLightClientKit/Rust/Voting/VotingRustBackend.swift
@@ -999,11 +999,13 @@ extension VotingRustBackend {
         return try decodeJSON(from: ptr)
     }
 
-    /// Reset the in-memory TreeClient.
-    public func resetTreeClient() throws {
+    /// Reset the in-memory TreeClient for a round (empty string resets all).
+    public func resetTreeClient(roundId: String = "") throws {
         let dbh = try requireHandle()
 
-        let result = zcashlc_voting_reset_tree_client(dbh)
+        let result = roundId.utf8CString.withUnsafeBufferPointer { buf in
+            zcashlc_voting_reset_tree_client(dbh, buf.baseAddress, UInt(buf.count - 1))
+        }
         guard result == 0 else {
             throw VotingRustBackendError.rustError(lastErrorMessage(fallback: "`reset_tree_client` failed"))
         }

--- a/Sources/ZcashLightClientKit/Rust/Voting/VotingRustBackend.swift
+++ b/Sources/ZcashLightClientKit/Rust/Voting/VotingRustBackend.swift
@@ -8,11 +8,24 @@ import libzcashlc
 
 // MARK: - Error
 
-public enum VotingRustBackendError: Error, Equatable {
+public enum VotingRustBackendError: LocalizedError, Equatable {
     case databaseAlreadyOpen
     case databaseNotOpen
     case rustError(String)
     case invalidData(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .databaseAlreadyOpen:
+            return "Voting database is already open. Please restart the app."
+        case .databaseNotOpen:
+            return "Voting database is not open. Please restart the app."
+        case .rustError(let message):
+            return "Voting backend error: \(message)"
+        case .invalidData(let message):
+            return "Invalid data: \(message)"
+        }
+    }
 }
 
 // MARK: - Progress callback

--- a/Sources/ZcashLightClientKit/Rust/Voting/VotingRustBackend.swift
+++ b/Sources/ZcashLightClientKit/Rust/Voting/VotingRustBackend.swift
@@ -1016,6 +1016,170 @@ extension VotingRustBackend {
     }
 }
 
+// MARK: - Share delegation tracking
+
+extension VotingRustBackend {
+    /// Compute the nullifier for a vote share.
+    ///
+    /// This is a static/pure function — no database handle needed.
+    /// `voteCommitment` and `primaryBlind` must each be exactly 32 bytes.
+    /// Returns a hex-encoded nullifier string.
+    public static func computeShareNullifier(
+        voteCommitment: [UInt8],
+        shareIndex: UInt32,
+        primaryBlind: [UInt8]
+    ) throws -> String {
+        let ptr = voteCommitment.withUnsafeBufferPointer { vcBuf in
+            primaryBlind.withUnsafeBufferPointer { blindBuf in
+                zcashlc_voting_compute_share_nullifier(
+                    vcBuf.baseAddress,
+                    blindBuf.baseAddress,
+                    shareIndex
+                )
+            }
+        }
+
+        guard let ptr else {
+            throw VotingRustBackendError.rustError(
+                staticLastErrorMessage(fallback: "`compute_share_nullifier` failed")
+            )
+        }
+        defer { zcashlc_string_free(ptr) }
+        return String(cString: ptr)
+    }
+
+    /// Record a share delegation after sending to helper servers.
+    public func recordShareDelegation(
+        roundId: String,
+        bundleIndex: UInt32,
+        proposalId: UInt32,
+        shareIndex: UInt32,
+        sentToURLs: [String],
+        nullifier: [UInt8],
+        submitAt: UInt64
+    ) throws {
+        let dbh = try requireHandle()
+        let roundIdBytes = [UInt8](roundId.utf8)
+        let urlsJson = try JSONEncoder().encode(sentToURLs)
+        let urlsBytes = [UInt8](urlsJson)
+
+        let result = roundIdBytes.withUnsafeBufferPointer { ridBuf in
+            urlsBytes.withUnsafeBufferPointer { urlsBuf in
+                nullifier.withUnsafeBufferPointer { nfBuf in
+                    zcashlc_voting_record_share_delegation(
+                        dbh,
+                        ridBuf.baseAddress,
+                        UInt(ridBuf.count),
+                        bundleIndex,
+                        proposalId,
+                        shareIndex,
+                        urlsBuf.baseAddress,
+                        UInt(urlsBuf.count),
+                        nfBuf.baseAddress,
+                        UInt(nfBuf.count),
+                        submitAt
+                    )
+                }
+            }
+        }
+
+        guard result == 0 else {
+            throw VotingRustBackendError.rustError(lastErrorMessage(fallback: "`record_share_delegation` failed"))
+        }
+    }
+
+    /// Get all share delegations for a round.
+    public func getShareDelegations(roundId: String) throws -> [VotingShareDelegation] {
+        let dbh = try requireHandle()
+        let roundIdBytes = [UInt8](roundId.utf8)
+
+        let ptr: UnsafeMutablePointer<FfiBoxedSlice>? = roundIdBytes.withUnsafeBufferPointer { ridBuf in
+            zcashlc_voting_get_share_delegations(dbh, ridBuf.baseAddress, UInt(ridBuf.count))
+        }
+
+        guard let ptr else {
+            throw VotingRustBackendError.rustError(lastErrorMessage(fallback: "`get_share_delegations` failed"))
+        }
+        defer { zcashlc_free_boxed_slice(ptr) }
+        return try decodeJSON(from: ptr)
+    }
+
+    /// Get unconfirmed share delegations for a round.
+    public func getUnconfirmedDelegations(roundId: String) throws -> [VotingShareDelegation] {
+        let dbh = try requireHandle()
+        let roundIdBytes = [UInt8](roundId.utf8)
+
+        let ptr: UnsafeMutablePointer<FfiBoxedSlice>? = roundIdBytes.withUnsafeBufferPointer { ridBuf in
+            zcashlc_voting_get_unconfirmed_delegations(dbh, ridBuf.baseAddress, UInt(ridBuf.count))
+        }
+
+        guard let ptr else {
+            throw VotingRustBackendError.rustError(lastErrorMessage(fallback: "`get_unconfirmed_delegations` failed"))
+        }
+        defer { zcashlc_free_boxed_slice(ptr) }
+        return try decodeJSON(from: ptr)
+    }
+
+    /// Mark a share delegation as confirmed on-chain.
+    public func markShareConfirmed(
+        roundId: String,
+        bundleIndex: UInt32,
+        proposalId: UInt32,
+        shareIndex: UInt32
+    ) throws {
+        let dbh = try requireHandle()
+        let roundIdBytes = [UInt8](roundId.utf8)
+
+        let result = roundIdBytes.withUnsafeBufferPointer { ridBuf in
+            zcashlc_voting_mark_share_confirmed(
+                dbh,
+                ridBuf.baseAddress,
+                UInt(ridBuf.count),
+                bundleIndex,
+                proposalId,
+                shareIndex
+            )
+        }
+
+        guard result == 0 else {
+            throw VotingRustBackendError.rustError(lastErrorMessage(fallback: "`mark_share_confirmed` failed"))
+        }
+    }
+
+    /// Append new server URLs to a share delegation's sent_to_urls.
+    public func addSentServers(
+        roundId: String,
+        bundleIndex: UInt32,
+        proposalId: UInt32,
+        shareIndex: UInt32,
+        newURLs: [String]
+    ) throws {
+        let dbh = try requireHandle()
+        let roundIdBytes = [UInt8](roundId.utf8)
+        let urlsJson = try JSONEncoder().encode(newURLs)
+        let urlsBytes = [UInt8](urlsJson)
+
+        let result = roundIdBytes.withUnsafeBufferPointer { ridBuf in
+            urlsBytes.withUnsafeBufferPointer { urlsBuf in
+                zcashlc_voting_add_sent_servers(
+                    dbh,
+                    ridBuf.baseAddress,
+                    UInt(ridBuf.count),
+                    bundleIndex,
+                    proposalId,
+                    shareIndex,
+                    urlsBuf.baseAddress,
+                    UInt(urlsBuf.count)
+                )
+            }
+        }
+
+        guard result == 0 else {
+            throw VotingRustBackendError.rustError(lastErrorMessage(fallback: "`add_sent_servers` failed"))
+        }
+    }
+}
+
 // MARK: - Static / free functions (no database needed)
 
 extension VotingRustBackend {

--- a/Sources/ZcashLightClientKit/Rust/Voting/VotingRustBackend.swift
+++ b/Sources/ZcashLightClientKit/Rust/Voting/VotingRustBackend.swift
@@ -276,40 +276,27 @@ extension VotingRustBackend {
 
 extension VotingRustBackend {
     /// Get wallet notes eligible for voting at the snapshot height.
+    ///
+    /// `accountUUID` must be exactly 16 bytes identifying the wallet account.
     public func getWalletNotes(
         walletDbPath: String,
         snapshotHeight: UInt64,
         networkId: UInt32,
-        seedFingerprint: [UInt8]?,
-        accountIndex: Int64
+        accountUUID: [UInt8]
     ) throws -> [VotingNoteInfo] {
         let dbh = try requireHandle()
         let pathBytes = [UInt8](walletDbPath.utf8)
 
         let ptr: UnsafeMutablePointer<FfiBoxedSlice>? = pathBytes.withUnsafeBufferPointer { pathBuf in
-            if let sfp = seedFingerprint {
-                return sfp.withUnsafeBufferPointer { sfpBuf in
-                    zcashlc_voting_get_wallet_notes(
-                        dbh,
-                        pathBuf.baseAddress,
-                        UInt(pathBuf.count),
-                        snapshotHeight,
-                        networkId,
-                        sfpBuf.baseAddress,
-                        UInt(sfpBuf.count),
-                        accountIndex
-                    )
-                }
-            } else {
-                return zcashlc_voting_get_wallet_notes(
+            accountUUID.withUnsafeBufferPointer { uuidBuf in
+                zcashlc_voting_get_wallet_notes(
                     dbh,
                     pathBuf.baseAddress,
                     UInt(pathBuf.count),
                     snapshotHeight,
                     networkId,
-                    nil,
-                    0,
-                    accountIndex
+                    uuidBuf.baseAddress,
+                    UInt(uuidBuf.count)
                 )
             }
         }

--- a/Sources/ZcashLightClientKit/Rust/Voting/VotingRustBackend.swift
+++ b/Sources/ZcashLightClientKit/Rust/Voting/VotingRustBackend.swift
@@ -507,7 +507,7 @@ extension VotingRustBackend {
     public func buildAndProveDelegation(
         roundId: String,
         bundleIndex: UInt32,
-        walletDbPath: String,
+        notes: [VotingNoteInfo],
         hotkeyRawAddress: [UInt8],
         pirServerUrl: String,
         networkId: UInt32,
@@ -515,13 +515,14 @@ extension VotingRustBackend {
     ) throws -> VotingDelegationProofResult {
         let dbh = try requireHandle()
         let roundIdBytes = [UInt8](roundId.utf8)
-        let pathBytes = [UInt8](walletDbPath.utf8)
+        let notesJson = try JSONEncoder().encode(notes)
+        let notesBytes = [UInt8](notesJson)
         let urlBytes = [UInt8](pirServerUrl.utf8)
 
         var context = ProgressContext(handler: progress)
 
         let ptr: UnsafeMutablePointer<FfiBoxedSlice>? = roundIdBytes.withUnsafeBufferPointer { ridBuf in
-            pathBytes.withUnsafeBufferPointer { pathBuf in
+            notesBytes.withUnsafeBufferPointer { notesBuf in
                 hotkeyRawAddress.withUnsafeBufferPointer { hkBuf in
                     urlBytes.withUnsafeBufferPointer { urlBuf in
                         withUnsafeMutablePointer(to: &context) { ctxPtr in
@@ -532,8 +533,8 @@ extension VotingRustBackend {
                                 ridBuf.baseAddress,
                                 UInt(ridBuf.count),
                                 bundleIndex,
-                                pathBuf.baseAddress,
-                                UInt(pathBuf.count),
+                                notesBuf.baseAddress,
+                                UInt(notesBuf.count),
                                 hkBuf.baseAddress,
                                 UInt(hkBuf.count),
                                 urlBuf.baseAddress,

--- a/Sources/ZcashLightClientKit/Rust/Voting/VotingRustBackend.swift
+++ b/Sources/ZcashLightClientKit/Rust/Voting/VotingRustBackend.swift
@@ -82,6 +82,27 @@ public final class VotingRustBackend: @unchecked Sendable {
     }
 }
 
+// MARK: - Wallet identity
+
+extension VotingRustBackend {
+    /// Set the wallet identifier for all subsequent voting operations.
+    /// Must be called after `open(path:)` and before any round operations.
+    public func setWalletId(_ walletId: String) throws {
+        let dbh = try requireHandle()
+        let walletIdBytes = [UInt8](walletId.utf8)
+        let result = walletIdBytes.withUnsafeBufferPointer { buf in
+            zcashlc_voting_set_wallet_id(
+                dbh,
+                buf.baseAddress,
+                UInt(buf.count)
+            )
+        }
+        guard result == 0 else {
+            throw VotingRustBackendError.rustError(lastErrorMessage(fallback: "`set_wallet_id` failed"))
+        }
+    }
+}
+
 // MARK: - Round management
 
 extension VotingRustBackend {
@@ -277,7 +298,8 @@ extension VotingRustBackend {
 extension VotingRustBackend {
     /// Get wallet notes eligible for voting at the snapshot height.
     ///
-    /// `accountUUID` must be exactly 16 bytes identifying the wallet account.
+    /// `accountUUID` (16 bytes) directly identifies the wallet account.
+    /// Falls back to positional `accountIndex` when UUID is empty.
     public func getWalletNotes(
         walletDbPath: String,
         snapshotHeight: UInt64,
@@ -288,15 +310,29 @@ extension VotingRustBackend {
         let pathBytes = [UInt8](walletDbPath.utf8)
 
         let ptr: UnsafeMutablePointer<FfiBoxedSlice>? = pathBytes.withUnsafeBufferPointer { pathBuf in
-            accountUUID.withUnsafeBufferPointer { uuidBuf in
-                zcashlc_voting_get_wallet_notes(
+            if !accountUUID.isEmpty {
+                return accountUUID.withUnsafeBufferPointer { uuidBuf in
+                    zcashlc_voting_get_wallet_notes(
+                        dbh,
+                        pathBuf.baseAddress,
+                        UInt(pathBuf.count),
+                        snapshotHeight,
+                        networkId,
+                        uuidBuf.baseAddress,
+                        UInt(uuidBuf.count),
+                        -1
+                    )
+                }
+            } else {
+                return zcashlc_voting_get_wallet_notes(
                     dbh,
                     pathBuf.baseAddress,
                     UInt(pathBuf.count),
                     snapshotHeight,
                     networkId,
-                    uuidBuf.baseAddress,
-                    UInt(uuidBuf.count)
+                    nil,
+                    0,
+                    -1
                 )
             }
         }

--- a/Sources/ZcashLightClientKit/Rust/Voting/VotingRustBackend.swift
+++ b/Sources/ZcashLightClientKit/Rust/Voting/VotingRustBackend.swift
@@ -657,7 +657,7 @@ extension VotingRustBackend {
 
 extension VotingRustBackend {
     /// Encrypt voting shares for a round.
-    public func encryptShares(roundId: String, shares: [UInt64]) throws -> [VotingEncryptedShare] {
+    public func encryptShares(roundId: String, shares: [UInt64]) throws -> [VotingWireEncryptedShare] {
         let dbh = try requireHandle()
         let roundIdBytes = [UInt8](roundId.utf8)
         let sharesJson = try JSONEncoder().encode(shares)
@@ -740,7 +740,7 @@ extension VotingRustBackend {
 
     /// Build share payloads for delegated share submission.
     public func buildSharePayloads(
-        encShares: [VotingEncryptedShare],
+        encShares: [VotingWireEncryptedShare],
         commitment: VotingVoteCommitmentBundle,
         voteDecision: UInt32,
         numOptions: UInt32,

--- a/Sources/ZcashLightClientKit/Rust/Voting/VotingRustBackend.swift
+++ b/Sources/ZcashLightClientKit/Rust/Voting/VotingRustBackend.swift
@@ -810,6 +810,147 @@ extension VotingRustBackend {
     }
 }
 
+// MARK: - Recovery state (TX hashes, bundles, keystone sigs)
+
+extension VotingRustBackend {
+    public func storeDelegationTxHash(roundId: String, bundleIndex: UInt32, txHash: String) throws {
+        let dbh = try requireHandle()
+        let ridBytes = [UInt8](roundId.utf8)
+        let txBytes = [UInt8](txHash.utf8)
+        let result = ridBytes.withUnsafeBufferPointer { ridBuf in
+            txBytes.withUnsafeBufferPointer { txBuf in
+                zcashlc_voting_store_delegation_tx_hash(dbh, ridBuf.baseAddress, UInt(ridBuf.count), bundleIndex, txBuf.baseAddress, UInt(txBuf.count))
+            }
+        }
+        guard result == 0 else { throw VotingRustBackendError.rustError(lastErrorMessage(fallback: "`store_delegation_tx_hash` failed")) }
+    }
+
+    public func getDelegationTxHash(roundId: String, bundleIndex: UInt32) throws -> String? {
+        let dbh = try requireHandle()
+        let ridBytes = [UInt8](roundId.utf8)
+        let ptr: UnsafeMutablePointer<FfiBoxedSlice>? = ridBytes.withUnsafeBufferPointer { ridBuf in
+            zcashlc_voting_get_delegation_tx_hash(dbh, ridBuf.baseAddress, UInt(ridBuf.count), bundleIndex)
+        }
+        guard let ptr else { throw VotingRustBackendError.rustError(lastErrorMessage(fallback: "`get_delegation_tx_hash` failed")) }
+        defer { zcashlc_free_boxed_slice(ptr) }
+        return try decodeJSON(from: ptr)
+    }
+
+    public func storeVoteTxHash(roundId: String, bundleIndex: UInt32, proposalId: UInt32, txHash: String) throws {
+        let dbh = try requireHandle()
+        let ridBytes = [UInt8](roundId.utf8)
+        let txBytes = [UInt8](txHash.utf8)
+        let result = ridBytes.withUnsafeBufferPointer { ridBuf in
+            txBytes.withUnsafeBufferPointer { txBuf in
+                zcashlc_voting_store_vote_tx_hash(dbh, ridBuf.baseAddress, UInt(ridBuf.count), bundleIndex, proposalId, txBuf.baseAddress, UInt(txBuf.count))
+            }
+        }
+        guard result == 0 else { throw VotingRustBackendError.rustError(lastErrorMessage(fallback: "`store_vote_tx_hash` failed")) }
+    }
+
+    public func getVoteTxHash(roundId: String, bundleIndex: UInt32, proposalId: UInt32) throws -> String? {
+        let dbh = try requireHandle()
+        let ridBytes = [UInt8](roundId.utf8)
+        let ptr: UnsafeMutablePointer<FfiBoxedSlice>? = ridBytes.withUnsafeBufferPointer { ridBuf in
+            zcashlc_voting_get_vote_tx_hash(dbh, ridBuf.baseAddress, UInt(ridBuf.count), bundleIndex, proposalId)
+        }
+        guard let ptr else { throw VotingRustBackendError.rustError(lastErrorMessage(fallback: "`get_vote_tx_hash` failed")) }
+        defer { zcashlc_free_boxed_slice(ptr) }
+        return try decodeJSON(from: ptr)
+    }
+
+    public func storeCommitmentBundle(roundId: String, bundleIndex: UInt32, proposalId: UInt32, bundleJson: String, vcTreePosition: UInt64) throws {
+        let dbh = try requireHandle()
+        let ridBytes = [UInt8](roundId.utf8)
+        let jsonBytes = [UInt8](bundleJson.utf8)
+        let result = ridBytes.withUnsafeBufferPointer { ridBuf in
+            jsonBytes.withUnsafeBufferPointer { jsonBuf in
+                zcashlc_voting_store_commitment_bundle(dbh, ridBuf.baseAddress, UInt(ridBuf.count), bundleIndex, proposalId, jsonBuf.baseAddress, UInt(jsonBuf.count), vcTreePosition)
+            }
+        }
+        guard result == 0 else { throw VotingRustBackendError.rustError(lastErrorMessage(fallback: "`store_commitment_bundle` failed")) }
+    }
+
+    public struct CommitmentBundleResult {
+        public let json: String
+        public let vcTreePosition: UInt64
+    }
+
+    public func getCommitmentBundle(roundId: String, bundleIndex: UInt32, proposalId: UInt32) throws -> CommitmentBundleResult? {
+        let dbh = try requireHandle()
+        let ridBytes = [UInt8](roundId.utf8)
+        let ptr: UnsafeMutablePointer<FfiBoxedSlice>? = ridBytes.withUnsafeBufferPointer { ridBuf in
+            zcashlc_voting_get_commitment_bundle(dbh, ridBuf.baseAddress, UInt(ridBuf.count), bundleIndex, proposalId)
+        }
+        guard let ptr else { throw VotingRustBackendError.rustError(lastErrorMessage(fallback: "`get_commitment_bundle` failed")) }
+        defer { zcashlc_free_boxed_slice(ptr) }
+        // Rust serializes Option<(String, u64)> as a JSON array [string, number] or null.
+        let decoded: CommitmentBundleWire? = try decodeJSON(from: ptr)
+        return decoded.map { CommitmentBundleResult(json: $0.json, vcTreePosition: $0.vcTreePosition) }
+    }
+
+    private struct CommitmentBundleWire: Decodable {
+        let json: String
+        let vcTreePosition: UInt64
+
+        init(from decoder: Decoder) throws {
+            var container = try decoder.unkeyedContainer()
+            json = try container.decode(String.self)
+            vcTreePosition = try container.decode(UInt64.self)
+        }
+    }
+
+    public func storeKeystoneSignature(roundId: String, bundleIndex: UInt32, sig: Data, sighash: Data, rk: Data) throws { // swiftlint:disable:this function_parameter_count
+        let dbh = try requireHandle()
+        let ridBytes = [UInt8](roundId.utf8)
+        let sigBytes = [UInt8](sig)
+        let sighashBytes = [UInt8](sighash)
+        let rkBytes = [UInt8](rk)
+        let result = ridBytes.withUnsafeBufferPointer { ridBuf in
+            sigBytes.withUnsafeBufferPointer { sigBuf in
+                sighashBytes.withUnsafeBufferPointer { shBuf in
+                    rkBytes.withUnsafeBufferPointer { rkBuf in
+                        zcashlc_voting_store_keystone_signature(dbh, ridBuf.baseAddress, UInt(ridBuf.count), bundleIndex, sigBuf.baseAddress, UInt(sigBuf.count), shBuf.baseAddress, UInt(shBuf.count), rkBuf.baseAddress, UInt(rkBuf.count))
+                    }
+                }
+            }
+        }
+        guard result == 0 else { throw VotingRustBackendError.rustError(lastErrorMessage(fallback: "`store_keystone_signature` failed")) }
+    }
+
+    public struct KeystoneSignatureOut: Codable {
+        public let bundleIndex: UInt32
+        public let sig: [UInt8]
+        public let sighash: [UInt8]
+        public let rk: [UInt8]
+
+        enum CodingKeys: String, CodingKey {
+            case bundleIndex = "bundle_index"
+            case sig, sighash, rk
+        }
+    }
+
+    public func getKeystoneSignatures(roundId: String) throws -> [KeystoneSignatureOut] {
+        let dbh = try requireHandle()
+        let ridBytes = [UInt8](roundId.utf8)
+        let ptr: UnsafeMutablePointer<FfiBoxedSlice>? = ridBytes.withUnsafeBufferPointer { ridBuf in
+            zcashlc_voting_get_keystone_signatures(dbh, ridBuf.baseAddress, UInt(ridBuf.count))
+        }
+        guard let ptr else { throw VotingRustBackendError.rustError(lastErrorMessage(fallback: "`get_keystone_signatures` failed")) }
+        defer { zcashlc_free_boxed_slice(ptr) }
+        return try decodeJSON(from: ptr)
+    }
+
+    public func clearRecoveryState(roundId: String) throws {
+        let dbh = try requireHandle()
+        let ridBytes = [UInt8](roundId.utf8)
+        let result = ridBytes.withUnsafeBufferPointer { ridBuf in
+            zcashlc_voting_clear_recovery_state(dbh, ridBuf.baseAddress, UInt(ridBuf.count))
+        }
+        guard result == 0 else { throw VotingRustBackendError.rustError(lastErrorMessage(fallback: "`clear_recovery_state` failed")) }
+    }
+}
+
 // MARK: - Tree sync
 
 extension VotingRustBackend {

--- a/Sources/ZcashLightClientKit/Rust/Voting/VotingTypes.swift
+++ b/Sources/ZcashLightClientKit/Rust/Voting/VotingTypes.swift
@@ -1,0 +1,408 @@
+// VotingTypes.swift
+// Swift types matching the JSON serde types in voting.rs.
+// All types are Codable for JSON deserialization across the FFI boundary.
+
+import Foundation
+
+// MARK: - Round State
+
+/// Phase of a voting round.
+public enum VotingRoundPhase: UInt32, Codable, Sendable {
+    case initialized = 0
+    case hotkeyGenerated = 1
+    case delegationConstructed = 2
+    case delegationProved = 3
+    case voteReady = 4
+}
+
+/// State of a voting round, decoded from FfiRoundState.
+public struct VotingRoundState: Sendable {
+    public let roundId: String
+    public let phase: VotingRoundPhase
+    public let snapshotHeight: UInt64
+    public let hotkeyAddress: String?
+    public let delegatedWeight: UInt64?
+    public let proofGenerated: Bool
+}
+
+/// Summary of a voting round for list display.
+public struct VotingRoundSummary: Sendable {
+    public let roundId: String
+    public let phase: VotingRoundPhase
+    public let snapshotHeight: UInt64
+    public let createdAt: UInt64
+}
+
+// MARK: - Hotkey
+
+/// Voting hotkey (secret key, public key, address).
+public struct VotingHotkey: Sendable {
+    public let secretKey: [UInt8]
+    public let publicKey: [UInt8]
+    public let address: String
+}
+
+// MARK: - Bundle Setup
+
+/// Result of setting up vote bundles.
+public struct VotingBundleSetupResult: Sendable {
+    public let bundleCount: UInt32
+    public let eligibleWeight: UInt64
+}
+
+// MARK: - Vote Record
+
+/// Record of a vote for a specific proposal/bundle.
+public struct VotingVoteRecord: Sendable {
+    public let proposalId: UInt32
+    public let bundleIndex: UInt32
+    public let choice: UInt32
+    public let submitted: Bool
+}
+
+// MARK: - Note Info (JSON)
+
+/// Note information for voting eligibility.
+public struct VotingNoteInfo: Codable, Sendable {
+    public let commitment: [UInt8]
+    public let nullifier: [UInt8]
+    public let value: UInt64
+    public let position: UInt64
+    public let diversifier: [UInt8]
+    public let rho: [UInt8]
+    public let rseed: [UInt8]
+    public let scope: UInt32
+    public let ufvkStr: String
+
+    enum CodingKeys: String, CodingKey {
+        case commitment, nullifier, value, position, diversifier, rho, rseed, scope
+        case ufvkStr = "ufvk_str"
+    }
+
+    public init(
+        commitment: [UInt8],
+        nullifier: [UInt8],
+        value: UInt64,
+        position: UInt64,
+        diversifier: [UInt8],
+        rho: [UInt8],
+        rseed: [UInt8],
+        scope: UInt32,
+        ufvkStr: String
+    ) {
+        self.commitment = commitment
+        self.nullifier = nullifier
+        self.value = value
+        self.position = position
+        self.diversifier = diversifier
+        self.rho = rho
+        self.rseed = rseed
+        self.scope = scope
+        self.ufvkStr = ufvkStr
+    }
+}
+
+// MARK: - Governance PCZT (JSON)
+
+/// Result of building a governance PCZT.
+public struct VotingGovernancePczt: Codable, Sendable {
+    public let pcztBytes: [UInt8]
+    // swiftlint:disable:next identifier_name
+    public let rk: [UInt8]
+    public let alpha: [UInt8]
+    public let nfSigned: [UInt8]
+    public let cmxNew: [UInt8]
+    public let govNullifiers: [[UInt8]]
+    public let van: [UInt8]
+    public let vanCommRand: [UInt8]
+    public let dummyNullifiers: [[UInt8]]
+    public let rhoSigned: [UInt8]
+    public let paddedCmx: [[UInt8]]
+    public let rseedSigned: [UInt8]
+    public let rseedOutput: [UInt8]
+    public let actionBytes: [UInt8]
+    public let actionIndex: UInt32
+    /// Each element is [rho, rseed].
+    public let paddedNoteSecrets: [[[UInt8]]]
+    public let pcztSighash: [UInt8]
+
+    enum CodingKeys: String, CodingKey {
+        case pcztBytes = "pczt_bytes"
+        // swiftlint:disable:next identifier_name
+        case rk, alpha
+        case nfSigned = "nf_signed"
+        case cmxNew = "cmx_new"
+        case govNullifiers = "gov_nullifiers"
+        case van
+        case vanCommRand = "van_comm_rand"
+        case dummyNullifiers = "dummy_nullifiers"
+        case rhoSigned = "rho_signed"
+        case paddedCmx = "padded_cmx"
+        case rseedSigned = "rseed_signed"
+        case rseedOutput = "rseed_output"
+        case actionBytes = "action_bytes"
+        case actionIndex = "action_index"
+        case paddedNoteSecrets = "padded_note_secrets"
+        case pcztSighash = "pczt_sighash"
+    }
+}
+
+// MARK: - Witness Data (JSON)
+
+/// Merkle witness data for a note.
+public struct VotingWitnessData: Codable, Sendable {
+    public let noteCommitment: [UInt8]
+    public let position: UInt64
+    public let root: [UInt8]
+    public let authPath: [[UInt8]]
+
+    enum CodingKeys: String, CodingKey {
+        case noteCommitment = "note_commitment"
+        case position, root
+        case authPath = "auth_path"
+    }
+
+    public init(
+        noteCommitment: [UInt8],
+        position: UInt64,
+        root: [UInt8],
+        authPath: [[UInt8]]
+    ) {
+        self.noteCommitment = noteCommitment
+        self.position = position
+        self.root = root
+        self.authPath = authPath
+    }
+}
+
+// MARK: - Delegation Proof Result (JSON)
+
+/// Result of building and proving a delegation.
+public struct VotingDelegationProofResult: Codable, Sendable {
+    public let proof: [UInt8]
+    public let publicInputs: [[UInt8]]
+    public let nfSigned: [UInt8]
+    public let cmxNew: [UInt8]
+    public let govNullifiers: [[UInt8]]
+    public let vanComm: [UInt8]
+    // swiftlint:disable:next identifier_name
+    public let rk: [UInt8]
+
+    enum CodingKeys: String, CodingKey {
+        case proof
+        case publicInputs = "public_inputs"
+        case nfSigned = "nf_signed"
+        case cmxNew = "cmx_new"
+        case govNullifiers = "gov_nullifiers"
+        case vanComm = "van_comm"
+        // swiftlint:disable:next identifier_name
+        case rk
+    }
+}
+
+// MARK: - Delegation Submission (JSON)
+
+/// Delegation submission payload.
+public struct VotingDelegationSubmission: Codable, Sendable {
+    // swiftlint:disable:next identifier_name
+    public let rk: [UInt8]
+    public let spendAuthSig: [UInt8]
+    public let sighash: [UInt8]
+    public let nfSigned: [UInt8]
+    public let cmxNew: [UInt8]
+    public let govComm: [UInt8]
+    public let govNullifiers: [[UInt8]]
+    public let proof: [UInt8]
+    public let voteRoundId: String
+
+    enum CodingKeys: String, CodingKey {
+        // swiftlint:disable:next identifier_name
+        case rk
+        case spendAuthSig = "spend_auth_sig"
+        case sighash
+        case nfSigned = "nf_signed"
+        case cmxNew = "cmx_new"
+        case govComm = "gov_comm"
+        case govNullifiers = "gov_nullifiers"
+        case proof
+        case voteRoundId = "vote_round_id"
+    }
+}
+
+// MARK: - Encrypted Share (JSON)
+
+/// An encrypted vote share.
+public struct VotingEncryptedShare: Codable, Sendable {
+    // swiftlint:disable:next identifier_name
+    public let c1: [UInt8]
+    // swiftlint:disable:next identifier_name
+    public let c2: [UInt8]
+    public let shareIndex: UInt32
+    public let plaintextValue: UInt64
+    public let randomness: [UInt8]
+
+    enum CodingKeys: String, CodingKey {
+        // swiftlint:disable:next identifier_name
+        case c1
+        // swiftlint:disable:next identifier_name
+        case c2
+        case shareIndex = "share_index"
+        case plaintextValue = "plaintext_value"
+        case randomness
+    }
+
+    public init(
+        // swiftlint:disable:next identifier_name
+        c1: [UInt8],
+        // swiftlint:disable:next identifier_name
+        c2: [UInt8],
+        shareIndex: UInt32,
+        plaintextValue: UInt64,
+        randomness: [UInt8]
+    ) {
+        self.c1 = c1
+        self.c2 = c2
+        self.shareIndex = shareIndex
+        self.plaintextValue = plaintextValue
+        self.randomness = randomness
+    }
+}
+
+// MARK: - Vote Commitment Bundle (JSON)
+
+/// A vote commitment bundle produced by ZKP #2.
+public struct VotingVoteCommitmentBundle: Codable, Sendable {
+    public let vanNullifier: [UInt8]
+    public let voteAuthorityNoteNew: [UInt8]
+    public let voteCommitment: [UInt8]
+    public let proposalId: UInt32
+    public let proof: [UInt8]
+    public let encShares: [VotingEncryptedShare]
+    public let anchorHeight: UInt32
+    public let voteRoundId: String
+    public let sharesHash: [UInt8]
+    public let shareBlinds: [[UInt8]]
+    public let shareComms: [[UInt8]]
+    public let rVpkBytes: [UInt8]
+    public let alphaV: [UInt8]
+
+    enum CodingKeys: String, CodingKey {
+        case vanNullifier = "van_nullifier"
+        case voteAuthorityNoteNew = "vote_authority_note_new"
+        case voteCommitment = "vote_commitment"
+        case proposalId = "proposal_id"
+        case proof
+        case encShares = "enc_shares"
+        case anchorHeight = "anchor_height"
+        case voteRoundId = "vote_round_id"
+        case sharesHash = "shares_hash"
+        case shareBlinds = "share_blinds"
+        case shareComms = "share_comms"
+        case rVpkBytes = "r_vpk_bytes"
+        case alphaV = "alpha_v"
+    }
+
+    public init(
+        vanNullifier: [UInt8],
+        voteAuthorityNoteNew: [UInt8],
+        voteCommitment: [UInt8],
+        proposalId: UInt32,
+        proof: [UInt8],
+        encShares: [VotingEncryptedShare],
+        anchorHeight: UInt32,
+        voteRoundId: String,
+        sharesHash: [UInt8],
+        shareBlinds: [[UInt8]],
+        shareComms: [[UInt8]],
+        rVpkBytes: [UInt8],
+        alphaV: [UInt8]
+    ) {
+        self.vanNullifier = vanNullifier
+        self.voteAuthorityNoteNew = voteAuthorityNoteNew
+        self.voteCommitment = voteCommitment
+        self.proposalId = proposalId
+        self.proof = proof
+        self.encShares = encShares
+        self.anchorHeight = anchorHeight
+        self.voteRoundId = voteRoundId
+        self.sharesHash = sharesHash
+        self.shareBlinds = shareBlinds
+        self.shareComms = shareComms
+        self.rVpkBytes = rVpkBytes
+        self.alphaV = alphaV
+    }
+}
+
+// MARK: - Share Payload (JSON)
+
+/// Share payload for delegated share submission.
+public struct VotingSharePayload: Codable, Sendable {
+    public let sharesHash: [UInt8]
+    public let proposalId: UInt32
+    public let voteDecision: UInt32
+    public let encShare: VotingEncryptedShare
+    public let treePosition: UInt64
+    public let allEncShares: [VotingEncryptedShare]
+    public let shareComms: [[UInt8]]
+    public let primaryBlind: [UInt8]
+
+    enum CodingKeys: String, CodingKey {
+        case sharesHash = "shares_hash"
+        case proposalId = "proposal_id"
+        case voteDecision = "vote_decision"
+        case encShare = "enc_share"
+        case treePosition = "tree_position"
+        case allEncShares = "all_enc_shares"
+        case shareComms = "share_comms"
+        case primaryBlind = "primary_blind"
+    }
+}
+
+// MARK: - Cast Vote Signature (JSON)
+
+/// Signature for a cast vote transaction.
+public struct VotingCastVoteSignature: Codable, Sendable {
+    public let voteAuthSig: [UInt8]
+
+    enum CodingKeys: String, CodingKey {
+        case voteAuthSig = "vote_auth_sig"
+    }
+}
+
+// MARK: - Delegation Inputs (JSON)
+
+/// Inputs needed for delegation construction.
+public struct VotingDelegationInputs: Codable, Sendable {
+    public let fvkBytes: [UInt8]
+    public let gDNewX: [UInt8]
+    public let pkDNewX: [UInt8]
+    public let hotkeyRawAddress: [UInt8]
+    public let hotkeyPublicKey: [UInt8]
+    public let hotkeyAddress: String
+    public let seedFingerprint: [UInt8]
+
+    enum CodingKeys: String, CodingKey {
+        case fvkBytes = "fvk_bytes"
+        case gDNewX = "g_d_new_x"
+        case pkDNewX = "pk_d_new_x"
+        case hotkeyRawAddress = "hotkey_raw_address"
+        case hotkeyPublicKey = "hotkey_public_key"
+        case hotkeyAddress = "hotkey_address"
+        case seedFingerprint = "seed_fingerprint"
+    }
+}
+
+// MARK: - VAN Witness (JSON)
+
+/// VAN Merkle witness for ZKP #2.
+public struct VotingVanWitness: Codable, Sendable {
+    public let authPath: [[UInt8]]
+    public let position: UInt32
+    public let anchorHeight: UInt32
+
+    enum CodingKeys: String, CodingKey {
+        case authPath = "auth_path"
+        case position
+        case anchorHeight = "anchor_height"
+    }
+}

--- a/Sources/ZcashLightClientKit/Rust/Voting/VotingTypes.swift
+++ b/Sources/ZcashLightClientKit/Rust/Voting/VotingTypes.swift
@@ -175,6 +175,33 @@ public struct VotingWitnessData: Codable, Sendable {
     }
 }
 
+// MARK: - Share Delegation (JSON)
+
+/// Record of a share delegation sent to helper servers.
+public struct VotingShareDelegation: Codable, Equatable, Sendable {
+    public let roundId: String
+    public let bundleIndex: UInt32
+    public let proposalId: UInt32
+    public let shareIndex: UInt32
+    public let sentToURLs: [String]
+    public let nullifier: [UInt8]
+    public let confirmed: Bool
+    public let submitAt: UInt64
+    public let createdAt: UInt64
+
+    enum CodingKeys: String, CodingKey {
+        case roundId = "round_id"
+        case bundleIndex = "bundle_index"
+        case proposalId = "proposal_id"
+        case shareIndex = "share_index"
+        case sentToURLs = "sent_to_urls"
+        case nullifier
+        case confirmed
+        case submitAt = "submit_at"
+        case createdAt = "created_at"
+    }
+}
+
 // MARK: - Delegation Proof Result (JSON)
 
 /// Result of building and proving a delegation.

--- a/Sources/ZcashLightClientKit/Rust/Voting/VotingTypes.swift
+++ b/Sources/ZcashLightClientKit/Rust/Voting/VotingTypes.swift
@@ -232,42 +232,6 @@ public struct VotingDelegationSubmission: Codable, Sendable {
 // MARK: - Encrypted Share (JSON)
 
 /// An encrypted vote share.
-public struct VotingEncryptedShare: Codable, Sendable {
-    // swiftlint:disable:next identifier_name
-    public let c1: [UInt8]
-    // swiftlint:disable:next identifier_name
-    public let c2: [UInt8]
-    public let shareIndex: UInt32
-    public let plaintextValue: UInt64
-    public let randomness: [UInt8]
-
-    enum CodingKeys: String, CodingKey {
-        // swiftlint:disable:next identifier_name
-        case c1
-        // swiftlint:disable:next identifier_name
-        case c2
-        case shareIndex = "share_index"
-        case plaintextValue = "plaintext_value"
-        case randomness
-    }
-
-    public init(
-        // swiftlint:disable:next identifier_name
-        c1: [UInt8],
-        // swiftlint:disable:next identifier_name
-        c2: [UInt8],
-        shareIndex: UInt32,
-        plaintextValue: UInt64,
-        randomness: [UInt8]
-    ) {
-        self.c1 = c1
-        self.c2 = c2
-        self.shareIndex = shareIndex
-        self.plaintextValue = plaintextValue
-        self.randomness = randomness
-    }
-}
-
 // MARK: - Vote Commitment Bundle (JSON)
 
 /// A vote commitment bundle produced by ZKP #2.
@@ -277,7 +241,7 @@ public struct VotingVoteCommitmentBundle: Codable, Sendable {
     public let voteCommitment: [UInt8]
     public let proposalId: UInt32
     public let proof: [UInt8]
-    public let encShares: [VotingEncryptedShare]
+    public let encShares: [VotingWireEncryptedShare]
     public let anchorHeight: UInt32
     public let voteRoundId: String
     public let sharesHash: [UInt8]
@@ -308,7 +272,7 @@ public struct VotingVoteCommitmentBundle: Codable, Sendable {
         voteCommitment: [UInt8],
         proposalId: UInt32,
         proof: [UInt8],
-        encShares: [VotingEncryptedShare],
+        encShares: [VotingWireEncryptedShare],
         anchorHeight: UInt32,
         voteRoundId: String,
         sharesHash: [UInt8],
@@ -333,6 +297,33 @@ public struct VotingVoteCommitmentBundle: Codable, Sendable {
     }
 }
 
+// MARK: - Wire Encrypted Share (JSON)
+
+/// Wire-safe encrypted share — contains only the public ciphertext components.
+/// Secrets (plaintextValue, randomness) stay inside Rust and never cross the FFI boundary.
+public struct VotingWireEncryptedShare: Codable, Sendable {
+    // swiftlint:disable:next identifier_name
+    public let c1: [UInt8]
+    // swiftlint:disable:next identifier_name
+    public let c2: [UInt8]
+    public let shareIndex: UInt32
+
+    enum CodingKeys: String, CodingKey {
+        // swiftlint:disable:next identifier_name
+        case c1
+        // swiftlint:disable:next identifier_name
+        case c2
+        case shareIndex = "share_index"
+    }
+
+    // swiftlint:disable:next identifier_name
+    public init(c1: [UInt8], c2: [UInt8], shareIndex: UInt32) {
+        self.c1 = c1
+        self.c2 = c2
+        self.shareIndex = shareIndex
+    }
+}
+
 // MARK: - Share Payload (JSON)
 
 /// Share payload for delegated share submission.
@@ -340,9 +331,9 @@ public struct VotingSharePayload: Codable, Sendable {
     public let sharesHash: [UInt8]
     public let proposalId: UInt32
     public let voteDecision: UInt32
-    public let encShare: VotingEncryptedShare
+    public let encShare: VotingWireEncryptedShare
     public let treePosition: UInt64
-    public let allEncShares: [VotingEncryptedShare]
+    public let allEncShares: [VotingWireEncryptedShare]
     public let shareComms: [[UInt8]]
     public let primaryBlind: [UInt8]
 

--- a/Sources/ZcashLightClientKit/Synchronizer.swift
+++ b/Sources/ZcashLightClientKit/Synchronizer.swift
@@ -42,6 +42,13 @@ public struct SynchronizerState: Equatable {
     public var syncStatus: SyncStatus
     /// height of the latest block on the blockchain known to this synchronizer.
     public var latestBlockHeight: BlockHeight
+    /// Height below which every block has been scanned contiguously from the wallet
+    /// birthday. Unlike `latestBlockHeight` (chain tip) or `maxScannedHeight` (head-first
+    /// scan progress), this is the only value that tells a caller "the wallet has
+    /// authoritative note and nullifier state for this height." Callers that need a
+    /// stable snapshot of balance at a specific height — e.g. voting power at a poll
+    /// snapshot — must gate on this, not on `latestBlockHeight`.
+    public var fullyScannedHeight: BlockHeight
 
     /// Represents a synchronizer that has made zero progress hasn't done a sync attempt
     public static var zero: SynchronizerState {
@@ -49,20 +56,23 @@ public struct SynchronizerState: Equatable {
             syncSessionID: .nullID,
             accountsBalances: [:],
             internalSyncStatus: .unprepared,
-            latestBlockHeight: .zero
+            latestBlockHeight: .zero,
+            fullyScannedHeight: .zero
         )
     }
-    
+
     init(
         syncSessionID: UUID,
         accountsBalances: [AccountUUID: AccountBalance],
         internalSyncStatus: InternalSyncStatus,
-        latestBlockHeight: BlockHeight
+        latestBlockHeight: BlockHeight,
+        fullyScannedHeight: BlockHeight = .zero
     ) {
         self.syncSessionID = syncSessionID
         self.accountsBalances = accountsBalances
         self.internalSyncStatus = internalSyncStatus
         self.latestBlockHeight = latestBlockHeight
+        self.fullyScannedHeight = fullyScannedHeight
         self.syncStatus = internalSyncStatus.mapToSyncStatus()
     }
 }

--- a/Sources/ZcashLightClientKit/Synchronizer.swift
+++ b/Sources/ZcashLightClientKit/Synchronizer.swift
@@ -479,6 +479,10 @@ public protocol Synchronizer: AnyObject {
     ///   hex-encoded bytes otherwise.
     func debugDatabase(sql: String) -> String
 
+    /// Fetch the commitment tree state at the given block height from lightwalletd,
+    /// returned as protobuf-serialized bytes suitable for witness generation.
+    func getTreeState(height: UInt64) async throws -> Data
+
     /// Get an ephemeral single use transparent address
     /// - Parameter accountUUID: The account for which the single use transparent address is going to be created.
     /// - Returns The struct with an ephemeral transparent address and gap limit info

--- a/Sources/ZcashLightClientKit/Synchronizer/SDKSynchronizer.swift
+++ b/Sources/ZcashLightClientKit/Synchronizer/SDKSynchronizer.swift
@@ -1210,7 +1210,8 @@ public class SDKSynchronizer: Synchronizer {
             syncSessionID: syncSession.value,
             accountsBalances: (try? await getAccountsBalances()) ?? [:],
             internalSyncStatus: status,
-            latestBlockHeight: latestBlocksDataProvider.latestBlockHeight
+            latestBlockHeight: latestBlocksDataProvider.latestBlockHeight,
+            fullyScannedHeight: latestBlocksDataProvider.fullyScannedHeight
         )
     }
 

--- a/Sources/ZcashLightClientKit/Synchronizer/SDKSynchronizer.swift
+++ b/Sources/ZcashLightClientKit/Synchronizer/SDKSynchronizer.swift
@@ -1028,7 +1028,13 @@ public class SDKSynchronizer: Synchronizer {
     public func debugDatabase(sql: String) -> String {
         transactionRepository.debugDatabase(sql: sql)
     }
-    
+
+    public func getTreeState(height: UInt64) async throws -> Data {
+        let blockID = BlockID.with { $0.height = height }
+        let treeState = try await initializer.lightWalletService.getTreeState(blockID, mode: .direct)
+        return try treeState.serializedData()
+    }
+
     public func getSingleUseTransparentAddress(accountUUID: AccountUUID) async throws -> SingleUseTransparentAddress {
         try await initializer.rustBackend.getSingleUseTransparentAddress(accountUUID: accountUUID)
     }

--- a/Tests/OfflineTests/SynchronizerOfflineTests.swift
+++ b/Tests/OfflineTests/SynchronizerOfflineTests.swift
@@ -439,7 +439,8 @@ class SynchronizerOfflineTests: ZcashTestCase {
             syncSessionID: .nullID,
             accountsBalances: [:],
             internalSyncStatus: internalSyncStatus,
-            latestBlockHeight: .zero
+            latestBlockHeight: .zero,
+            fullyScannedHeight: .zero
         )
     }
 }

--- a/Tests/TestUtils/Sourcery/GeneratedMocks/AutoMockable.generated.swift
+++ b/Tests/TestUtils/Sourcery/GeneratedMocks/AutoMockable.generated.swift
@@ -2504,6 +2504,30 @@ class SynchronizerMock: Synchronizer {
         try await deleteAccountClosure!(accountUUID)
     }
 
+    // MARK: - getTreeState (height)
+
+    var getTreeStateHeightThrowableError: Error?
+    var getTreeStateHeightCallsCount = 0
+    var getTreeStateHeightCalled: Bool {
+        return getTreeStateHeightCallsCount > 0
+    }
+    var getTreeStateHeightReceivedHeight: UInt64?
+    var getTreeStateHeightReturnValue: Data!
+    var getTreeStateHeightClosure: ((UInt64) async throws -> Data)?
+
+    func getTreeState(height: UInt64) async throws -> Data {
+        if let error = getTreeStateHeightThrowableError {
+            throw error
+        }
+        getTreeStateHeightCallsCount += 1
+        getTreeStateHeightReceivedHeight = height
+        if let closure = getTreeStateHeightClosure {
+            return try await closure(height)
+        } else {
+            return getTreeStateHeightReturnValue
+        }
+    }
+
 }
 class TransactionRepositoryMock: TransactionRepository {
 

--- a/Tests/TestUtils/Stubs.swift
+++ b/Tests/TestUtils/Stubs.swift
@@ -148,7 +148,8 @@ extension SynchronizerState {
             syncSessionID: .nullID,
             accountsBalances: [:],
             internalSyncStatus: .syncing(0, false),
-            latestBlockHeight: 222222
+            latestBlockHeight: 222222,
+            fullyScannedHeight: 0
         )
     }
 }

--- a/rust/build.rs
+++ b/rust/build.rs
@@ -3,7 +3,13 @@ extern crate cbindgen;
 use std::{env, path::PathBuf};
 
 fn main() {
-    println!("cargo:rerun-if-changed=rust/src/lib.rs");
+    // Re-run when any Rust source changes so cbindgen regenerates the C header.
+    for entry in std::fs::read_dir("rust/src").expect("rust/src should exist") {
+        let path = entry.expect("readable dir entry").path();
+        if path.extension().is_some_and(|ext| ext == "rs") {
+            println!("cargo:rerun-if-changed={}", path.display());
+        }
+    }
     println!("cargo:rerun-if-changed=rust/wrapper.c");
     println!("cargo:rerun-if-changed=rust/wrapper.h");
 

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -95,6 +95,7 @@ use zip32::fingerprint::SeedFingerprint;
 mod derivation;
 mod ffi;
 mod tor;
+mod voting;
 
 #[cfg(target_vendor = "apple")]
 mod os_log;

--- a/rust/src/voting.rs
+++ b/rust/src/voting.rs
@@ -1383,9 +1383,13 @@ pub unsafe extern "C" fn zcashlc_voting_generate_note_witnesses(
             .collect();
         let checkpoint_height = zcash_protocol::consensus::BlockHeight::from_u32(params.snapshot_height as u32);
 
-        let merkle_paths = wallet_db
-            .generate_orchard_witnesses_at_frontier(&positions, nonempty_frontier, checkpoint_height)
-            .map_err(|e| anyhow!("generate_orchard_witnesses_at_frontier failed: {}", e))?;
+        let merkle_paths = voting::orchard_witnesses::generate_orchard_witnesses_at_frontier(
+            wallet_db.conn(),
+            &positions,
+            nonempty_frontier,
+            checkpoint_height,
+        )
+        .map_err(|e| anyhow!("generate_orchard_witnesses_at_frontier failed: {}", e))?;
 
         // Convert MerklePaths to WitnessData
         let root_bytes = frontier_root.to_bytes().to_vec();

--- a/rust/src/voting.rs
+++ b/rust/src/voting.rs
@@ -2553,6 +2553,248 @@ pub unsafe extern "C" fn zcashlc_voting_version() -> *mut c_char {
 }
 
 // =============================================================================
+// D. Share delegation tracking
+// =============================================================================
+
+/// JSON representation for share delegation records crossing the FFI boundary.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct JsonShareDelegationRecord {
+    pub round_id: String,
+    pub bundle_index: u32,
+    pub proposal_id: u32,
+    pub share_index: u32,
+    pub sent_to_urls: Vec<String>,
+    pub nullifier: Vec<u8>,
+    pub confirmed: bool,
+    pub submit_at: u64,
+    pub created_at: u64,
+}
+
+impl From<voting::ShareDelegationRecord> for JsonShareDelegationRecord {
+    fn from(r: voting::ShareDelegationRecord) -> Self {
+        Self {
+            round_id: r.round_id,
+            bundle_index: r.bundle_index,
+            proposal_id: r.proposal_id,
+            share_index: r.share_index,
+            sent_to_urls: r.sent_to_urls,
+            nullifier: r.nullifier,
+            confirmed: r.confirmed,
+            submit_at: r.submit_at,
+            created_at: r.created_at,
+        }
+    }
+}
+
+/// Compute the share reveal nullifier from client-known inputs.
+///
+/// Returns the 32-byte nullifier as a hex string (64 chars), or null on error.
+///
+/// # Safety
+///
+/// - `vote_commitment` must point to exactly 32 bytes.
+/// - `primary_blind` must point to exactly 32 bytes.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn zcashlc_voting_compute_share_nullifier(
+    vote_commitment: *const u8,
+    primary_blind: *const u8,
+    share_index: u32,
+) -> *mut c_char {
+    let res = catch_panic(|| {
+        let vc = unsafe { bytes_from_ptr(vote_commitment, 32) };
+        let blind = unsafe { bytes_from_ptr(primary_blind, 32) };
+
+        let nullifier = voting::share_tracking::compute_share_nullifier(vc, share_index, blind)
+            .map_err(|e| anyhow!("compute_share_nullifier failed: {}", e))?;
+
+        let hex_str: String = nullifier.iter().map(|b| format!("{:02x}", b)).collect();
+        let c_str = CString::new(hex_str)
+            .map_err(|e| anyhow!("null byte in hex string: {}", e))?;
+        Ok(c_str.into_raw())
+    });
+    unwrap_exc_or_null(res)
+}
+
+/// Record a share delegation after sending to helper servers.
+///
+/// Returns 0 on success, -1 on error.
+///
+/// # Safety
+///
+/// - `db` must be a valid, non-null `VotingDatabaseHandle` pointer.
+/// - String params must be valid UTF-8 pointers with correct lengths.
+/// - `nullifier_ptr` must point to `nullifier_len` bytes.
+/// - `sent_to_urls_json` must be a JSON array of strings.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn zcashlc_voting_record_share_delegation(
+    db: *mut VotingDatabaseHandle,
+    round_id: *const u8,
+    round_id_len: usize,
+    bundle_index: u32,
+    proposal_id: u32,
+    share_index: u32,
+    sent_to_urls_json: *const u8,
+    sent_to_urls_json_len: usize,
+    nullifier_ptr: *const u8,
+    nullifier_len: usize,
+    submit_at: u64,
+) -> i32 {
+    let db = AssertUnwindSafe(db);
+    let res = catch_panic(|| {
+        let handle =
+            unsafe { db.as_ref() }.ok_or_else(|| anyhow!("VotingDatabaseHandle is null"))?;
+        let round_id_str = unsafe { str_from_ptr(round_id, round_id_len) }?;
+        let urls_bytes = unsafe { bytes_from_ptr(sent_to_urls_json, sent_to_urls_json_len) };
+        let sent_to_urls: Vec<String> = serde_json::from_slice(urls_bytes)?;
+        let nullifier = unsafe { bytes_from_ptr(nullifier_ptr, nullifier_len) };
+
+        handle
+            .db
+            .record_share_delegation(
+                &round_id_str,
+                bundle_index,
+                proposal_id,
+                share_index,
+                &sent_to_urls,
+                nullifier,
+                submit_at,
+            )
+            .map_err(|e| anyhow!("{}", e))?;
+        Ok(0)
+    });
+    unwrap_exc_or(res, -1)
+}
+
+/// Get all share delegations for a round.
+///
+/// Returns a JSON array of `JsonShareDelegationRecord`, or null on error.
+///
+/// # Safety
+///
+/// - `db` must be a valid, non-null `VotingDatabaseHandle` pointer.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn zcashlc_voting_get_share_delegations(
+    db: *mut VotingDatabaseHandle,
+    round_id: *const u8,
+    round_id_len: usize,
+) -> *mut crate::ffi::BoxedSlice {
+    let db = AssertUnwindSafe(db);
+    let res = catch_panic(|| {
+        let handle =
+            unsafe { db.as_ref() }.ok_or_else(|| anyhow!("VotingDatabaseHandle is null"))?;
+        let round_id_str = unsafe { str_from_ptr(round_id, round_id_len) }?;
+
+        let records = handle
+            .db
+            .get_share_delegations(&round_id_str)
+            .map_err(|e| anyhow!("{}", e))?;
+
+        let json_records: Vec<JsonShareDelegationRecord> =
+            records.into_iter().map(Into::into).collect();
+        json_to_boxed_slice(&json_records)
+    });
+    unwrap_exc_or_null(res)
+}
+
+/// Get unconfirmed share delegations for a round.
+///
+/// Returns a JSON array of `JsonShareDelegationRecord`, or null on error.
+///
+/// # Safety
+///
+/// - `db` must be a valid, non-null `VotingDatabaseHandle` pointer.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn zcashlc_voting_get_unconfirmed_delegations(
+    db: *mut VotingDatabaseHandle,
+    round_id: *const u8,
+    round_id_len: usize,
+) -> *mut crate::ffi::BoxedSlice {
+    let db = AssertUnwindSafe(db);
+    let res = catch_panic(|| {
+        let handle =
+            unsafe { db.as_ref() }.ok_or_else(|| anyhow!("VotingDatabaseHandle is null"))?;
+        let round_id_str = unsafe { str_from_ptr(round_id, round_id_len) }?;
+
+        let records = handle
+            .db
+            .get_unconfirmed_delegations(&round_id_str)
+            .map_err(|e| anyhow!("{}", e))?;
+
+        let json_records: Vec<JsonShareDelegationRecord> =
+            records.into_iter().map(Into::into).collect();
+        json_to_boxed_slice(&json_records)
+    });
+    unwrap_exc_or_null(res)
+}
+
+/// Mark a share delegation as confirmed on-chain.
+///
+/// Returns 0 on success, -1 on error.
+///
+/// # Safety
+///
+/// - `db` must be a valid, non-null `VotingDatabaseHandle` pointer.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn zcashlc_voting_mark_share_confirmed(
+    db: *mut VotingDatabaseHandle,
+    round_id: *const u8,
+    round_id_len: usize,
+    bundle_index: u32,
+    proposal_id: u32,
+    share_index: u32,
+) -> i32 {
+    let db = AssertUnwindSafe(db);
+    let res = catch_panic(|| {
+        let handle =
+            unsafe { db.as_ref() }.ok_or_else(|| anyhow!("VotingDatabaseHandle is null"))?;
+        let round_id_str = unsafe { str_from_ptr(round_id, round_id_len) }?;
+
+        handle
+            .db
+            .mark_share_confirmed(&round_id_str, bundle_index, proposal_id, share_index)
+            .map_err(|e| anyhow!("{}", e))?;
+        Ok(0)
+    });
+    unwrap_exc_or(res, -1)
+}
+
+/// Append new server URLs to a share delegation's sent_to_urls.
+///
+/// Returns 0 on success, -1 on error.
+///
+/// # Safety
+///
+/// - `db` must be a valid, non-null `VotingDatabaseHandle` pointer.
+/// - `new_urls_json` must be a JSON array of strings.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn zcashlc_voting_add_sent_servers(
+    db: *mut VotingDatabaseHandle,
+    round_id: *const u8,
+    round_id_len: usize,
+    bundle_index: u32,
+    proposal_id: u32,
+    share_index: u32,
+    new_urls_json: *const u8,
+    new_urls_json_len: usize,
+) -> i32 {
+    let db = AssertUnwindSafe(db);
+    let res = catch_panic(|| {
+        let handle =
+            unsafe { db.as_ref() }.ok_or_else(|| anyhow!("VotingDatabaseHandle is null"))?;
+        let round_id_str = unsafe { str_from_ptr(round_id, round_id_len) }?;
+        let urls_bytes = unsafe { bytes_from_ptr(new_urls_json, new_urls_json_len) };
+        let new_urls: Vec<String> = serde_json::from_slice(urls_bytes)?;
+
+        handle
+            .db
+            .add_sent_servers(&round_id_str, bundle_index, proposal_id, share_index, &new_urls)
+            .map_err(|e| anyhow!("{}", e))?;
+        Ok(0)
+    });
+    unwrap_exc_or(res, -1)
+}
+
+// =============================================================================
 // Internal helpers
 // =============================================================================
 

--- a/rust/src/voting.rs
+++ b/rust/src/voting.rs
@@ -16,9 +16,15 @@ use std::sync::Arc;
 
 use anyhow::anyhow;
 use ffi_helpers::panic::catch_panic;
+use incrementalmerkletree::Position;
+use orchard::note::ExtractedNoteCommitment;
+use orchard::tree::MerkleHashOrchard;
+use prost::Message;
 use serde::{Deserialize, Serialize};
+use zcash_client_backend::proto::service::TreeState;
+use zcash_client_sqlite::util::SystemClock;
 use zcash_keys::keys::{UnifiedFullViewingKey, UnifiedSpendingKey};
-use zcash_protocol::consensus::{MAIN_NETWORK, TEST_NETWORK};
+use zcash_protocol::consensus::{self, MAIN_NETWORK, Network, TEST_NETWORK};
 use zip32::{AccountId, Scope};
 
 use librustvoting as voting;
@@ -57,6 +63,77 @@ unsafe fn bytes_from_ptr<'a>(ptr: *const u8, len: usize) -> &'a [u8] {
 fn json_to_boxed_slice<T: Serialize>(value: &T) -> anyhow::Result<*mut crate::ffi::BoxedSlice> {
     let json = serde_json::to_vec(value)?;
     Ok(crate::ffi::BoxedSlice::some(json))
+}
+
+/// Convert a librustzcash ReceivedNote (orchard) into librustvoting's NoteInfo.
+///
+/// Requires the account's UFVK and network to compute the nullifier and
+/// encode the UFVK string.
+fn received_note_to_note_info<P: consensus::Parameters>(
+    note: &zcash_client_backend::wallet::ReceivedNote<
+        zcash_client_sqlite::ReceivedNoteId,
+        orchard::note::Note,
+    >,
+    ufvk: &UnifiedFullViewingKey,
+    network: &P,
+) -> anyhow::Result<voting::NoteInfo> {
+    let orchard_note = note.note();
+    let fvk = ufvk
+        .orchard()
+        .ok_or_else(|| anyhow!("UFVK has no Orchard component"))?;
+
+    // Compute nullifier from note + full viewing key
+    let nullifier = orchard_note.nullifier(fvk);
+
+    // Compute cmx (extracted note commitment)
+    let cmx: ExtractedNoteCommitment = orchard_note.commitment().into();
+
+    // Extract raw fields
+    let diversifier = orchard_note.recipient().diversifier().as_array().to_vec();
+    let value = orchard_note.value().inner();
+    let rho = orchard_note.rho().to_bytes().to_vec();
+    let rseed = orchard_note.rseed().as_bytes().to_vec();
+    let position = u64::from(note.note_commitment_tree_position());
+    let scope = match note.spending_key_scope() {
+        Scope::External => 0u32,
+        Scope::Internal => 1u32,
+    };
+    let ufvk_str = ufvk.encode(network);
+
+    Ok(voting::NoteInfo {
+        commitment: cmx.to_bytes().to_vec(),
+        nullifier: nullifier.to_bytes().to_vec(),
+        value,
+        position,
+        diversifier,
+        rho,
+        rseed,
+        scope,
+        ufvk_str,
+    })
+}
+
+/// Open the wallet database and return a network value.
+fn open_wallet_db(
+    wallet_db_path: &str,
+    network_id: u32,
+) -> anyhow::Result<(
+    zcash_client_sqlite::WalletDb<rusqlite::Connection, Network, SystemClock, rand::rngs::OsRng>,
+    Network,
+)> {
+    let network = match network_id {
+        0 => Network::MainNetwork,
+        1 => Network::TestNetwork,
+        _ => return Err(anyhow!("invalid network_id {}", network_id)),
+    };
+    let wallet_db = zcash_client_sqlite::WalletDb::for_path(
+        wallet_db_path,
+        network,
+        SystemClock,
+        rand::rngs::OsRng,
+    )
+    .map_err(|e| anyhow!("failed to open wallet DB: {}", e))?;
+    Ok((wallet_db, network))
 }
 
 // =============================================================================
@@ -944,11 +1021,11 @@ pub unsafe extern "C" fn zcashlc_voting_get_wallet_notes(
 ) -> *mut crate::ffi::BoxedSlice {
     let db = AssertUnwindSafe(db);
     let res = catch_panic(|| {
-        let handle =
+        let _handle =
             unsafe { db.as_ref() }.ok_or_else(|| anyhow!("VotingDatabaseHandle is null"))?;
         let wallet_path_str = unsafe { str_from_ptr(wallet_db_path, wallet_db_path_len) }?;
 
-        let seed_fp = if seed_fingerprint.is_null() || seed_fingerprint_len == 0 {
+        let _seed_fp = if seed_fingerprint.is_null() || seed_fingerprint_len == 0 {
             None
         } else {
             Some(unsafe { bytes_from_ptr(seed_fingerprint, seed_fingerprint_len) }.to_vec())
@@ -959,18 +1036,40 @@ pub unsafe extern "C" fn zcashlc_voting_get_wallet_notes(
             Some(account_index as u32)
         };
 
-        let notes = handle
-            .db
-            .get_wallet_notes(
-                &wallet_path_str,
-                snapshot_height,
-                network_id,
-                seed_fp.as_deref(),
-                acct_idx,
-            )
-            .map_err(|e| anyhow!("get_wallet_notes failed: {}", e))?;
+        let (wallet_db, network) = open_wallet_db(&wallet_path_str, network_id)?;
 
-        let json_notes: Vec<JsonNoteInfo> = notes.into_iter().map(Into::into).collect();
+        // Resolve the account UUID — use account_index to pick from the
+        // wallet's account list, or default to the first account.
+        use zcash_client_backend::data_api::WalletRead;
+        let account_ids = wallet_db.get_account_ids()?;
+        let target_id = match acct_idx {
+            Some(idx) => account_ids
+                .get(idx as usize)
+                .copied()
+                .ok_or_else(|| anyhow!("account_index {} out of range (wallet has {} accounts)", idx, account_ids.len()))?,
+            None => *account_ids
+                .first()
+                .ok_or_else(|| anyhow!("no accounts in wallet"))?,
+        };
+        let account = wallet_db
+            .get_account(target_id)?
+            .ok_or_else(|| anyhow!("account not found"))?;
+
+        use zcash_client_backend::data_api::Account;
+        let ufvk = account.ufvk()
+            .ok_or_else(|| anyhow!("account has no UFVK"))?;
+        let account_uuid = account.id();
+
+        let height = zcash_protocol::consensus::BlockHeight::from_u32(snapshot_height as u32);
+        let received_notes = wallet_db
+            .get_orchard_notes_at_snapshot(account_uuid, height)
+            .map_err(|e| anyhow!("get_orchard_notes_at_snapshot failed: {}", e))?;
+
+        let mut json_notes = Vec::with_capacity(received_notes.len());
+        for rn in &received_notes {
+            let note_info = received_note_to_note_info(rn, ufvk, &network)?;
+            json_notes.push(JsonNoteInfo::from(note_info));
+        }
         json_to_boxed_slice(&json_notes)
     });
     unwrap_exc_or_null(res)
@@ -1212,10 +1311,57 @@ pub unsafe extern "C" fn zcashlc_voting_generate_note_witnesses(
         let json_notes: Vec<JsonNoteInfo> = serde_json::from_slice(notes_bytes)?;
         let core_notes: Vec<voting::NoteInfo> = json_notes.into_iter().map(Into::into).collect();
 
-        let witnesses = handle
-            .db
-            .generate_note_witnesses(&round_id_str, bundle_index, &wallet_path_str, &core_notes)
-            .map_err(|e| anyhow!("generate_note_witnesses failed: {}", e))?;
+        // Load cached tree state from voting DB and parse frontier
+        let conn = handle.db.conn();
+        let tree_state_bytes = voting::storage::queries::load_tree_state(&conn, &round_id_str)
+            .map_err(|e| anyhow!("load_tree_state failed: {}", e))?;
+        let params = voting::storage::queries::load_round_params(&conn, &round_id_str)
+            .map_err(|e| anyhow!("load_round_params failed: {}", e))?;
+        drop(conn);
+
+        let tree_state = TreeState::decode(tree_state_bytes.as_slice())
+            .map_err(|e| anyhow!("failed to decode TreeState protobuf: {}", e))?;
+        let orchard_ct = tree_state.orchard_tree()
+            .map_err(|e| anyhow!("failed to parse orchard tree from TreeState: {}", e))?;
+        let frontier_root = orchard_ct.root();
+        let frontier = orchard_ct.to_frontier();
+        let nonempty_frontier = frontier.take()
+            .ok_or_else(|| anyhow!("empty orchard frontier — no orchard activity at snapshot height"))?;
+
+        // Generate witnesses from wallet DB shard data + frontier
+        let (wallet_db, _network) = open_wallet_db(&wallet_path_str, 0)?; // network_id not needed for tree ops
+        let positions: Vec<Position> = core_notes
+            .iter()
+            .map(|n| Position::from(n.position))
+            .collect();
+        let checkpoint_height = zcash_protocol::consensus::BlockHeight::from_u32(params.snapshot_height as u32);
+
+        let merkle_paths = wallet_db
+            .generate_orchard_witnesses_at_frontier(&positions, nonempty_frontier, checkpoint_height)
+            .map_err(|e| anyhow!("generate_orchard_witnesses_at_frontier failed: {}", e))?;
+
+        // Convert MerklePaths to WitnessData
+        let root_bytes = frontier_root.to_bytes().to_vec();
+        let witnesses: Vec<voting::WitnessData> = merkle_paths
+            .into_iter()
+            .zip(core_notes.iter())
+            .map(|(path, note): (incrementalmerkletree::MerklePath<MerkleHashOrchard, { orchard::NOTE_COMMITMENT_TREE_DEPTH as u8 }>, &voting::NoteInfo)| {
+                let auth_path: Vec<Vec<u8>> = path.path_elems()
+                    .iter()
+                    .map(|h: &MerkleHashOrchard| h.to_bytes().to_vec())
+                    .collect();
+                voting::WitnessData {
+                    note_commitment: note.commitment.clone(),
+                    position: note.position,
+                    root: root_bytes.clone(),
+                    auth_path,
+                }
+            })
+            .collect();
+
+        // Verify and cache in voting DB
+        handle.db.store_witnesses(&round_id_str, bundle_index, &witnesses)
+            .map_err(|e| anyhow!("store_witnesses failed: {}", e))?;
 
         let json_witnesses: Vec<JsonWitnessData> =
             witnesses.into_iter().map(Into::into).collect();
@@ -1243,8 +1389,8 @@ pub unsafe extern "C" fn zcashlc_voting_build_and_prove_delegation(
     round_id: *const u8,
     round_id_len: usize,
     bundle_index: u32,
-    wallet_db_path: *const u8,
-    wallet_db_path_len: usize,
+    notes_json: *const u8,
+    notes_json_len: usize,
     hotkey_raw_address: *const u8,
     hotkey_raw_address_len: usize,
     pir_server_url: *const u8,
@@ -1259,7 +1405,9 @@ pub unsafe extern "C" fn zcashlc_voting_build_and_prove_delegation(
         let handle =
             unsafe { db.as_ref() }.ok_or_else(|| anyhow!("VotingDatabaseHandle is null"))?;
         let round_id_str = unsafe { str_from_ptr(round_id, round_id_len) }?;
-        let wallet_path_str = unsafe { str_from_ptr(wallet_db_path, wallet_db_path_len) }?;
+        let notes_bytes = unsafe { bytes_from_ptr(notes_json, notes_json_len) };
+        let json_notes: Vec<JsonNoteInfo> = serde_json::from_slice(notes_bytes)?;
+        let core_notes: Vec<voting::NoteInfo> = json_notes.into_iter().map(Into::into).collect();
         let hotkey_addr = unsafe { bytes_from_ptr(hotkey_raw_address, hotkey_raw_address_len) };
         let pir_url = unsafe { str_from_ptr(pir_server_url, pir_server_url_len) }?;
 
@@ -1276,7 +1424,7 @@ pub unsafe extern "C" fn zcashlc_voting_build_and_prove_delegation(
             .build_and_prove_delegation(
                 &round_id_str,
                 bundle_index,
-                &wallet_path_str,
+                &core_notes,
                 hotkey_addr,
                 &pir_url,
                 network_id,
@@ -2034,8 +2182,11 @@ pub unsafe extern "C" fn zcashlc_voting_extract_nc_root(
 ) -> *mut crate::ffi::BoxedSlice {
     let res = catch_panic(|| {
         let bytes = unsafe { bytes_from_ptr(tree_state_bytes, tree_state_bytes_len) };
-        let nc_root = voting::extract_nc_root(bytes)
-            .map_err(|e| anyhow!("extract_nc_root failed: {}", e))?;
+        let tree_state = TreeState::decode(bytes)
+            .map_err(|e| anyhow!("failed to decode TreeState protobuf: {}", e))?;
+        let orchard_ct = tree_state.orchard_tree()
+            .map_err(|e| anyhow!("failed to parse orchard tree from TreeState: {}", e))?;
+        let nc_root = orchard_ct.root().to_bytes().to_vec();
         Ok(crate::ffi::BoxedSlice::some(nc_root))
     });
     unwrap_exc_or_null(res)

--- a/rust/src/voting.rs
+++ b/rust/src/voting.rs
@@ -1020,12 +1020,13 @@ pub unsafe extern "C" fn zcashlc_voting_delete_skipped_bundles(
 ///
 /// Returns JSON-encoded `Vec<NoteInfo>` as `*mut FfiBoxedSlice`, or null on error.
 ///
-/// `seed_fingerprint` and `account_index` are optional filters: pass null/0 to skip.
+/// `account_uuid` must be a non-null pointer to a 16-byte AccountUuid.
 ///
 /// # Safety
 ///
 /// - `db` must be a valid, non-null `VotingDatabaseHandle` pointer.
 /// - `wallet_db_path` must be a valid path for reads of `wallet_db_path_len` bytes.
+/// - `account_uuid` must be a valid pointer to 16 bytes.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn zcashlc_voting_get_wallet_notes(
     db: *mut VotingDatabaseHandle,
@@ -1033,9 +1034,8 @@ pub unsafe extern "C" fn zcashlc_voting_get_wallet_notes(
     wallet_db_path_len: usize,
     snapshot_height: u64,
     network_id: u32,
-    seed_fingerprint: *const u8,
-    seed_fingerprint_len: usize,
-    account_index: i64,
+    account_uuid: *const u8,
+    account_uuid_len: usize,
 ) -> *mut crate::ffi::BoxedSlice {
     let db = AssertUnwindSafe(db);
     let res = catch_panic(|| {
@@ -1043,32 +1043,17 @@ pub unsafe extern "C" fn zcashlc_voting_get_wallet_notes(
             unsafe { db.as_ref() }.ok_or_else(|| anyhow!("VotingDatabaseHandle is null"))?;
         let wallet_path_str = unsafe { str_from_ptr(wallet_db_path, wallet_db_path_len) }?;
 
-        let _seed_fp = if seed_fingerprint.is_null() || seed_fingerprint_len == 0 {
-            None
-        } else {
-            Some(unsafe { bytes_from_ptr(seed_fingerprint, seed_fingerprint_len) }.to_vec())
-        };
-        let acct_idx = if account_index < 0 {
-            None
-        } else {
-            Some(account_index as u32)
-        };
-
         let (wallet_db, network) = open_wallet_db(&wallet_path_str, network_id)?;
 
-        // Resolve the account UUID — use account_index to pick from the
-        // wallet's account list, or default to the first account.
         use zcash_client_backend::data_api::WalletRead;
-        let account_ids = wallet_db.get_account_ids()?;
-        let target_id = match acct_idx {
-            Some(idx) => account_ids
-                .get(idx as usize)
-                .copied()
-                .ok_or_else(|| anyhow!("account_index {} out of range (wallet has {} accounts)", idx, account_ids.len()))?,
-            None => *account_ids
-                .first()
-                .ok_or_else(|| anyhow!("no accounts in wallet"))?,
-        };
+        if account_uuid.is_null() || account_uuid_len != 16 {
+            return Err(anyhow!("account_uuid must be a non-null pointer to 16 bytes"));
+        }
+        let uuid_bytes = unsafe { bytes_from_ptr(account_uuid, account_uuid_len) };
+        let arr: [u8; 16] = uuid_bytes
+            .try_into()
+            .map_err(|_| anyhow!("account_uuid must be 16 bytes"))?;
+        let target_id = zcash_client_sqlite::AccountUuid::from_uuid(uuid::Uuid::from_bytes(arr));
         let account = wallet_db
             .get_account(target_id)?
             .ok_or_else(|| anyhow!("account not found"))?;

--- a/rust/src/voting.rs
+++ b/rust/src/voting.rs
@@ -1809,6 +1809,209 @@ pub unsafe extern "C" fn zcashlc_voting_mark_vote_submitted(
 }
 
 // =============================================================================
+// A2. VotingDatabase methods — Recovery state (TX hashes, bundles, share delegations, keystone sigs)
+// =============================================================================
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn zcashlc_voting_store_delegation_tx_hash(
+    db: *mut VotingDatabaseHandle,
+    round_id: *const u8,
+    round_id_len: usize,
+    bundle_index: u32,
+    tx_hash: *const u8,
+    tx_hash_len: usize,
+) -> i32 {
+    let db = AssertUnwindSafe(db);
+    let res = catch_panic(|| {
+        let handle = unsafe { db.as_ref() }.ok_or_else(|| anyhow!("VotingDatabaseHandle is null"))?;
+        let round_id_str = unsafe { str_from_ptr(round_id, round_id_len) }?;
+        let tx_hash_str = unsafe { str_from_ptr(tx_hash, tx_hash_len) }?;
+        handle.db.store_delegation_tx_hash(&round_id_str, bundle_index, &tx_hash_str)
+            .map_err(|e| anyhow!("{}", e))?;
+        Ok(0)
+    });
+    unwrap_exc_or(res, -1)
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn zcashlc_voting_get_delegation_tx_hash(
+    db: *mut VotingDatabaseHandle,
+    round_id: *const u8,
+    round_id_len: usize,
+    bundle_index: u32,
+) -> *mut crate::ffi::BoxedSlice {
+    let db = AssertUnwindSafe(db);
+    let res = catch_panic(|| {
+        let handle = unsafe { db.as_ref() }.ok_or_else(|| anyhow!("VotingDatabaseHandle is null"))?;
+        let round_id_str = unsafe { str_from_ptr(round_id, round_id_len) }?;
+        let hash = handle.db.get_delegation_tx_hash(&round_id_str, bundle_index)
+            .map_err(|e| anyhow!("{}", e))?;
+        json_to_boxed_slice(&hash)
+    });
+    unwrap_exc_or_null(res)
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn zcashlc_voting_store_vote_tx_hash(
+    db: *mut VotingDatabaseHandle,
+    round_id: *const u8,
+    round_id_len: usize,
+    bundle_index: u32,
+    proposal_id: u32,
+    tx_hash: *const u8,
+    tx_hash_len: usize,
+) -> i32 {
+    let db = AssertUnwindSafe(db);
+    let res = catch_panic(|| {
+        let handle = unsafe { db.as_ref() }.ok_or_else(|| anyhow!("VotingDatabaseHandle is null"))?;
+        let round_id_str = unsafe { str_from_ptr(round_id, round_id_len) }?;
+        let tx_hash_str = unsafe { str_from_ptr(tx_hash, tx_hash_len) }?;
+        handle.db.store_vote_tx_hash(&round_id_str, bundle_index, proposal_id, &tx_hash_str)
+            .map_err(|e| anyhow!("{}", e))?;
+        Ok(0)
+    });
+    unwrap_exc_or(res, -1)
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn zcashlc_voting_get_vote_tx_hash(
+    db: *mut VotingDatabaseHandle,
+    round_id: *const u8,
+    round_id_len: usize,
+    bundle_index: u32,
+    proposal_id: u32,
+) -> *mut crate::ffi::BoxedSlice {
+    let db = AssertUnwindSafe(db);
+    let res = catch_panic(|| {
+        let handle = unsafe { db.as_ref() }.ok_or_else(|| anyhow!("VotingDatabaseHandle is null"))?;
+        let round_id_str = unsafe { str_from_ptr(round_id, round_id_len) }?;
+        let hash = handle.db.get_vote_tx_hash(&round_id_str, bundle_index, proposal_id)
+            .map_err(|e| anyhow!("{}", e))?;
+        json_to_boxed_slice(&hash)
+    });
+    unwrap_exc_or_null(res)
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn zcashlc_voting_store_commitment_bundle(
+    db: *mut VotingDatabaseHandle,
+    round_id: *const u8,
+    round_id_len: usize,
+    bundle_index: u32,
+    proposal_id: u32,
+    bundle_json: *const u8,
+    bundle_json_len: usize,
+    vc_tree_position: u64,
+) -> i32 {
+    let db = AssertUnwindSafe(db);
+    let res = catch_panic(|| {
+        let handle = unsafe { db.as_ref() }.ok_or_else(|| anyhow!("VotingDatabaseHandle is null"))?;
+        let round_id_str = unsafe { str_from_ptr(round_id, round_id_len) }?;
+        let json_str = unsafe { str_from_ptr(bundle_json, bundle_json_len) }?;
+        handle.db.store_commitment_bundle(&round_id_str, bundle_index, proposal_id, &json_str, vc_tree_position)
+            .map_err(|e| anyhow!("{}", e))?;
+        Ok(0)
+    });
+    unwrap_exc_or(res, -1)
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn zcashlc_voting_get_commitment_bundle(
+    db: *mut VotingDatabaseHandle,
+    round_id: *const u8,
+    round_id_len: usize,
+    bundle_index: u32,
+    proposal_id: u32,
+) -> *mut crate::ffi::BoxedSlice {
+    let db = AssertUnwindSafe(db);
+    let res = catch_panic(|| {
+        let handle = unsafe { db.as_ref() }.ok_or_else(|| anyhow!("VotingDatabaseHandle is null"))?;
+        let round_id_str = unsafe { str_from_ptr(round_id, round_id_len) }?;
+        let result = handle.db.get_commitment_bundle(&round_id_str, bundle_index, proposal_id)
+            .map_err(|e| anyhow!("{}", e))?;
+        json_to_boxed_slice(&result)
+    });
+    unwrap_exc_or_null(res)
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn zcashlc_voting_store_keystone_signature(
+    db: *mut VotingDatabaseHandle,
+    round_id: *const u8,
+    round_id_len: usize,
+    bundle_index: u32,
+    sig: *const u8,
+    sig_len: usize,
+    sighash: *const u8,
+    sighash_len: usize,
+    rk: *const u8,
+    rk_len: usize,
+) -> i32 {
+    let db = AssertUnwindSafe(db);
+    let res = catch_panic(|| {
+        let handle = unsafe { db.as_ref() }.ok_or_else(|| anyhow!("VotingDatabaseHandle is null"))?;
+        let round_id_str = unsafe { str_from_ptr(round_id, round_id_len) }?;
+        let sig_bytes = unsafe { bytes_from_ptr(sig, sig_len) };
+        let sighash_bytes = unsafe { bytes_from_ptr(sighash, sighash_len) };
+        let rk_bytes = unsafe { bytes_from_ptr(rk, rk_len) };
+        handle.db.store_keystone_signature(&round_id_str, bundle_index, sig_bytes, sighash_bytes, rk_bytes)
+            .map_err(|e| anyhow!("{}", e))?;
+        Ok(0)
+    });
+    unwrap_exc_or(res, -1)
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn zcashlc_voting_get_keystone_signatures(
+    db: *mut VotingDatabaseHandle,
+    round_id: *const u8,
+    round_id_len: usize,
+) -> *mut crate::ffi::BoxedSlice {
+    let db = AssertUnwindSafe(db);
+    let res = catch_panic(|| {
+        let handle = unsafe { db.as_ref() }.ok_or_else(|| anyhow!("VotingDatabaseHandle is null"))?;
+        let round_id_str = unsafe { str_from_ptr(round_id, round_id_len) }?;
+        let sigs = handle.db.get_keystone_signatures(&round_id_str)
+            .map_err(|e| anyhow!("{}", e))?;
+
+        #[derive(serde::Serialize)]
+        struct SigOut {
+            bundle_index: u32,
+            sig: Vec<u8>,
+            sighash: Vec<u8>,
+            rk: Vec<u8>,
+        }
+
+        let out: Vec<SigOut> = sigs.into_iter().map(|s| SigOut {
+            bundle_index: s.bundle_index,
+            sig: s.sig,
+            sighash: s.sighash,
+            rk: s.rk,
+        }).collect();
+
+        json_to_boxed_slice(&out)
+    });
+    unwrap_exc_or_null(res)
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn zcashlc_voting_clear_recovery_state(
+    db: *mut VotingDatabaseHandle,
+    round_id: *const u8,
+    round_id_len: usize,
+) -> i32 {
+    let db = AssertUnwindSafe(db);
+    let res = catch_panic(|| {
+        let handle = unsafe { db.as_ref() }.ok_or_else(|| anyhow!("VotingDatabaseHandle is null"))?;
+        let round_id_str = unsafe { str_from_ptr(round_id, round_id_len) }?;
+        handle.db.clear_recovery_state(&round_id_str)
+            .map_err(|e| anyhow!("{}", e))?;
+        Ok(0)
+    });
+    unwrap_exc_or(res, -1)
+}
+
+// =============================================================================
 // B. VotingDatabase methods — Tree sync
 // =============================================================================
 

--- a/rust/src/voting.rs
+++ b/rust/src/voting.rs
@@ -1673,6 +1673,7 @@ pub unsafe extern "C" fn zcashlc_voting_build_vote_commitment(
     anchor_height: u32,
     progress_callback: Option<unsafe extern "C" fn(f64, *mut std::ffi::c_void)>,
     progress_context: *mut std::ffi::c_void,
+    single_share: u8,
 ) -> *mut crate::ffi::BoxedSlice {
     let db = AssertUnwindSafe(db);
     let progress_context = AssertUnwindSafe(progress_context);
@@ -1714,6 +1715,7 @@ pub unsafe extern "C" fn zcashlc_voting_build_vote_commitment(
                 &auth_path,
                 van_position,
                 anchor_height,
+                single_share != 0,
                 reporter.as_ref(),
             )
             .map_err(|e| anyhow!("build_vote_commitment failed: {}", e))?;
@@ -1744,6 +1746,7 @@ pub unsafe extern "C" fn zcashlc_voting_build_share_payloads(
     vote_decision: u32,
     num_options: u32,
     vc_tree_position: u64,
+    single_share: u8,
 ) -> *mut crate::ffi::BoxedSlice {
     let db = AssertUnwindSafe(db);
     let res = catch_panic(|| {
@@ -1768,6 +1771,7 @@ pub unsafe extern "C" fn zcashlc_voting_build_share_payloads(
                 vote_decision,
                 num_options,
                 vc_tree_position,
+                single_share != 0,
             )
             .map_err(|e| anyhow!("build_share_payloads failed: {}", e))?;
 

--- a/rust/src/voting.rs
+++ b/rust/src/voting.rs
@@ -2089,15 +2089,18 @@ pub unsafe extern "C" fn zcashlc_voting_generate_van_witness(
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn zcashlc_voting_reset_tree_client(
     db: *mut VotingDatabaseHandle,
+    round_id: *const u8,
+    round_id_len: usize,
 ) -> i32 {
     let db = AssertUnwindSafe(db);
     let res = catch_panic(|| {
         let handle =
             unsafe { db.as_ref() }.ok_or_else(|| anyhow!("VotingDatabaseHandle is null"))?;
+        let round_id_str = unsafe { str_from_ptr(round_id, round_id_len) }?;
 
         handle
             .tree_sync
-            .reset()
+            .reset(&round_id_str)
             .map_err(|e| anyhow!("reset_tree_client failed: {}", e))?;
         Ok(0)
     });

--- a/rust/src/voting.rs
+++ b/rust/src/voting.rs
@@ -649,6 +649,32 @@ pub unsafe extern "C" fn zcashlc_voting_db_free(ptr: *mut VotingDatabaseHandle) 
     }
 }
 
+/// Set the wallet identifier for all subsequent voting operations.
+/// Must be called after `zcashlc_voting_db_open` and before any round operations.
+///
+/// Returns 0 on success, -1 on error.
+///
+/// # Safety
+///
+/// - `db` must be a valid, non-null `VotingDatabaseHandle` pointer.
+/// - `wallet_id` must be valid for reads of `wallet_id_len` bytes.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn zcashlc_voting_set_wallet_id(
+    db: *mut VotingDatabaseHandle,
+    wallet_id: *const u8,
+    wallet_id_len: usize,
+) -> i32 {
+    let db = AssertUnwindSafe(db);
+    let res = catch_panic(|| {
+        let handle =
+            unsafe { db.as_ref() }.ok_or_else(|| anyhow!("VotingDatabaseHandle is null"))?;
+        let wallet_id_str = unsafe { str_from_ptr(wallet_id, wallet_id_len) }?;
+        handle.db.set_wallet_id(&wallet_id_str);
+        Ok(0)
+    });
+    unwrap_exc_or(res, -1)
+}
+
 // =============================================================================
 // Free functions for #[repr(C)] return types
 // =============================================================================
@@ -1020,13 +1046,13 @@ pub unsafe extern "C" fn zcashlc_voting_delete_skipped_bundles(
 ///
 /// Returns JSON-encoded `Vec<NoteInfo>` as `*mut FfiBoxedSlice`, or null on error.
 ///
-/// `account_uuid` must be a non-null pointer to a 16-byte AccountUuid.
+/// When `account_uuid` is non-null and 16 bytes, it is used directly to look up the
+/// account. Otherwise falls back to positional `account_index` into `get_account_ids()`.
 ///
 /// # Safety
 ///
 /// - `db` must be a valid, non-null `VotingDatabaseHandle` pointer.
 /// - `wallet_db_path` must be a valid path for reads of `wallet_db_path_len` bytes.
-/// - `account_uuid` must be a valid pointer to 16 bytes.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn zcashlc_voting_get_wallet_notes(
     db: *mut VotingDatabaseHandle,
@@ -1036,6 +1062,7 @@ pub unsafe extern "C" fn zcashlc_voting_get_wallet_notes(
     network_id: u32,
     account_uuid: *const u8,
     account_uuid_len: usize,
+    account_index: i64,
 ) -> *mut crate::ffi::BoxedSlice {
     let db = AssertUnwindSafe(db);
     let res = catch_panic(|| {
@@ -1046,14 +1073,30 @@ pub unsafe extern "C" fn zcashlc_voting_get_wallet_notes(
         let (wallet_db, network) = open_wallet_db(&wallet_path_str, network_id)?;
 
         use zcash_client_backend::data_api::WalletRead;
-        if account_uuid.is_null() || account_uuid_len != 16 {
-            return Err(anyhow!("account_uuid must be a non-null pointer to 16 bytes"));
-        }
-        let uuid_bytes = unsafe { bytes_from_ptr(account_uuid, account_uuid_len) };
-        let arr: [u8; 16] = uuid_bytes
-            .try_into()
-            .map_err(|_| anyhow!("account_uuid must be 16 bytes"))?;
-        let target_id = zcash_client_sqlite::AccountUuid::from_uuid(uuid::Uuid::from_bytes(arr));
+        let target_id = if !account_uuid.is_null() && account_uuid_len == 16 {
+            let uuid_bytes = unsafe { bytes_from_ptr(account_uuid, account_uuid_len) };
+            let arr: [u8; 16] = uuid_bytes
+                .try_into()
+                .map_err(|_| anyhow!("account_uuid must be 16 bytes"))?;
+            zcash_client_sqlite::AccountUuid::from_uuid(uuid::Uuid::from_bytes(arr))
+        } else {
+            // Legacy fallback: positional index into account list.
+            let acct_idx = if account_index < 0 {
+                None
+            } else {
+                Some(account_index as u32)
+            };
+            let account_ids = wallet_db.get_account_ids()?;
+            match acct_idx {
+                Some(idx) => account_ids
+                    .get(idx as usize)
+                    .copied()
+                    .ok_or_else(|| anyhow!("account_index {} out of range (wallet has {} accounts)", idx, account_ids.len()))?,
+                None => *account_ids
+                    .first()
+                    .ok_or_else(|| anyhow!("no accounts in wallet"))?,
+            }
+        };
         let account = wallet_db
             .get_account(target_id)?
             .ok_or_else(|| anyhow!("account not found"))?;
@@ -1315,10 +1358,11 @@ pub unsafe extern "C" fn zcashlc_voting_generate_note_witnesses(
         let core_notes: Vec<voting::NoteInfo> = json_notes.into_iter().map(Into::into).collect();
 
         // Load cached tree state from voting DB and parse frontier
+        let wallet_id = handle.db.wallet_id();
         let conn = handle.db.conn();
-        let tree_state_bytes = voting::storage::queries::load_tree_state(&conn, &round_id_str)
+        let tree_state_bytes = voting::storage::queries::load_tree_state(&conn, &round_id_str, &wallet_id)
             .map_err(|e| anyhow!("load_tree_state failed: {}", e))?;
-        let params = voting::storage::queries::load_round_params(&conn, &round_id_str)
+        let params = voting::storage::queries::load_round_params(&conn, &round_id_str, &wallet_id)
             .map_err(|e| anyhow!("load_round_params failed: {}", e))?;
         drop(conn);
 

--- a/rust/src/voting.rs
+++ b/rust/src/voting.rs
@@ -1108,8 +1108,8 @@ pub unsafe extern "C" fn zcashlc_voting_get_wallet_notes(
 
         let height = zcash_protocol::consensus::BlockHeight::from_u32(snapshot_height as u32);
         let received_notes = wallet_db
-            .get_orchard_notes_at_snapshot(account_uuid, height)
-            .map_err(|e| anyhow!("get_orchard_notes_at_snapshot failed: {}", e))?;
+            .get_orchard_notes_at_historical_height(account_uuid, height)
+            .map_err(|e| anyhow!("get_orchard_notes_at_historical_height failed: {}", e))?;
 
         let mut json_notes = Vec::with_capacity(received_notes.len());
         for rn in &received_notes {
@@ -1384,8 +1384,8 @@ pub unsafe extern "C" fn zcashlc_voting_generate_note_witnesses(
         let checkpoint_height = zcash_protocol::consensus::BlockHeight::from_u32(params.snapshot_height as u32);
 
         let merkle_paths = wallet_db
-            .generate_orchard_witnesses_at_frontier(&positions, nonempty_frontier, checkpoint_height)
-            .map_err(|e| anyhow!("generate_orchard_witnesses_at_frontier failed: {}", e))?;
+            .generate_orchard_witnesses_at_historical_height(&positions, nonempty_frontier, checkpoint_height)
+            .map_err(|e| anyhow!("generate_orchard_witnesses_at_historical_height failed: {}", e))?;
 
         // Convert MerklePaths to WitnessData
         let root_bytes = frontier_root.to_bytes().to_vec();

--- a/rust/src/voting.rs
+++ b/rust/src/voting.rs
@@ -27,7 +27,7 @@ use zcash_keys::keys::{UnifiedFullViewingKey, UnifiedSpendingKey};
 use zcash_protocol::consensus::{self, MAIN_NETWORK, Network, TEST_NETWORK};
 use zip32::{AccountId, Scope};
 
-use librustvoting as voting;
+use zcash_voting as voting;
 use voting::storage::VotingDb;
 use voting::tree_sync::VoteTreeSync;
 
@@ -65,7 +65,7 @@ fn json_to_boxed_slice<T: Serialize>(value: &T) -> anyhow::Result<*mut crate::ff
     Ok(crate::ffi::BoxedSlice::some(json))
 }
 
-/// Convert a librustzcash ReceivedNote (orchard) into librustvoting's NoteInfo.
+/// Convert a librustzcash ReceivedNote (orchard) into zcash_voting's NoteInfo.
 ///
 /// Requires the account's UFVK and network to compute the nullifier and
 /// encode the UFVK string.

--- a/rust/src/voting.rs
+++ b/rust/src/voting.rs
@@ -1,0 +1,2163 @@
+#![allow(clippy::missing_safety_doc)]
+
+//! Hand-rolled C FFI for the voting functionality.
+//!
+//! Follows the same patterns as `lib.rs` and `ffi.rs`:
+//! - Functions: `#[unsafe(no_mangle)] pub unsafe extern "C" fn zcashlc_voting_*()`
+//! - Error handling: `catch_panic()` + `unwrap_exc_or_null()` / `unwrap_exc_or()`
+//! - Opaque pointers: `Box::into_raw(Box::new(obj))` to create, `Box::from_raw(ptr)` to free
+//! - Complex types: JSON serialization via serde across the FFI boundary
+//! - Simple return types: `#[repr(C)]` structs
+
+use std::ffi::CString;
+use std::os::raw::c_char;
+use std::panic::AssertUnwindSafe;
+use std::sync::Arc;
+
+use anyhow::anyhow;
+use ffi_helpers::panic::catch_panic;
+use serde::{Deserialize, Serialize};
+use zcash_keys::keys::{UnifiedFullViewingKey, UnifiedSpendingKey};
+use zcash_protocol::consensus::{MAIN_NETWORK, TEST_NETWORK};
+use zip32::{AccountId, Scope};
+
+use librustvoting as voting;
+use voting::storage::VotingDb;
+use voting::tree_sync::VoteTreeSync;
+
+use crate::{unwrap_exc_or, unwrap_exc_or_null};
+
+// =============================================================================
+// Helper functions
+// =============================================================================
+
+/// Parse a UTF-8 string from raw pointer + length.
+///
+/// # Safety
+///
+/// - `ptr` must be non-null and valid for reads for `len` bytes.
+/// - The memory referenced by `ptr` must not be mutated for the duration of the call.
+unsafe fn str_from_ptr(ptr: *const u8, len: usize) -> anyhow::Result<String> {
+    let bytes = unsafe { std::slice::from_raw_parts(ptr, len) };
+    Ok(std::str::from_utf8(bytes)?.to_string())
+}
+
+/// Parse a byte slice from raw pointer + length.
+///
+/// # Safety
+///
+/// - `ptr` must be non-null and valid for reads for `len` bytes.
+/// - The memory referenced by `ptr` must not be mutated for the duration of the call.
+unsafe fn bytes_from_ptr<'a>(ptr: *const u8, len: usize) -> &'a [u8] {
+    unsafe { std::slice::from_raw_parts(ptr, len) }
+}
+
+
+/// Return JSON-serialized bytes as `*mut ffi::BoxedSlice`.
+fn json_to_boxed_slice<T: Serialize>(value: &T) -> anyhow::Result<*mut crate::ffi::BoxedSlice> {
+    let json = serde_json::to_vec(value)?;
+    Ok(crate::ffi::BoxedSlice::some(json))
+}
+
+// =============================================================================
+// Serde-compatible types for JSON serialization across the FFI boundary
+// =============================================================================
+
+/// JSON-serializable NoteInfo.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct JsonNoteInfo {
+    pub commitment: Vec<u8>,
+    pub nullifier: Vec<u8>,
+    pub value: u64,
+    pub position: u64,
+    pub diversifier: Vec<u8>,
+    pub rho: Vec<u8>,
+    pub rseed: Vec<u8>,
+    pub scope: u32,
+    pub ufvk_str: String,
+}
+
+impl From<JsonNoteInfo> for voting::NoteInfo {
+    fn from(n: JsonNoteInfo) -> Self {
+        Self {
+            commitment: n.commitment,
+            nullifier: n.nullifier,
+            value: n.value,
+            position: n.position,
+            diversifier: n.diversifier,
+            rho: n.rho,
+            rseed: n.rseed,
+            scope: n.scope,
+            ufvk_str: n.ufvk_str,
+        }
+    }
+}
+
+impl From<voting::NoteInfo> for JsonNoteInfo {
+    fn from(n: voting::NoteInfo) -> Self {
+        Self {
+            commitment: n.commitment,
+            nullifier: n.nullifier,
+            value: n.value,
+            position: n.position,
+            diversifier: n.diversifier,
+            rho: n.rho,
+            rseed: n.rseed,
+            scope: n.scope,
+            ufvk_str: n.ufvk_str,
+        }
+    }
+}
+
+/// JSON-serializable GovernancePczt.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct JsonGovernancePczt {
+    pub pczt_bytes: Vec<u8>,
+    pub rk: Vec<u8>,
+    pub alpha: Vec<u8>,
+    pub nf_signed: Vec<u8>,
+    pub cmx_new: Vec<u8>,
+    pub gov_nullifiers: Vec<Vec<u8>>,
+    pub van: Vec<u8>,
+    pub van_comm_rand: Vec<u8>,
+    pub dummy_nullifiers: Vec<Vec<u8>>,
+    pub rho_signed: Vec<u8>,
+    pub padded_cmx: Vec<Vec<u8>>,
+    pub rseed_signed: Vec<u8>,
+    pub rseed_output: Vec<u8>,
+    pub action_bytes: Vec<u8>,
+    pub action_index: u32,
+    /// padded_note_secrets: list of [rho, rseed] pairs
+    pub padded_note_secrets: Vec<Vec<Vec<u8>>>,
+    pub pczt_sighash: Vec<u8>,
+}
+
+impl From<voting::GovernancePczt> for JsonGovernancePczt {
+    fn from(g: voting::GovernancePczt) -> Self {
+        Self {
+            pczt_bytes: g.pczt_bytes,
+            rk: g.rk,
+            alpha: g.alpha,
+            nf_signed: g.nf_signed,
+            cmx_new: g.cmx_new,
+            gov_nullifiers: g.gov_nullifiers,
+            van: g.van,
+            van_comm_rand: g.van_comm_rand,
+            dummy_nullifiers: g.dummy_nullifiers,
+            rho_signed: g.rho_signed,
+            padded_cmx: g.padded_cmx,
+            rseed_signed: g.rseed_signed,
+            rseed_output: g.rseed_output,
+            action_bytes: g.action_bytes,
+            action_index: g.action_index as u32,
+            padded_note_secrets: g
+                .padded_note_secrets
+                .into_iter()
+                .map(|(rho, rseed)| vec![rho, rseed])
+                .collect(),
+            pczt_sighash: g.pczt_sighash,
+        }
+    }
+}
+
+/// JSON-serializable WitnessData.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct JsonWitnessData {
+    pub note_commitment: Vec<u8>,
+    pub position: u64,
+    pub root: Vec<u8>,
+    pub auth_path: Vec<Vec<u8>>,
+}
+
+impl From<voting::WitnessData> for JsonWitnessData {
+    fn from(w: voting::WitnessData) -> Self {
+        Self {
+            note_commitment: w.note_commitment,
+            position: w.position,
+            root: w.root,
+            auth_path: w.auth_path,
+        }
+    }
+}
+
+impl From<JsonWitnessData> for voting::WitnessData {
+    fn from(w: JsonWitnessData) -> Self {
+        Self {
+            note_commitment: w.note_commitment,
+            position: w.position,
+            root: w.root,
+            auth_path: w.auth_path,
+        }
+    }
+}
+
+/// JSON-serializable DelegationProofResult.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct JsonDelegationProofResult {
+    pub proof: Vec<u8>,
+    pub public_inputs: Vec<Vec<u8>>,
+    pub nf_signed: Vec<u8>,
+    pub cmx_new: Vec<u8>,
+    pub gov_nullifiers: Vec<Vec<u8>>,
+    pub van_comm: Vec<u8>,
+    pub rk: Vec<u8>,
+}
+
+impl From<voting::DelegationProofResult> for JsonDelegationProofResult {
+    fn from(r: voting::DelegationProofResult) -> Self {
+        Self {
+            proof: r.proof,
+            public_inputs: r.public_inputs,
+            nf_signed: r.nf_signed,
+            cmx_new: r.cmx_new,
+            gov_nullifiers: r.gov_nullifiers,
+            van_comm: r.van_comm,
+            rk: r.rk,
+        }
+    }
+}
+
+/// JSON-serializable DelegationSubmission.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct JsonDelegationSubmission {
+    pub rk: Vec<u8>,
+    pub spend_auth_sig: Vec<u8>,
+    pub sighash: Vec<u8>,
+    pub nf_signed: Vec<u8>,
+    pub cmx_new: Vec<u8>,
+    pub gov_comm: Vec<u8>,
+    pub gov_nullifiers: Vec<Vec<u8>>,
+    pub proof: Vec<u8>,
+    pub vote_round_id: String,
+}
+
+impl From<voting::DelegationSubmissionData> for JsonDelegationSubmission {
+    fn from(d: voting::DelegationSubmissionData) -> Self {
+        Self {
+            rk: d.rk,
+            spend_auth_sig: d.spend_auth_sig,
+            sighash: d.sighash,
+            nf_signed: d.nf_signed,
+            cmx_new: d.cmx_new,
+            gov_comm: d.gov_comm,
+            gov_nullifiers: d.gov_nullifiers,
+            proof: d.proof,
+            vote_round_id: d.vote_round_id,
+        }
+    }
+}
+
+/// JSON-serializable EncryptedShare.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct JsonEncryptedShare {
+    pub c1: Vec<u8>,
+    pub c2: Vec<u8>,
+    pub share_index: u32,
+    pub plaintext_value: u64,
+    pub randomness: Vec<u8>,
+}
+
+impl From<voting::EncryptedShare> for JsonEncryptedShare {
+    fn from(s: voting::EncryptedShare) -> Self {
+        Self {
+            c1: s.c1,
+            c2: s.c2,
+            share_index: s.share_index,
+            plaintext_value: s.plaintext_value,
+            randomness: s.randomness,
+        }
+    }
+}
+
+impl From<JsonEncryptedShare> for voting::EncryptedShare {
+    fn from(s: JsonEncryptedShare) -> Self {
+        Self {
+            c1: s.c1,
+            c2: s.c2,
+            share_index: s.share_index,
+            plaintext_value: s.plaintext_value,
+            randomness: s.randomness,
+        }
+    }
+}
+
+/// JSON-serializable VoteCommitmentBundle.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct JsonVoteCommitmentBundle {
+    pub van_nullifier: Vec<u8>,
+    pub vote_authority_note_new: Vec<u8>,
+    pub vote_commitment: Vec<u8>,
+    pub proposal_id: u32,
+    pub proof: Vec<u8>,
+    pub enc_shares: Vec<JsonEncryptedShare>,
+    pub anchor_height: u32,
+    pub vote_round_id: String,
+    pub shares_hash: Vec<u8>,
+    pub share_blinds: Vec<Vec<u8>>,
+    pub share_comms: Vec<Vec<u8>>,
+    pub r_vpk_bytes: Vec<u8>,
+    pub alpha_v: Vec<u8>,
+}
+
+impl From<voting::VoteCommitmentBundle> for JsonVoteCommitmentBundle {
+    fn from(b: voting::VoteCommitmentBundle) -> Self {
+        Self {
+            van_nullifier: b.van_nullifier,
+            vote_authority_note_new: b.vote_authority_note_new,
+            vote_commitment: b.vote_commitment,
+            proposal_id: b.proposal_id,
+            proof: b.proof,
+            enc_shares: b.enc_shares.into_iter().map(Into::into).collect(),
+            anchor_height: b.anchor_height,
+            vote_round_id: b.vote_round_id,
+            shares_hash: b.shares_hash,
+            share_blinds: b.share_blinds,
+            share_comms: b.share_comms,
+            r_vpk_bytes: b.r_vpk_bytes,
+            alpha_v: b.alpha_v,
+        }
+    }
+}
+
+impl From<JsonVoteCommitmentBundle> for voting::VoteCommitmentBundle {
+    fn from(b: JsonVoteCommitmentBundle) -> Self {
+        Self {
+            van_nullifier: b.van_nullifier,
+            vote_authority_note_new: b.vote_authority_note_new,
+            vote_commitment: b.vote_commitment,
+            proposal_id: b.proposal_id,
+            proof: b.proof,
+            enc_shares: b.enc_shares.into_iter().map(Into::into).collect(),
+            anchor_height: b.anchor_height,
+            vote_round_id: b.vote_round_id,
+            shares_hash: b.shares_hash,
+            share_blinds: b.share_blinds,
+            share_comms: b.share_comms,
+            r_vpk_bytes: b.r_vpk_bytes,
+            alpha_v: b.alpha_v,
+        }
+    }
+}
+
+/// JSON-serializable SharePayload.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct JsonSharePayload {
+    pub shares_hash: Vec<u8>,
+    pub proposal_id: u32,
+    pub vote_decision: u32,
+    pub enc_share: JsonEncryptedShare,
+    pub tree_position: u64,
+    pub all_enc_shares: Vec<JsonEncryptedShare>,
+    pub share_comms: Vec<Vec<u8>>,
+    pub primary_blind: Vec<u8>,
+}
+
+impl From<voting::SharePayload> for JsonSharePayload {
+    fn from(p: voting::SharePayload) -> Self {
+        Self {
+            shares_hash: p.shares_hash,
+            proposal_id: p.proposal_id,
+            vote_decision: p.vote_decision,
+            enc_share: p.enc_share.into(),
+            tree_position: p.tree_position,
+            all_enc_shares: p.all_enc_shares.into_iter().map(Into::into).collect(),
+            share_comms: p.share_comms,
+            primary_blind: p.primary_blind,
+        }
+    }
+}
+
+/// JSON-serializable CastVoteSignature.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct JsonCastVoteSignature {
+    pub vote_auth_sig: Vec<u8>,
+}
+
+impl From<voting::CastVoteSignature> for JsonCastVoteSignature {
+    fn from(s: voting::CastVoteSignature) -> Self {
+        Self {
+            vote_auth_sig: s.vote_auth_sig,
+        }
+    }
+}
+
+/// JSON-serializable DelegationInputs.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct JsonDelegationInputs {
+    pub fvk_bytes: Vec<u8>,
+    pub g_d_new_x: Vec<u8>,
+    pub pk_d_new_x: Vec<u8>,
+    pub hotkey_raw_address: Vec<u8>,
+    pub hotkey_public_key: Vec<u8>,
+    pub hotkey_address: String,
+    pub seed_fingerprint: Vec<u8>,
+}
+
+/// JSON-serializable VanWitness.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct JsonVanWitness {
+    pub auth_path: Vec<Vec<u8>>,
+    pub position: u32,
+    pub anchor_height: u32,
+}
+
+impl From<voting::tree_sync::VanWitness> for JsonVanWitness {
+    fn from(w: voting::tree_sync::VanWitness) -> Self {
+        Self {
+            auth_path: w.auth_path.iter().map(|h| h.to_vec()).collect(),
+            position: w.position,
+            anchor_height: w.anchor_height,
+        }
+    }
+}
+
+// =============================================================================
+// Progress callback
+// =============================================================================
+
+/// C function pointer type for proof progress reporting.
+pub type VotingProgressCallback =
+    unsafe extern "C" fn(progress: f64, context: *mut std::ffi::c_void);
+
+/// Bridges a C function pointer to the `ProofProgressReporter` trait.
+struct ProgressBridge {
+    callback: VotingProgressCallback,
+    context: *mut std::ffi::c_void,
+}
+
+// SAFETY: The caller guarantees the context pointer is valid for the duration
+// of the proof operation and that the callback is thread-safe.
+unsafe impl Send for ProgressBridge {}
+unsafe impl Sync for ProgressBridge {}
+
+impl voting::ProofProgressReporter for ProgressBridge {
+    fn on_progress(&self, progress: f64) {
+        unsafe { (self.callback)(progress, self.context) }
+    }
+}
+
+// =============================================================================
+// #[repr(C)] structs for simple, frequently-accessed return types
+// =============================================================================
+
+/// Round state returned by `zcashlc_voting_get_round_state`.
+#[repr(C)]
+pub struct FfiRoundState {
+    round_id: *mut c_char,
+    /// 0=Initialized, 1=HotkeyGenerated, 2=DelegationConstructed,
+    /// 3=DelegationProved, 4=VoteReady
+    phase: u32,
+    snapshot_height: u64,
+    /// Nullable — null if no hotkey has been generated yet.
+    hotkey_address: *mut c_char,
+    /// -1 if None, otherwise the delegated weight value.
+    delegated_weight: i64,
+    proof_generated: bool,
+}
+
+/// Voting hotkey returned by `zcashlc_voting_generate_hotkey`.
+#[repr(C)]
+pub struct FfiVotingHotkey {
+    secret_key: *mut u8,
+    secret_key_len: usize,
+    public_key: *mut u8,
+    public_key_len: usize,
+    address: *mut c_char,
+}
+
+/// Bundle setup result returned by `zcashlc_voting_setup_bundles`.
+#[repr(C)]
+pub struct FfiBundleSetupResult {
+    bundle_count: u32,
+    eligible_weight: u64,
+}
+
+/// Round summary for list display.
+#[repr(C)]
+pub struct FfiRoundSummary {
+    round_id: *mut c_char,
+    phase: u32,
+    snapshot_height: u64,
+    created_at: u64,
+}
+
+/// Array of round summaries.
+#[repr(C)]
+pub struct FfiRoundSummaries {
+    ptr: *mut FfiRoundSummary,
+    len: usize,
+}
+
+/// Vote record for a single proposal/bundle.
+#[repr(C)]
+pub struct FfiVoteRecord {
+    proposal_id: u32,
+    bundle_index: u32,
+    choice: u32,
+    submitted: bool,
+}
+
+/// Array of vote records.
+#[repr(C)]
+pub struct FfiVoteRecords {
+    ptr: *mut FfiVoteRecord,
+    len: usize,
+}
+
+// =============================================================================
+// A. VotingDatabase opaque handle
+// =============================================================================
+
+/// Opaque handle wrapping the voting database and tree sync state.
+pub struct VotingDatabaseHandle {
+    db: Arc<VotingDb>,
+    tree_sync: VoteTreeSync,
+}
+
+/// Open a voting database at the given path.
+///
+/// Returns an opaque `*mut VotingDatabaseHandle` on success, or null on error.
+///
+/// # Safety
+///
+/// - `path` must be non-null and valid for reads for `path_len` bytes.
+/// - The memory referenced by `path` must not be mutated for the duration of the call.
+/// - Call `zcashlc_voting_db_free` to free the returned handle.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn zcashlc_voting_db_open(
+    path: *const u8,
+    path_len: usize,
+) -> *mut VotingDatabaseHandle {
+    let res = catch_panic(|| {
+        let path_str = unsafe { str_from_ptr(path, path_len) }?;
+        let db = VotingDb::open(&path_str)
+            .map_err(|e| anyhow!("Error opening voting database: {}", e))?;
+        Ok(Box::into_raw(Box::new(VotingDatabaseHandle {
+            db: Arc::new(db),
+            tree_sync: VoteTreeSync::new(),
+        })))
+    });
+    unwrap_exc_or_null(res)
+}
+
+/// Free a VotingDatabaseHandle.
+///
+/// # Safety
+///
+/// - If `ptr` is non-null, it must be a pointer previously returned by
+///   `zcashlc_voting_db_open` that has not already been freed.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn zcashlc_voting_db_free(ptr: *mut VotingDatabaseHandle) {
+    if !ptr.is_null() {
+        let s: Box<VotingDatabaseHandle> = unsafe { Box::from_raw(ptr) };
+        drop(s);
+    }
+}
+
+// =============================================================================
+// Free functions for #[repr(C)] return types
+// =============================================================================
+
+/// Free an `FfiRoundState` value.
+///
+/// # Safety
+///
+/// - `ptr` must be non-null and must point to a struct returned by
+///   `zcashlc_voting_get_round_state`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn zcashlc_voting_free_round_state(ptr: *mut FfiRoundState) {
+    if !ptr.is_null() {
+        let s: Box<FfiRoundState> = unsafe { Box::from_raw(ptr) };
+        if !s.round_id.is_null() {
+            drop(unsafe { CString::from_raw(s.round_id) });
+        }
+        if !s.hotkey_address.is_null() {
+            drop(unsafe { CString::from_raw(s.hotkey_address) });
+        }
+        drop(s);
+    }
+}
+
+/// Free an `FfiVotingHotkey` value.
+///
+/// # Safety
+///
+/// - `ptr` must be non-null and must point to a struct returned by
+///   `zcashlc_voting_generate_hotkey` or `zcashlc_voting_generate_hotkey_standalone`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn zcashlc_voting_free_hotkey(ptr: *mut FfiVotingHotkey) {
+    if !ptr.is_null() {
+        let s: Box<FfiVotingHotkey> = unsafe { Box::from_raw(ptr) };
+        if !s.secret_key.is_null() {
+            crate::free_ptr_from_vec(s.secret_key, s.secret_key_len);
+        }
+        if !s.public_key.is_null() {
+            crate::free_ptr_from_vec(s.public_key, s.public_key_len);
+        }
+        if !s.address.is_null() {
+            drop(unsafe { CString::from_raw(s.address) });
+        }
+        drop(s);
+    }
+}
+
+/// Free an `FfiBundleSetupResult` value.
+///
+/// # Safety
+///
+/// - `ptr` must be non-null and must point to a struct returned by
+///   `zcashlc_voting_setup_bundles`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn zcashlc_voting_free_bundle_setup_result(ptr: *mut FfiBundleSetupResult) {
+    if !ptr.is_null() {
+        let s: Box<FfiBundleSetupResult> = unsafe { Box::from_raw(ptr) };
+        drop(s);
+    }
+}
+
+/// Free an `FfiRoundSummaries` value.
+///
+/// # Safety
+///
+/// - `ptr` must be non-null and must point to a struct returned by
+///   `zcashlc_voting_list_rounds`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn zcashlc_voting_free_round_summaries(ptr: *mut FfiRoundSummaries) {
+    if !ptr.is_null() {
+        let s: Box<FfiRoundSummaries> = unsafe { Box::from_raw(ptr) };
+        if !s.ptr.is_null() {
+            let summaries =
+                unsafe { Box::from_raw(std::ptr::slice_from_raw_parts_mut(s.ptr, s.len)) };
+            for summary in summaries.iter() {
+                if !summary.round_id.is_null() {
+                    drop(unsafe { CString::from_raw(summary.round_id) });
+                }
+            }
+            drop(summaries);
+        }
+        drop(s);
+    }
+}
+
+/// Free an `FfiVoteRecords` value.
+///
+/// # Safety
+///
+/// - `ptr` must be non-null and must point to a struct returned by
+///   `zcashlc_voting_get_votes`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn zcashlc_voting_free_vote_records(ptr: *mut FfiVoteRecords) {
+    if !ptr.is_null() {
+        let s: Box<FfiVoteRecords> = unsafe { Box::from_raw(ptr) };
+        if !s.ptr.is_null() {
+            let records =
+                unsafe { Box::from_raw(std::ptr::slice_from_raw_parts_mut(s.ptr, s.len)) };
+            drop(records);
+        }
+        drop(s);
+    }
+}
+
+// =============================================================================
+// B. VotingDatabase methods — Round management
+// =============================================================================
+
+/// Initialize a voting round.
+///
+/// Returns 0 on success, -1 on error.
+///
+/// # Safety
+///
+/// - `db` must be a valid, non-null `VotingDatabaseHandle` pointer.
+/// - String/byte parameters must be valid for their stated lengths.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn zcashlc_voting_init_round(
+    db: *mut VotingDatabaseHandle,
+    round_id: *const u8,
+    round_id_len: usize,
+    snapshot_height: u64,
+    ea_pk: *const u8,
+    ea_pk_len: usize,
+    nc_root: *const u8,
+    nc_root_len: usize,
+    nullifier_imt_root: *const u8,
+    nullifier_imt_root_len: usize,
+    session_json: *const u8,
+    session_json_len: usize,
+) -> i32 {
+    let db = AssertUnwindSafe(db);
+    let res = catch_panic(|| {
+        let handle = unsafe { db.as_ref() }
+            .ok_or_else(|| anyhow!("VotingDatabaseHandle is null"))?;
+        let round_id_str = unsafe { str_from_ptr(round_id, round_id_len) }?;
+        let ea_pk_bytes = unsafe { bytes_from_ptr(ea_pk, ea_pk_len) }.to_vec();
+        let nc_root_bytes = unsafe { bytes_from_ptr(nc_root, nc_root_len) }.to_vec();
+        let nullifier_imt_root_bytes =
+            unsafe { bytes_from_ptr(nullifier_imt_root, nullifier_imt_root_len) }.to_vec();
+
+        let session = if session_json.is_null() || session_json_len == 0 {
+            None
+        } else {
+            Some(unsafe { str_from_ptr(session_json, session_json_len) }?)
+        };
+
+        let params = voting::VotingRoundParams {
+            vote_round_id: round_id_str,
+            snapshot_height,
+            ea_pk: ea_pk_bytes,
+            nc_root: nc_root_bytes,
+            nullifier_imt_root: nullifier_imt_root_bytes,
+        };
+
+        handle
+            .db
+            .init_round(&params, session.as_deref())
+            .map_err(|e| anyhow!("init_round failed: {}", e))?;
+        Ok(0)
+    });
+    unwrap_exc_or(res, -1)
+}
+
+/// Get the state of a voting round.
+///
+/// Returns a pointer to `FfiRoundState` on success, or null on error.
+/// Call `zcashlc_voting_free_round_state` to free the returned pointer.
+///
+/// # Safety
+///
+/// - `db` must be a valid, non-null `VotingDatabaseHandle` pointer.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn zcashlc_voting_get_round_state(
+    db: *mut VotingDatabaseHandle,
+    round_id: *const u8,
+    round_id_len: usize,
+) -> *mut FfiRoundState {
+    let db = AssertUnwindSafe(db);
+    let res = catch_panic(|| {
+        let handle = unsafe { db.as_ref() }
+            .ok_or_else(|| anyhow!("VotingDatabaseHandle is null"))?;
+        let round_id_str = unsafe { str_from_ptr(round_id, round_id_len) }?;
+
+        let state = handle
+            .db
+            .get_round_state(&round_id_str)
+            .map_err(|e| anyhow!("get_round_state failed: {}", e))?;
+
+        let phase = match state.phase {
+            voting::storage::RoundPhase::Initialized => 0,
+            voting::storage::RoundPhase::HotkeyGenerated => 1,
+            voting::storage::RoundPhase::DelegationConstructed => 2,
+            voting::storage::RoundPhase::DelegationProved => 3,
+            voting::storage::RoundPhase::VoteReady => 4,
+        };
+
+        let ffi_state = FfiRoundState {
+            round_id: CString::new(state.round_id)
+                .map_err(|e| anyhow!("invalid round_id string: {}", e))?
+                .into_raw(),
+            phase,
+            snapshot_height: state.snapshot_height,
+            hotkey_address: match state.hotkey_address {
+                Some(addr) => CString::new(addr)
+                    .map_err(|e| anyhow!("invalid hotkey_address string: {}", e))?
+                    .into_raw(),
+                None => std::ptr::null_mut(),
+            },
+            delegated_weight: state.delegated_weight.map_or(-1, |w| w as i64),
+            proof_generated: state.proof_generated,
+        };
+
+        Ok(Box::into_raw(Box::new(ffi_state)))
+    });
+    unwrap_exc_or_null(res)
+}
+
+/// List all voting rounds.
+///
+/// Returns a pointer to `FfiRoundSummaries` on success, or null on error.
+/// Call `zcashlc_voting_free_round_summaries` to free the returned pointer.
+///
+/// # Safety
+///
+/// - `db` must be a valid, non-null `VotingDatabaseHandle` pointer.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn zcashlc_voting_list_rounds(
+    db: *mut VotingDatabaseHandle,
+) -> *mut FfiRoundSummaries {
+    let db = AssertUnwindSafe(db);
+    let res = catch_panic(|| {
+        let handle =
+            unsafe { db.as_ref() }.ok_or_else(|| anyhow!("VotingDatabaseHandle is null"))?;
+
+        let rounds = handle
+            .db
+            .list_rounds()
+            .map_err(|e| anyhow!("list_rounds failed: {}", e))?;
+
+        let ffi_rounds: Vec<FfiRoundSummary> = rounds
+            .into_iter()
+            .map(|s| {
+                let phase = match s.phase {
+                    voting::storage::RoundPhase::Initialized => 0,
+                    voting::storage::RoundPhase::HotkeyGenerated => 1,
+                    voting::storage::RoundPhase::DelegationConstructed => 2,
+                    voting::storage::RoundPhase::DelegationProved => 3,
+                    voting::storage::RoundPhase::VoteReady => 4,
+                };
+                FfiRoundSummary {
+                    round_id: CString::new(s.round_id).unwrap().into_raw(),
+                    phase,
+                    snapshot_height: s.snapshot_height,
+                    created_at: s.created_at,
+                }
+            })
+            .collect();
+
+        let (ptr, len) = crate::ptr_from_vec(ffi_rounds);
+        Ok(Box::into_raw(Box::new(FfiRoundSummaries { ptr, len })))
+    });
+    unwrap_exc_or_null(res)
+}
+
+/// Get vote records for a round.
+///
+/// Returns a pointer to `FfiVoteRecords` on success, or null on error.
+/// Call `zcashlc_voting_free_vote_records` to free the returned pointer.
+///
+/// # Safety
+///
+/// - `db` must be a valid, non-null `VotingDatabaseHandle` pointer.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn zcashlc_voting_get_votes(
+    db: *mut VotingDatabaseHandle,
+    round_id: *const u8,
+    round_id_len: usize,
+) -> *mut FfiVoteRecords {
+    let db = AssertUnwindSafe(db);
+    let res = catch_panic(|| {
+        let handle =
+            unsafe { db.as_ref() }.ok_or_else(|| anyhow!("VotingDatabaseHandle is null"))?;
+        let round_id_str = unsafe { str_from_ptr(round_id, round_id_len) }?;
+
+        let votes = handle
+            .db
+            .get_votes(&round_id_str)
+            .map_err(|e| anyhow!("get_votes failed: {}", e))?;
+
+        let ffi_votes: Vec<FfiVoteRecord> = votes
+            .into_iter()
+            .map(|v| FfiVoteRecord {
+                proposal_id: v.proposal_id,
+                bundle_index: v.bundle_index,
+                choice: v.choice,
+                submitted: v.submitted,
+            })
+            .collect();
+
+        let (ptr, len) = crate::ptr_from_vec(ffi_votes);
+        Ok(Box::into_raw(Box::new(FfiVoteRecords { ptr, len })))
+    });
+    unwrap_exc_or_null(res)
+}
+
+/// Clear all data for a voting round.
+///
+/// Returns 0 on success, -1 on error.
+///
+/// # Safety
+///
+/// - `db` must be a valid, non-null `VotingDatabaseHandle` pointer.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn zcashlc_voting_clear_round(
+    db: *mut VotingDatabaseHandle,
+    round_id: *const u8,
+    round_id_len: usize,
+) -> i32 {
+    let db = AssertUnwindSafe(db);
+    let res = catch_panic(|| {
+        let handle =
+            unsafe { db.as_ref() }.ok_or_else(|| anyhow!("VotingDatabaseHandle is null"))?;
+        let round_id_str = unsafe { str_from_ptr(round_id, round_id_len) }?;
+
+        handle
+            .db
+            .clear_round(&round_id_str)
+            .map_err(|e| anyhow!("clear_round failed: {}", e))?;
+        Ok(0)
+    });
+    unwrap_exc_or(res, -1)
+}
+
+/// Delete bundle rows with index >= `keep_count`, removing skipped bundles.
+///
+/// Returns the number of deleted rows on success (>= 0), or -1 on error.
+///
+/// # Safety
+///
+/// - `db` must be a valid, non-null `VotingDatabaseHandle` pointer.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn zcashlc_voting_delete_skipped_bundles(
+    db: *mut VotingDatabaseHandle,
+    round_id: *const u8,
+    round_id_len: usize,
+    keep_count: u32,
+) -> i64 {
+    let db = AssertUnwindSafe(db);
+    let res = catch_panic(|| {
+        let handle =
+            unsafe { db.as_ref() }.ok_or_else(|| anyhow!("VotingDatabaseHandle is null"))?;
+        let round_id_str = unsafe { str_from_ptr(round_id, round_id_len) }?;
+
+        let deleted = handle
+            .db
+            .delete_skipped_bundles(&round_id_str, keep_count)
+            .map_err(|e| anyhow!("delete_skipped_bundles failed: {}", e))?;
+        Ok(deleted as i64)
+    });
+    unwrap_exc_or(res, -1)
+}
+
+// =============================================================================
+// B. VotingDatabase methods — Wallet notes
+// =============================================================================
+
+/// Get wallet notes eligible for voting at the given snapshot height.
+///
+/// Returns JSON-encoded `Vec<NoteInfo>` as `*mut FfiBoxedSlice`, or null on error.
+///
+/// `seed_fingerprint` and `account_index` are optional filters: pass null/0 to skip.
+///
+/// # Safety
+///
+/// - `db` must be a valid, non-null `VotingDatabaseHandle` pointer.
+/// - `wallet_db_path` must be a valid path for reads of `wallet_db_path_len` bytes.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn zcashlc_voting_get_wallet_notes(
+    db: *mut VotingDatabaseHandle,
+    wallet_db_path: *const u8,
+    wallet_db_path_len: usize,
+    snapshot_height: u64,
+    network_id: u32,
+    seed_fingerprint: *const u8,
+    seed_fingerprint_len: usize,
+    account_index: i64,
+) -> *mut crate::ffi::BoxedSlice {
+    let db = AssertUnwindSafe(db);
+    let res = catch_panic(|| {
+        let handle =
+            unsafe { db.as_ref() }.ok_or_else(|| anyhow!("VotingDatabaseHandle is null"))?;
+        let wallet_path_str = unsafe { str_from_ptr(wallet_db_path, wallet_db_path_len) }?;
+
+        let seed_fp = if seed_fingerprint.is_null() || seed_fingerprint_len == 0 {
+            None
+        } else {
+            Some(unsafe { bytes_from_ptr(seed_fingerprint, seed_fingerprint_len) }.to_vec())
+        };
+        let acct_idx = if account_index < 0 {
+            None
+        } else {
+            Some(account_index as u32)
+        };
+
+        let notes = handle
+            .db
+            .get_wallet_notes(
+                &wallet_path_str,
+                snapshot_height,
+                network_id,
+                seed_fp.as_deref(),
+                acct_idx,
+            )
+            .map_err(|e| anyhow!("get_wallet_notes failed: {}", e))?;
+
+        let json_notes: Vec<JsonNoteInfo> = notes.into_iter().map(Into::into).collect();
+        json_to_boxed_slice(&json_notes)
+    });
+    unwrap_exc_or_null(res)
+}
+
+// =============================================================================
+// B. VotingDatabase methods — Delegation setup
+// =============================================================================
+
+/// Generate a voting hotkey for a round.
+///
+/// Returns a pointer to `FfiVotingHotkey` on success, or null on error.
+/// Call `zcashlc_voting_free_hotkey` to free the returned pointer.
+///
+/// # Safety
+///
+/// - `db` must be a valid, non-null `VotingDatabaseHandle` pointer.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn zcashlc_voting_generate_hotkey(
+    db: *mut VotingDatabaseHandle,
+    round_id: *const u8,
+    round_id_len: usize,
+    seed: *const u8,
+    seed_len: usize,
+) -> *mut FfiVotingHotkey {
+    let db = AssertUnwindSafe(db);
+    let res = catch_panic(|| {
+        let handle =
+            unsafe { db.as_ref() }.ok_or_else(|| anyhow!("VotingDatabaseHandle is null"))?;
+        let round_id_str = unsafe { str_from_ptr(round_id, round_id_len) }?;
+        let seed_bytes = unsafe { bytes_from_ptr(seed, seed_len) };
+
+        let hotkey = handle
+            .db
+            .generate_hotkey(&round_id_str, seed_bytes)
+            .map_err(|e| anyhow!("generate_hotkey failed: {}", e))?;
+
+        Ok(Box::into_raw(Box::new(voting_hotkey_to_ffi(hotkey))))
+    });
+    unwrap_exc_or_null(res)
+}
+
+/// Set up note bundles for a voting round.
+///
+/// `notes_json` is a JSON-encoded `Vec<NoteInfo>`.
+///
+/// Returns a pointer to `FfiBundleSetupResult` on success, or null on error.
+/// Call `zcashlc_voting_free_bundle_setup_result` to free the returned pointer.
+///
+/// # Safety
+///
+/// - `db` must be a valid, non-null `VotingDatabaseHandle` pointer.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn zcashlc_voting_setup_bundles(
+    db: *mut VotingDatabaseHandle,
+    round_id: *const u8,
+    round_id_len: usize,
+    notes_json: *const u8,
+    notes_json_len: usize,
+) -> *mut FfiBundleSetupResult {
+    let db = AssertUnwindSafe(db);
+    let res = catch_panic(|| {
+        let handle =
+            unsafe { db.as_ref() }.ok_or_else(|| anyhow!("VotingDatabaseHandle is null"))?;
+        let round_id_str = unsafe { str_from_ptr(round_id, round_id_len) }?;
+        let notes_bytes = unsafe { bytes_from_ptr(notes_json, notes_json_len) };
+        let json_notes: Vec<JsonNoteInfo> = serde_json::from_slice(notes_bytes)?;
+        let core_notes: Vec<voting::NoteInfo> = json_notes.into_iter().map(Into::into).collect();
+
+        let (count, weight) = handle
+            .db
+            .setup_bundles(&round_id_str, &core_notes)
+            .map_err(|e| anyhow!("setup_bundles failed: {}", e))?;
+
+        Ok(Box::into_raw(Box::new(FfiBundleSetupResult {
+            bundle_count: count,
+            eligible_weight: weight,
+        })))
+    });
+    unwrap_exc_or_null(res)
+}
+
+/// Get the number of bundles for a round.
+///
+/// Returns the bundle count on success (>= 0), or -1 on error.
+///
+/// # Safety
+///
+/// - `db` must be a valid, non-null `VotingDatabaseHandle` pointer.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn zcashlc_voting_get_bundle_count(
+    db: *mut VotingDatabaseHandle,
+    round_id: *const u8,
+    round_id_len: usize,
+) -> i64 {
+    let db = AssertUnwindSafe(db);
+    let res = catch_panic(|| {
+        let handle =
+            unsafe { db.as_ref() }.ok_or_else(|| anyhow!("VotingDatabaseHandle is null"))?;
+        let round_id_str = unsafe { str_from_ptr(round_id, round_id_len) }?;
+
+        let count = handle
+            .db
+            .get_bundle_count(&round_id_str)
+            .map_err(|e| anyhow!("get_bundle_count failed: {}", e))?;
+        Ok(count as i64)
+    });
+    unwrap_exc_or(res, -1)
+}
+
+/// Build a governance PCZT for a bundle.
+///
+/// `notes_json` is a JSON-encoded `Vec<NoteInfo>`.
+///
+/// Returns JSON-encoded `GovernancePczt` as `*mut FfiBoxedSlice`, or null on error.
+///
+/// # Safety
+///
+/// - `db` must be a valid, non-null `VotingDatabaseHandle` pointer.
+/// - All pointer/length pairs must be valid.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn zcashlc_voting_build_governance_pczt(
+    db: *mut VotingDatabaseHandle,
+    round_id: *const u8,
+    round_id_len: usize,
+    bundle_index: u32,
+    notes_json: *const u8,
+    notes_json_len: usize,
+    fvk_bytes: *const u8,
+    fvk_bytes_len: usize,
+    hotkey_raw_address: *const u8,
+    hotkey_raw_address_len: usize,
+    consensus_branch_id: u32,
+    coin_type: u32,
+    seed_fingerprint: *const u8,
+    seed_fingerprint_len: usize,
+    account_index: u32,
+    round_name: *const u8,
+    round_name_len: usize,
+    address_index: u32,
+) -> *mut crate::ffi::BoxedSlice {
+    let db = AssertUnwindSafe(db);
+    let res = catch_panic(|| {
+        let handle =
+            unsafe { db.as_ref() }.ok_or_else(|| anyhow!("VotingDatabaseHandle is null"))?;
+        let round_id_str = unsafe { str_from_ptr(round_id, round_id_len) }?;
+        let notes_bytes = unsafe { bytes_from_ptr(notes_json, notes_json_len) };
+        let json_notes: Vec<JsonNoteInfo> = serde_json::from_slice(notes_bytes)?;
+        let core_notes: Vec<voting::NoteInfo> = json_notes.into_iter().map(Into::into).collect();
+        let fvk = unsafe { bytes_from_ptr(fvk_bytes, fvk_bytes_len) };
+        let hotkey_addr = unsafe { bytes_from_ptr(hotkey_raw_address, hotkey_raw_address_len) };
+        let seed_fp_bytes = unsafe { bytes_from_ptr(seed_fingerprint, seed_fingerprint_len) };
+        let seed_fp_32: [u8; 32] = seed_fp_bytes.try_into().map_err(|_| {
+            anyhow!("seed_fingerprint must be 32 bytes, got {}", seed_fp_bytes.len())
+        })?;
+        let round_name_str = unsafe { str_from_ptr(round_name, round_name_len) }?;
+
+        let pczt = handle
+            .db
+            .build_governance_pczt(
+                &round_id_str,
+                bundle_index,
+                &core_notes,
+                fvk,
+                hotkey_addr,
+                consensus_branch_id,
+                coin_type,
+                &seed_fp_32,
+                account_index,
+                &round_name_str,
+                address_index,
+            )
+            .map_err(|e| anyhow!("build_governance_pczt failed: {}", e))?;
+
+        let json_pczt: JsonGovernancePczt = pczt.into();
+        json_to_boxed_slice(&json_pczt)
+    });
+    unwrap_exc_or_null(res)
+}
+
+/// Store a tree state for witness generation.
+///
+/// Returns 0 on success, -1 on error.
+///
+/// # Safety
+///
+/// - `db` must be a valid, non-null `VotingDatabaseHandle` pointer.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn zcashlc_voting_store_tree_state(
+    db: *mut VotingDatabaseHandle,
+    round_id: *const u8,
+    round_id_len: usize,
+    tree_state_bytes: *const u8,
+    tree_state_bytes_len: usize,
+) -> i32 {
+    let db = AssertUnwindSafe(db);
+    let res = catch_panic(|| {
+        let handle =
+            unsafe { db.as_ref() }.ok_or_else(|| anyhow!("VotingDatabaseHandle is null"))?;
+        let round_id_str = unsafe { str_from_ptr(round_id, round_id_len) }?;
+        let ts_bytes = unsafe { bytes_from_ptr(tree_state_bytes, tree_state_bytes_len) };
+
+        handle
+            .db
+            .store_tree_state(&round_id_str, ts_bytes)
+            .map_err(|e| anyhow!("store_tree_state failed: {}", e))?;
+        Ok(0)
+    });
+    unwrap_exc_or(res, -1)
+}
+
+/// Generate Merkle inclusion witnesses for notes in a bundle.
+///
+/// `notes_json` is a JSON-encoded `Vec<NoteInfo>`.
+///
+/// Returns JSON-encoded `Vec<WitnessData>` as `*mut FfiBoxedSlice`, or null on error.
+///
+/// # Safety
+///
+/// - `db` must be a valid, non-null `VotingDatabaseHandle` pointer.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn zcashlc_voting_generate_note_witnesses(
+    db: *mut VotingDatabaseHandle,
+    round_id: *const u8,
+    round_id_len: usize,
+    bundle_index: u32,
+    wallet_db_path: *const u8,
+    wallet_db_path_len: usize,
+    notes_json: *const u8,
+    notes_json_len: usize,
+) -> *mut crate::ffi::BoxedSlice {
+    let db = AssertUnwindSafe(db);
+    let res = catch_panic(|| {
+        let handle =
+            unsafe { db.as_ref() }.ok_or_else(|| anyhow!("VotingDatabaseHandle is null"))?;
+        let round_id_str = unsafe { str_from_ptr(round_id, round_id_len) }?;
+        let wallet_path_str = unsafe { str_from_ptr(wallet_db_path, wallet_db_path_len) }?;
+        let notes_bytes = unsafe { bytes_from_ptr(notes_json, notes_json_len) };
+        let json_notes: Vec<JsonNoteInfo> = serde_json::from_slice(notes_bytes)?;
+        let core_notes: Vec<voting::NoteInfo> = json_notes.into_iter().map(Into::into).collect();
+
+        let witnesses = handle
+            .db
+            .generate_note_witnesses(&round_id_str, bundle_index, &wallet_path_str, &core_notes)
+            .map_err(|e| anyhow!("generate_note_witnesses failed: {}", e))?;
+
+        let json_witnesses: Vec<JsonWitnessData> =
+            witnesses.into_iter().map(Into::into).collect();
+        json_to_boxed_slice(&json_witnesses)
+    });
+    unwrap_exc_or_null(res)
+}
+
+// =============================================================================
+// B. VotingDatabase methods — Delegation proof
+// =============================================================================
+
+/// Build and prove the real delegation ZKP (#1). Long-running.
+///
+/// Returns JSON-encoded `DelegationProofResult` as `*mut FfiBoxedSlice`, or null on error.
+///
+/// # Safety
+///
+/// - `db` must be a valid, non-null `VotingDatabaseHandle` pointer.
+/// - `progress_callback` must be a valid function pointer (or null to skip progress).
+/// - `progress_context` is passed through to the callback unchanged.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn zcashlc_voting_build_and_prove_delegation(
+    db: *mut VotingDatabaseHandle,
+    round_id: *const u8,
+    round_id_len: usize,
+    bundle_index: u32,
+    wallet_db_path: *const u8,
+    wallet_db_path_len: usize,
+    hotkey_raw_address: *const u8,
+    hotkey_raw_address_len: usize,
+    pir_server_url: *const u8,
+    pir_server_url_len: usize,
+    network_id: u32,
+    progress_callback: Option<unsafe extern "C" fn(f64, *mut std::ffi::c_void)>,
+    progress_context: *mut std::ffi::c_void,
+) -> *mut crate::ffi::BoxedSlice {
+    let db = AssertUnwindSafe(db);
+    let progress_context = AssertUnwindSafe(progress_context);
+    let res = catch_panic(|| {
+        let handle =
+            unsafe { db.as_ref() }.ok_or_else(|| anyhow!("VotingDatabaseHandle is null"))?;
+        let round_id_str = unsafe { str_from_ptr(round_id, round_id_len) }?;
+        let wallet_path_str = unsafe { str_from_ptr(wallet_db_path, wallet_db_path_len) }?;
+        let hotkey_addr = unsafe { bytes_from_ptr(hotkey_raw_address, hotkey_raw_address_len) };
+        let pir_url = unsafe { str_from_ptr(pir_server_url, pir_server_url_len) }?;
+
+        let reporter: Box<dyn voting::ProofProgressReporter> = match progress_callback {
+            Some(cb) => Box::new(ProgressBridge {
+                callback: cb,
+                context: *progress_context,
+            }),
+            None => Box::new(voting::NoopProgressReporter),
+        };
+
+        let result = handle
+            .db
+            .build_and_prove_delegation(
+                &round_id_str,
+                bundle_index,
+                &wallet_path_str,
+                hotkey_addr,
+                &pir_url,
+                network_id,
+                reporter.as_ref(),
+            )
+            .map_err(|e| anyhow!("build_and_prove_delegation failed: {}", e))?;
+
+        let json_result: JsonDelegationProofResult = result.into();
+        json_to_boxed_slice(&json_result)
+    });
+    unwrap_exc_or_null(res)
+}
+
+/// Get the delegation submission payload using a seed-derived signing key.
+///
+/// Returns JSON-encoded `DelegationSubmission` as `*mut FfiBoxedSlice`, or null on error.
+///
+/// # Safety
+///
+/// - `db` must be a valid, non-null `VotingDatabaseHandle` pointer.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn zcashlc_voting_get_delegation_submission(
+    db: *mut VotingDatabaseHandle,
+    round_id: *const u8,
+    round_id_len: usize,
+    bundle_index: u32,
+    sender_seed: *const u8,
+    sender_seed_len: usize,
+    network_id: u32,
+    account_index: u32,
+) -> *mut crate::ffi::BoxedSlice {
+    let db = AssertUnwindSafe(db);
+    let res = catch_panic(|| {
+        let handle =
+            unsafe { db.as_ref() }.ok_or_else(|| anyhow!("VotingDatabaseHandle is null"))?;
+        let round_id_str = unsafe { str_from_ptr(round_id, round_id_len) }?;
+        let seed = unsafe { bytes_from_ptr(sender_seed, sender_seed_len) };
+
+        let submission = handle
+            .db
+            .get_delegation_submission(
+                &round_id_str,
+                bundle_index,
+                seed,
+                network_id,
+                account_index,
+            )
+            .map_err(|e| anyhow!("get_delegation_submission failed: {}", e))?;
+
+        let json_sub: JsonDelegationSubmission = submission.into();
+        json_to_boxed_slice(&json_sub)
+    });
+    unwrap_exc_or_null(res)
+}
+
+/// Get the delegation submission payload using a Keystone-provided signature.
+///
+/// Returns JSON-encoded `DelegationSubmission` as `*mut FfiBoxedSlice`, or null on error.
+///
+/// # Safety
+///
+/// - `db` must be a valid, non-null `VotingDatabaseHandle` pointer.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn zcashlc_voting_get_delegation_submission_with_keystone_sig(
+    db: *mut VotingDatabaseHandle,
+    round_id: *const u8,
+    round_id_len: usize,
+    bundle_index: u32,
+    sig: *const u8,
+    sig_len: usize,
+    sighash: *const u8,
+    sighash_len: usize,
+) -> *mut crate::ffi::BoxedSlice {
+    let db = AssertUnwindSafe(db);
+    let res = catch_panic(|| {
+        let handle =
+            unsafe { db.as_ref() }.ok_or_else(|| anyhow!("VotingDatabaseHandle is null"))?;
+        let round_id_str = unsafe { str_from_ptr(round_id, round_id_len) }?;
+        let sig_bytes = unsafe { bytes_from_ptr(sig, sig_len) };
+        let sighash_bytes = unsafe { bytes_from_ptr(sighash, sighash_len) };
+
+        let submission = handle
+            .db
+            .get_delegation_submission_with_keystone_sig(
+                &round_id_str,
+                bundle_index,
+                sig_bytes,
+                sighash_bytes,
+            )
+            .map_err(|e| {
+                anyhow!(
+                    "get_delegation_submission_with_keystone_sig failed: {}",
+                    e
+                )
+            })?;
+
+        let json_sub: JsonDelegationSubmission = submission.into();
+        json_to_boxed_slice(&json_sub)
+    });
+    unwrap_exc_or_null(res)
+}
+
+/// Store the VAN leaf position after delegation TX is confirmed on chain.
+///
+/// Returns 0 on success, -1 on error.
+///
+/// # Safety
+///
+/// - `db` must be a valid, non-null `VotingDatabaseHandle` pointer.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn zcashlc_voting_store_van_position(
+    db: *mut VotingDatabaseHandle,
+    round_id: *const u8,
+    round_id_len: usize,
+    bundle_index: u32,
+    position: u32,
+) -> i32 {
+    let db = AssertUnwindSafe(db);
+    let res = catch_panic(|| {
+        let handle =
+            unsafe { db.as_ref() }.ok_or_else(|| anyhow!("VotingDatabaseHandle is null"))?;
+        let round_id_str = unsafe { str_from_ptr(round_id, round_id_len) }?;
+
+        handle
+            .db
+            .store_van_position(&round_id_str, bundle_index, position)
+            .map_err(|e| anyhow!("store_van_position failed: {}", e))?;
+        Ok(0)
+    });
+    unwrap_exc_or(res, -1)
+}
+
+// =============================================================================
+// B. VotingDatabase methods — Voting
+// =============================================================================
+
+/// Encrypt voting shares for a round.
+///
+/// `shares_json` is a JSON-encoded `Vec<u64>`.
+///
+/// Returns JSON-encoded `Vec<EncryptedShare>` as `*mut FfiBoxedSlice`, or null on error.
+///
+/// # Safety
+///
+/// - `db` must be a valid, non-null `VotingDatabaseHandle` pointer.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn zcashlc_voting_encrypt_shares(
+    db: *mut VotingDatabaseHandle,
+    round_id: *const u8,
+    round_id_len: usize,
+    shares_json: *const u8,
+    shares_json_len: usize,
+) -> *mut crate::ffi::BoxedSlice {
+    let db = AssertUnwindSafe(db);
+    let res = catch_panic(|| {
+        let handle =
+            unsafe { db.as_ref() }.ok_or_else(|| anyhow!("VotingDatabaseHandle is null"))?;
+        let round_id_str = unsafe { str_from_ptr(round_id, round_id_len) }?;
+        let shares_bytes = unsafe { bytes_from_ptr(shares_json, shares_json_len) };
+        let shares: Vec<u64> = serde_json::from_slice(shares_bytes)?;
+
+        let encrypted = handle
+            .db
+            .encrypt_shares(&round_id_str, &shares)
+            .map_err(|e| anyhow!("encrypt_shares failed: {}", e))?;
+
+        let json_shares: Vec<JsonEncryptedShare> =
+            encrypted.into_iter().map(Into::into).collect();
+        json_to_boxed_slice(&json_shares)
+    });
+    unwrap_exc_or_null(res)
+}
+
+/// Build a vote commitment (ZKP #2) for a proposal.
+///
+/// `van_auth_path_json` is a JSON-encoded `Vec<Vec<u8>>` (each element is 32 bytes).
+///
+/// Returns JSON-encoded `VoteCommitmentBundle` as `*mut FfiBoxedSlice`, or null on error.
+///
+/// # Safety
+///
+/// - `db` must be a valid, non-null `VotingDatabaseHandle` pointer.
+/// - `progress_callback` must be a valid function pointer (or null to skip progress).
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn zcashlc_voting_build_vote_commitment(
+    db: *mut VotingDatabaseHandle,
+    round_id: *const u8,
+    round_id_len: usize,
+    bundle_index: u32,
+    hotkey_seed: *const u8,
+    hotkey_seed_len: usize,
+    network_id: u32,
+    proposal_id: u32,
+    choice: u32,
+    num_options: u32,
+    van_auth_path_json: *const u8,
+    van_auth_path_json_len: usize,
+    van_position: u32,
+    anchor_height: u32,
+    progress_callback: Option<unsafe extern "C" fn(f64, *mut std::ffi::c_void)>,
+    progress_context: *mut std::ffi::c_void,
+) -> *mut crate::ffi::BoxedSlice {
+    let db = AssertUnwindSafe(db);
+    let progress_context = AssertUnwindSafe(progress_context);
+    let res = catch_panic(|| {
+        let handle =
+            unsafe { db.as_ref() }.ok_or_else(|| anyhow!("VotingDatabaseHandle is null"))?;
+        let round_id_str = unsafe { str_from_ptr(round_id, round_id_len) }?;
+        let seed = unsafe { bytes_from_ptr(hotkey_seed, hotkey_seed_len) };
+        let auth_path_bytes =
+            unsafe { bytes_from_ptr(van_auth_path_json, van_auth_path_json_len) };
+        let auth_path_vecs: Vec<Vec<u8>> = serde_json::from_slice(auth_path_bytes)?;
+        let auth_path: Vec<[u8; 32]> = auth_path_vecs
+            .into_iter()
+            .map(|v| {
+                v.try_into().map_err(|_| {
+                    anyhow!("each auth_path sibling must be 32 bytes")
+                })
+            })
+            .collect::<anyhow::Result<Vec<_>>>()?;
+
+        let reporter: Box<dyn voting::ProofProgressReporter> = match progress_callback {
+            Some(cb) => Box::new(ProgressBridge {
+                callback: cb,
+                context: *progress_context,
+            }),
+            None => Box::new(voting::NoopProgressReporter),
+        };
+
+        let bundle = handle
+            .db
+            .build_vote_commitment(
+                &round_id_str,
+                bundle_index,
+                seed,
+                network_id,
+                proposal_id,
+                choice,
+                num_options,
+                &auth_path,
+                van_position,
+                anchor_height,
+                reporter.as_ref(),
+            )
+            .map_err(|e| anyhow!("build_vote_commitment failed: {}", e))?;
+
+        let json_bundle: JsonVoteCommitmentBundle = bundle.into();
+        json_to_boxed_slice(&json_bundle)
+    });
+    unwrap_exc_or_null(res)
+}
+
+/// Build share payloads for delegated share submission.
+///
+/// `enc_shares_json` is JSON-encoded `Vec<EncryptedShare>`.
+/// `commitment_json` is JSON-encoded `VoteCommitmentBundle`.
+///
+/// Returns JSON-encoded `Vec<SharePayload>` as `*mut FfiBoxedSlice`, or null on error.
+///
+/// # Safety
+///
+/// - `db` must be a valid, non-null `VotingDatabaseHandle` pointer.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn zcashlc_voting_build_share_payloads(
+    db: *mut VotingDatabaseHandle,
+    enc_shares_json: *const u8,
+    enc_shares_json_len: usize,
+    commitment_json: *const u8,
+    commitment_json_len: usize,
+    vote_decision: u32,
+    num_options: u32,
+    vc_tree_position: u64,
+) -> *mut crate::ffi::BoxedSlice {
+    let db = AssertUnwindSafe(db);
+    let res = catch_panic(|| {
+        let handle =
+            unsafe { db.as_ref() }.ok_or_else(|| anyhow!("VotingDatabaseHandle is null"))?;
+
+        let shares_bytes = unsafe { bytes_from_ptr(enc_shares_json, enc_shares_json_len) };
+        let json_shares: Vec<JsonEncryptedShare> = serde_json::from_slice(shares_bytes)?;
+        let core_shares: Vec<voting::EncryptedShare> =
+            json_shares.into_iter().map(Into::into).collect();
+
+        let commitment_bytes = unsafe { bytes_from_ptr(commitment_json, commitment_json_len) };
+        let json_commitment: JsonVoteCommitmentBundle =
+            serde_json::from_slice(commitment_bytes)?;
+        let core_commitment: voting::VoteCommitmentBundle = json_commitment.into();
+
+        let payloads = handle
+            .db
+            .build_share_payloads(
+                &core_shares,
+                &core_commitment,
+                vote_decision,
+                num_options,
+                vc_tree_position,
+            )
+            .map_err(|e| anyhow!("build_share_payloads failed: {}", e))?;
+
+        let json_payloads: Vec<JsonSharePayload> =
+            payloads.into_iter().map(Into::into).collect();
+        json_to_boxed_slice(&json_payloads)
+    });
+    unwrap_exc_or_null(res)
+}
+
+/// Mark a vote as submitted for a specific proposal/bundle.
+///
+/// Returns 0 on success, -1 on error.
+///
+/// # Safety
+///
+/// - `db` must be a valid, non-null `VotingDatabaseHandle` pointer.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn zcashlc_voting_mark_vote_submitted(
+    db: *mut VotingDatabaseHandle,
+    round_id: *const u8,
+    round_id_len: usize,
+    bundle_index: u32,
+    proposal_id: u32,
+) -> i32 {
+    let db = AssertUnwindSafe(db);
+    let res = catch_panic(|| {
+        let handle =
+            unsafe { db.as_ref() }.ok_or_else(|| anyhow!("VotingDatabaseHandle is null"))?;
+        let round_id_str = unsafe { str_from_ptr(round_id, round_id_len) }?;
+
+        handle
+            .db
+            .mark_vote_submitted(&round_id_str, bundle_index, proposal_id)
+            .map_err(|e| anyhow!("mark_vote_submitted failed: {}", e))?;
+        Ok(0)
+    });
+    unwrap_exc_or(res, -1)
+}
+
+// =============================================================================
+// B. VotingDatabase methods — Tree sync
+// =============================================================================
+
+/// Sync the vote commitment tree from a chain node.
+///
+/// Returns the latest synced block height on success (>= 0), or -1 on error.
+///
+/// # Safety
+///
+/// - `db` must be a valid, non-null `VotingDatabaseHandle` pointer.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn zcashlc_voting_sync_vote_tree(
+    db: *mut VotingDatabaseHandle,
+    round_id: *const u8,
+    round_id_len: usize,
+    node_url: *const u8,
+    node_url_len: usize,
+) -> i64 {
+    let db = AssertUnwindSafe(db);
+    let res = catch_panic(|| {
+        let handle =
+            unsafe { db.as_ref() }.ok_or_else(|| anyhow!("VotingDatabaseHandle is null"))?;
+        let round_id_str = unsafe { str_from_ptr(round_id, round_id_len) }?;
+        let url = unsafe { str_from_ptr(node_url, node_url_len) }?;
+
+        let height = handle
+            .tree_sync
+            .sync(&handle.db, &round_id_str, &url)
+            .map_err(|e| anyhow!("sync_vote_tree failed: {}", e))?;
+        Ok(height as i64)
+    });
+    unwrap_exc_or(res, -1)
+}
+
+/// Generate a VAN Merkle witness for ZKP #2.
+///
+/// Returns JSON-encoded `VanWitness` as `*mut FfiBoxedSlice`, or null on error.
+///
+/// # Safety
+///
+/// - `db` must be a valid, non-null `VotingDatabaseHandle` pointer.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn zcashlc_voting_generate_van_witness(
+    db: *mut VotingDatabaseHandle,
+    round_id: *const u8,
+    round_id_len: usize,
+    bundle_index: u32,
+    anchor_height: u32,
+) -> *mut crate::ffi::BoxedSlice {
+    let db = AssertUnwindSafe(db);
+    let res = catch_panic(|| {
+        let handle =
+            unsafe { db.as_ref() }.ok_or_else(|| anyhow!("VotingDatabaseHandle is null"))?;
+        let round_id_str = unsafe { str_from_ptr(round_id, round_id_len) }?;
+
+        let witness = handle
+            .tree_sync
+            .generate_van_witness(&handle.db, &round_id_str, bundle_index, anchor_height)
+            .map_err(|e| anyhow!("generate_van_witness failed: {}", e))?;
+
+        let json_witness: JsonVanWitness = witness.into();
+        json_to_boxed_slice(&json_witness)
+    });
+    unwrap_exc_or_null(res)
+}
+
+/// Drop the in-memory TreeClient so the next `sync_vote_tree()` call
+/// creates a fresh one.
+///
+/// Returns 0 on success, -1 on error.
+///
+/// # Safety
+///
+/// - `db` must be a valid, non-null `VotingDatabaseHandle` pointer.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn zcashlc_voting_reset_tree_client(
+    db: *mut VotingDatabaseHandle,
+) -> i32 {
+    let db = AssertUnwindSafe(db);
+    let res = catch_panic(|| {
+        let handle =
+            unsafe { db.as_ref() }.ok_or_else(|| anyhow!("VotingDatabaseHandle is null"))?;
+
+        handle
+            .tree_sync
+            .reset()
+            .map_err(|e| anyhow!("reset_tree_client failed: {}", e))?;
+        Ok(0)
+    });
+    unwrap_exc_or(res, -1)
+}
+
+// =============================================================================
+// C. Free functions (no VotingDatabase needed)
+// =============================================================================
+
+/// Generate a standalone voting hotkey (no database needed).
+///
+/// Returns a pointer to `FfiVotingHotkey` on success, or null on error.
+/// Call `zcashlc_voting_free_hotkey` to free the returned pointer.
+///
+/// # Safety
+///
+/// - `seed` must be non-null and valid for reads for `seed_len` bytes.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn zcashlc_voting_generate_hotkey_standalone(
+    seed: *const u8,
+    seed_len: usize,
+) -> *mut FfiVotingHotkey {
+    let res = catch_panic(|| {
+        let seed_bytes = unsafe { bytes_from_ptr(seed, seed_len) };
+        let hotkey = voting::hotkey::generate_hotkey(seed_bytes)
+            .map_err(|e| anyhow!("generate_hotkey failed: {}", e))?;
+        Ok(Box::into_raw(Box::new(voting_hotkey_to_ffi(hotkey))))
+    });
+    unwrap_exc_or_null(res)
+}
+
+/// Decompose a weight into power-of-two components.
+///
+/// Returns JSON-encoded `Vec<u64>` as `*mut FfiBoxedSlice`, or null on error.
+///
+/// # Safety
+///
+/// No pointer parameters.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn zcashlc_voting_decompose_weight(
+    weight: u64,
+) -> *mut crate::ffi::BoxedSlice {
+    let res = catch_panic(|| {
+        let components = voting::decompose::decompose_weight(weight);
+        json_to_boxed_slice(&components)
+    });
+    unwrap_exc_or_null(res)
+}
+
+/// Generate delegation inputs from sender seed and hotkey seed.
+///
+/// Returns JSON-encoded `DelegationInputs` as `*mut FfiBoxedSlice`, or null on error.
+///
+/// # Safety
+///
+/// - `sender_seed` and `hotkey_seed` must be valid for their stated lengths.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn zcashlc_voting_generate_delegation_inputs(
+    sender_seed: *const u8,
+    sender_seed_len: usize,
+    hotkey_seed: *const u8,
+    hotkey_seed_len: usize,
+    network_id: u32,
+    account_index: u32,
+) -> *mut crate::ffi::BoxedSlice {
+    let res = catch_panic(|| {
+        let sender = unsafe { bytes_from_ptr(sender_seed, sender_seed_len) };
+        let hotkey = unsafe { bytes_from_ptr(hotkey_seed, hotkey_seed_len) };
+
+        if sender.len() < 32 {
+            return Err(anyhow!(
+                "sender_seed must be at least 32 bytes, got {}",
+                sender.len()
+            ));
+        }
+        if hotkey.len() < 32 {
+            return Err(anyhow!(
+                "hotkey_seed must be at least 32 bytes, got {}",
+                hotkey.len()
+            ));
+        }
+
+        let account = AccountId::try_from(account_index)
+            .map_err(|_| anyhow!("account_index must be < 2^31, got {}", account_index))?;
+
+        // Derive sender Orchard FVK
+        let sender_usk = match network_id {
+            0 => UnifiedSpendingKey::from_seed(&MAIN_NETWORK, sender, account),
+            1 => UnifiedSpendingKey::from_seed(&TEST_NETWORK, sender, account),
+            _ => {
+                return Err(anyhow!(
+                    "invalid network_id {}, expected 0 (mainnet) or 1 (testnet)",
+                    network_id
+                ))
+            }
+        }
+        .map_err(|e| anyhow!("failed to derive sender UnifiedSpendingKey: {}", e))?;
+
+        let sender_fvk = sender_usk
+            .to_unified_full_viewing_key()
+            .orchard()
+            .ok_or_else(|| anyhow!("sender UFVK is missing Orchard component"))?
+            .to_bytes()
+            .to_vec();
+
+        // Derive hotkey-side Orchard material
+        let hotkey_usk = match network_id {
+            0 => UnifiedSpendingKey::from_seed(&MAIN_NETWORK, hotkey, account),
+            1 => UnifiedSpendingKey::from_seed(&TEST_NETWORK, hotkey, account),
+            _ => unreachable!("network_id validated above"),
+        }
+        .map_err(|e| anyhow!("failed to derive hotkey UnifiedSpendingKey: {}", e))?;
+
+        let hotkey_ufvk = hotkey_usk.to_unified_full_viewing_key();
+        let hotkey_orchard_fvk = hotkey_ufvk
+            .orchard()
+            .ok_or_else(|| anyhow!("hotkey UFVK is missing Orchard component"))?;
+
+        let app_hotkey = voting::hotkey::generate_hotkey(hotkey)
+            .map_err(|e| anyhow!("generate_hotkey failed: {}", e))?;
+        let hotkey_addr = hotkey_orchard_fvk.address_at(0u32, Scope::External);
+        let hotkey_raw_address = hotkey_addr.to_raw_address_bytes().to_vec();
+
+        let hotkey_addr_43: [u8; 43] = hotkey_raw_address
+            .as_slice()
+            .try_into()
+            .map_err(|_| anyhow!("address serialization must be 43 bytes"))?;
+        let (g_d_new_x, pk_d_new_x) =
+            voting::action::derive_hotkey_x_coords_from_raw_address(&hotkey_addr_43)
+                .map_err(|e| anyhow!("derive_hotkey_x_coords failed: {}", e))?;
+
+        let seed_fp = zip32::fingerprint::SeedFingerprint::from_seed(sender)
+            .ok_or_else(|| anyhow!("failed to compute seed fingerprint (seed too short?)"))?;
+
+        let inputs = JsonDelegationInputs {
+            fvk_bytes: sender_fvk,
+            g_d_new_x: g_d_new_x.to_vec(),
+            pk_d_new_x: pk_d_new_x.to_vec(),
+            hotkey_raw_address,
+            hotkey_public_key: app_hotkey.public_key,
+            hotkey_address: app_hotkey.address,
+            seed_fingerprint: seed_fp.to_bytes().to_vec(),
+        };
+        json_to_boxed_slice(&inputs)
+    });
+    unwrap_exc_or_null(res)
+}
+
+/// Generate delegation inputs using an explicit FVK instead of deriving from sender seed.
+///
+/// Returns JSON-encoded `DelegationInputs` as `*mut FfiBoxedSlice`, or null on error.
+///
+/// # Safety
+///
+/// - All pointer/length pairs must be valid.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn zcashlc_voting_generate_delegation_inputs_with_fvk(
+    fvk_bytes: *const u8,
+    fvk_bytes_len: usize,
+    hotkey_seed: *const u8,
+    hotkey_seed_len: usize,
+    network_id: u32,
+    account_index: u32,
+    seed_fingerprint: *const u8,
+    seed_fingerprint_len: usize,
+) -> *mut crate::ffi::BoxedSlice {
+    let res = catch_panic(|| {
+        let fvk = unsafe { bytes_from_ptr(fvk_bytes, fvk_bytes_len) }.to_vec();
+        let hotkey = unsafe { bytes_from_ptr(hotkey_seed, hotkey_seed_len) };
+        let seed_fp = unsafe { bytes_from_ptr(seed_fingerprint, seed_fingerprint_len) }.to_vec();
+
+        if fvk.len() != 96 {
+            return Err(anyhow!(
+                "fvk_bytes must be 96 bytes, got {}",
+                fvk.len()
+            ));
+        }
+        if hotkey.len() < 32 {
+            return Err(anyhow!(
+                "hotkey_seed must be at least 32 bytes, got {}",
+                hotkey.len()
+            ));
+        }
+        if seed_fp.len() != 32 {
+            return Err(anyhow!(
+                "seed_fingerprint must be 32 bytes, got {}",
+                seed_fp.len()
+            ));
+        }
+
+        let account = AccountId::try_from(account_index)
+            .map_err(|_| anyhow!("account_index must be < 2^31, got {}", account_index))?;
+
+        // Derive hotkey-side Orchard material
+        let hotkey_usk = match network_id {
+            0 => UnifiedSpendingKey::from_seed(&MAIN_NETWORK, hotkey, account),
+            1 => UnifiedSpendingKey::from_seed(&TEST_NETWORK, hotkey, account),
+            _ => {
+                return Err(anyhow!(
+                    "invalid network_id {}, expected 0 (mainnet) or 1 (testnet)",
+                    network_id
+                ))
+            }
+        }
+        .map_err(|e| anyhow!("failed to derive hotkey UnifiedSpendingKey: {}", e))?;
+
+        let hotkey_ufvk = hotkey_usk.to_unified_full_viewing_key();
+        let hotkey_orchard_fvk = hotkey_ufvk
+            .orchard()
+            .ok_or_else(|| anyhow!("hotkey UFVK is missing Orchard component"))?;
+
+        let app_hotkey = voting::hotkey::generate_hotkey(hotkey)
+            .map_err(|e| anyhow!("generate_hotkey failed: {}", e))?;
+        let hotkey_addr = hotkey_orchard_fvk.address_at(0u32, Scope::External);
+        let hotkey_raw_address = hotkey_addr.to_raw_address_bytes().to_vec();
+
+        let hotkey_addr_43: [u8; 43] = hotkey_raw_address
+            .as_slice()
+            .try_into()
+            .map_err(|_| anyhow!("address serialization must be 43 bytes"))?;
+        let (g_d_new_x, pk_d_new_x) =
+            voting::action::derive_hotkey_x_coords_from_raw_address(&hotkey_addr_43)
+                .map_err(|e| anyhow!("derive_hotkey_x_coords failed: {}", e))?;
+
+        let inputs = JsonDelegationInputs {
+            fvk_bytes: fvk,
+            g_d_new_x: g_d_new_x.to_vec(),
+            pk_d_new_x: pk_d_new_x.to_vec(),
+            hotkey_raw_address,
+            hotkey_public_key: app_hotkey.public_key,
+            hotkey_address: app_hotkey.address,
+            seed_fingerprint: seed_fp,
+        };
+        json_to_boxed_slice(&inputs)
+    });
+    unwrap_exc_or_null(res)
+}
+
+/// Extract the ZIP-244 shielded sighash from finalized PCZT bytes.
+///
+/// Returns the 32-byte sighash as `*mut FfiBoxedSlice`, or null on error.
+///
+/// # Safety
+///
+/// - `pczt_bytes` must be valid for reads of `pczt_bytes_len` bytes.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn zcashlc_voting_extract_pczt_sighash(
+    pczt_bytes: *const u8,
+    pczt_bytes_len: usize,
+) -> *mut crate::ffi::BoxedSlice {
+    let res = catch_panic(|| {
+        let bytes = unsafe { bytes_from_ptr(pczt_bytes, pczt_bytes_len) };
+        let sighash = voting::action::extract_pczt_sighash(bytes)
+            .map_err(|e| anyhow!("extract_pczt_sighash failed: {}", e))?;
+        Ok(crate::ffi::BoxedSlice::some(sighash.to_vec()))
+    });
+    unwrap_exc_or_null(res)
+}
+
+/// Extract a spend auth signature from a signed PCZT.
+///
+/// Returns the signature bytes as `*mut FfiBoxedSlice`, or null on error.
+///
+/// # Safety
+///
+/// - `signed_pczt_bytes` must be valid for reads of `signed_pczt_bytes_len` bytes.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn zcashlc_voting_extract_spend_auth_sig(
+    signed_pczt_bytes: *const u8,
+    signed_pczt_bytes_len: usize,
+    action_index: u32,
+) -> *mut crate::ffi::BoxedSlice {
+    let res = catch_panic(|| {
+        let bytes = unsafe { bytes_from_ptr(signed_pczt_bytes, signed_pczt_bytes_len) };
+        let sig = voting::action::extract_spend_auth_sig(bytes, action_index as usize)
+            .map_err(|e| anyhow!("extract_spend_auth_sig failed: {}", e))?;
+        Ok(crate::ffi::BoxedSlice::some(sig.to_vec()))
+    });
+    unwrap_exc_or_null(res)
+}
+
+/// Extract the 96-byte Orchard FVK from a UFVK string.
+///
+/// Returns the raw 96-byte Orchard FVK as `*mut FfiBoxedSlice`, or null on error.
+///
+/// # Safety
+///
+/// - `ufvk_str` must be valid for reads of `ufvk_str_len` bytes (UTF-8 encoded).
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn zcashlc_voting_extract_orchard_fvk_from_ufvk(
+    ufvk_str: *const u8,
+    ufvk_str_len: usize,
+    network_id: u32,
+) -> *mut crate::ffi::BoxedSlice {
+    let res = catch_panic(|| {
+        let ufvk_string = unsafe { str_from_ptr(ufvk_str, ufvk_str_len) }?;
+
+        let ufvk = match network_id {
+            0 => UnifiedFullViewingKey::decode(&MAIN_NETWORK, &ufvk_string),
+            1 => UnifiedFullViewingKey::decode(&TEST_NETWORK, &ufvk_string),
+            _ => {
+                return Err(anyhow!(
+                    "invalid network_id {}, expected 0 (mainnet) or 1 (testnet)",
+                    network_id
+                ))
+            }
+        }
+        .map_err(|e| anyhow!("failed to decode UFVK string: {}", e))?;
+
+        let orchard_fvk = ufvk
+            .orchard()
+            .ok_or_else(|| anyhow!("UFVK has no Orchard component"))?;
+        Ok(crate::ffi::BoxedSlice::some(
+            orchard_fvk.to_bytes().to_vec(),
+        ))
+    });
+    unwrap_exc_or_null(res)
+}
+
+/// Extract the Orchard note commitment tree root from a protobuf-encoded TreeState.
+///
+/// Returns the 32-byte nc_root as `*mut FfiBoxedSlice`, or null on error.
+///
+/// # Safety
+///
+/// - `tree_state_bytes` must be valid for reads of `tree_state_bytes_len` bytes.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn zcashlc_voting_extract_nc_root(
+    tree_state_bytes: *const u8,
+    tree_state_bytes_len: usize,
+) -> *mut crate::ffi::BoxedSlice {
+    let res = catch_panic(|| {
+        let bytes = unsafe { bytes_from_ptr(tree_state_bytes, tree_state_bytes_len) };
+        let nc_root = voting::extract_nc_root(bytes)
+            .map_err(|e| anyhow!("extract_nc_root failed: {}", e))?;
+        Ok(crate::ffi::BoxedSlice::some(nc_root))
+    });
+    unwrap_exc_or_null(res)
+}
+
+/// Sign a cast-vote transaction.
+///
+/// Takes fields from `VoteCommitmentBundle` plus hotkey seed and computes
+/// the spend auth signature.
+///
+/// Returns JSON-encoded `CastVoteSignature` as `*mut FfiBoxedSlice`, or null on error.
+///
+/// # Safety
+///
+/// - All pointer/length pairs must be valid.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn zcashlc_voting_sign_cast_vote(
+    hotkey_seed: *const u8,
+    hotkey_seed_len: usize,
+    network_id: u32,
+    vote_round_id_hex: *const u8,
+    vote_round_id_hex_len: usize,
+    r_vpk_bytes: *const u8,
+    r_vpk_bytes_len: usize,
+    van_nullifier: *const u8,
+    van_nullifier_len: usize,
+    vote_authority_note_new: *const u8,
+    vote_authority_note_new_len: usize,
+    vote_commitment: *const u8,
+    vote_commitment_len: usize,
+    proposal_id: u32,
+    anchor_height: u32,
+    alpha_v: *const u8,
+    alpha_v_len: usize,
+) -> *mut crate::ffi::BoxedSlice {
+    let res = catch_panic(|| {
+        let seed = unsafe { bytes_from_ptr(hotkey_seed, hotkey_seed_len) };
+        let round_id = unsafe { str_from_ptr(vote_round_id_hex, vote_round_id_hex_len) }?;
+        let r_vpk = unsafe { bytes_from_ptr(r_vpk_bytes, r_vpk_bytes_len) };
+        let van_nf = unsafe { bytes_from_ptr(van_nullifier, van_nullifier_len) };
+        let van_new = unsafe { bytes_from_ptr(vote_authority_note_new, vote_authority_note_new_len) };
+        let vc = unsafe { bytes_from_ptr(vote_commitment, vote_commitment_len) };
+        let alpha = unsafe { bytes_from_ptr(alpha_v, alpha_v_len) };
+
+        let sig = voting::vote_commitment::sign_cast_vote(
+            seed,
+            network_id,
+            &round_id,
+            r_vpk,
+            van_nf,
+            van_new,
+            vc,
+            proposal_id,
+            anchor_height,
+            alpha,
+        )
+        .map_err(|e| anyhow!("sign_cast_vote failed: {}", e))?;
+
+        let json_sig: JsonCastVoteSignature = sig.into();
+        json_to_boxed_slice(&json_sig)
+    });
+    unwrap_exc_or_null(res)
+}
+
+/// Verify a Merkle witness.
+///
+/// `witness_json` is a JSON-encoded `WitnessData`.
+///
+/// Returns 1 if valid, 0 if invalid, -1 on error.
+///
+/// # Safety
+///
+/// - `witness_json` must be valid for reads of `witness_json_len` bytes.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn zcashlc_voting_verify_witness(
+    witness_json: *const u8,
+    witness_json_len: usize,
+) -> i32 {
+    let res = catch_panic(|| {
+        let bytes = unsafe { bytes_from_ptr(witness_json, witness_json_len) };
+        let json_witness: JsonWitnessData = serde_json::from_slice(bytes)?;
+        let core_witness: voting::WitnessData = json_witness.into();
+
+        let valid = voting::witness::verify_witness(&core_witness)
+            .map_err(|e| anyhow!("verify_witness failed: {}", e))?;
+        Ok(if valid { 1 } else { 0 })
+    });
+    unwrap_exc_or(res, -1)
+}
+
+/// Return the voting FFI version string.
+///
+/// The caller must free the returned string with `zcashlc_string_free`.
+///
+/// # Safety
+///
+/// No pointer parameters.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn zcashlc_voting_version() -> *mut c_char {
+    let res = catch_panic(|| {
+        let version = env!("CARGO_PKG_VERSION");
+        let c_str = CString::new(version)
+            .map_err(|e| anyhow!("version string contains null byte: {}", e))?;
+        Ok(c_str.into_raw())
+    });
+    unwrap_exc_or_null(res)
+}
+
+// =============================================================================
+// Internal helpers
+// =============================================================================
+
+/// Convert a `voting::VotingHotkey` to the FFI representation.
+fn voting_hotkey_to_ffi(hotkey: voting::VotingHotkey) -> FfiVotingHotkey {
+    let (sk_ptr, sk_len) = crate::ptr_from_vec(hotkey.secret_key);
+    let (pk_ptr, pk_len) = crate::ptr_from_vec(hotkey.public_key);
+    let address = CString::new(hotkey.address).unwrap().into_raw();
+    FfiVotingHotkey {
+        secret_key: sk_ptr,
+        secret_key_len: sk_len,
+        public_key: pk_ptr,
+        public_key_len: pk_len,
+        address,
+    }
+}

--- a/rust/src/voting.rs
+++ b/rust/src/voting.rs
@@ -324,36 +324,22 @@ impl From<voting::DelegationSubmissionData> for JsonDelegationSubmission {
     }
 }
 
-/// JSON-serializable EncryptedShare.
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct JsonEncryptedShare {
-    pub c1: Vec<u8>,
-    pub c2: Vec<u8>,
-    pub share_index: u32,
-    pub plaintext_value: u64,
-    pub randomness: Vec<u8>,
-}
-
-impl From<voting::EncryptedShare> for JsonEncryptedShare {
+impl From<voting::EncryptedShare> for JsonWireEncryptedShare {
     fn from(s: voting::EncryptedShare) -> Self {
         Self {
             c1: s.c1,
             c2: s.c2,
             share_index: s.share_index,
-            plaintext_value: s.plaintext_value,
-            randomness: s.randomness,
         }
     }
 }
 
-impl From<JsonEncryptedShare> for voting::EncryptedShare {
-    fn from(s: JsonEncryptedShare) -> Self {
+impl From<JsonWireEncryptedShare> for voting::WireEncryptedShare {
+    fn from(s: JsonWireEncryptedShare) -> Self {
         Self {
             c1: s.c1,
             c2: s.c2,
             share_index: s.share_index,
-            plaintext_value: s.plaintext_value,
-            randomness: s.randomness,
         }
     }
 }
@@ -366,7 +352,7 @@ pub struct JsonVoteCommitmentBundle {
     pub vote_commitment: Vec<u8>,
     pub proposal_id: u32,
     pub proof: Vec<u8>,
-    pub enc_shares: Vec<JsonEncryptedShare>,
+    pub enc_shares: Vec<JsonWireEncryptedShare>,
     pub anchor_height: u32,
     pub vote_round_id: String,
     pub shares_hash: Vec<u8>,
@@ -404,7 +390,9 @@ impl From<JsonVoteCommitmentBundle> for voting::VoteCommitmentBundle {
             vote_commitment: b.vote_commitment,
             proposal_id: b.proposal_id,
             proof: b.proof,
-            enc_shares: b.enc_shares.into_iter().map(Into::into).collect(),
+            // enc_shares with secrets are not sent across FFI; wire shares are
+            // passed separately to build_share_payloads, so this is unused.
+            enc_shares: Vec::new(),
             anchor_height: b.anchor_height,
             vote_round_id: b.vote_round_id,
             shares_hash: b.shares_hash,
@@ -416,15 +404,24 @@ impl From<JsonVoteCommitmentBundle> for voting::VoteCommitmentBundle {
     }
 }
 
+/// Wire-safe encrypted share that omits secret fields (plaintext_value, randomness).
+/// Used in SharePayload which is sent to the helper server.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct JsonWireEncryptedShare {
+    pub c1: Vec<u8>,
+    pub c2: Vec<u8>,
+    pub share_index: u32,
+}
+
 /// JSON-serializable SharePayload.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct JsonSharePayload {
     pub shares_hash: Vec<u8>,
     pub proposal_id: u32,
     pub vote_decision: u32,
-    pub enc_share: JsonEncryptedShare,
+    pub enc_share: JsonWireEncryptedShare,
     pub tree_position: u64,
-    pub all_enc_shares: Vec<JsonEncryptedShare>,
+    pub all_enc_shares: Vec<JsonWireEncryptedShare>,
     pub share_comms: Vec<Vec<u8>>,
     pub primary_blind: Vec<u8>,
 }
@@ -435,11 +432,32 @@ impl From<voting::SharePayload> for JsonSharePayload {
             shares_hash: p.shares_hash,
             proposal_id: p.proposal_id,
             vote_decision: p.vote_decision,
-            enc_share: p.enc_share.into(),
+            enc_share: JsonWireEncryptedShare {
+                c1: p.enc_share.c1,
+                c2: p.enc_share.c2,
+                share_index: p.enc_share.share_index,
+            },
             tree_position: p.tree_position,
-            all_enc_shares: p.all_enc_shares.into_iter().map(Into::into).collect(),
+            all_enc_shares: p.all_enc_shares
+                .into_iter()
+                .map(|s| JsonWireEncryptedShare {
+                    c1: s.c1,
+                    c2: s.c2,
+                    share_index: s.share_index,
+                })
+                .collect(),
             share_comms: p.share_comms,
             primary_blind: p.primary_blind,
+        }
+    }
+}
+
+impl From<voting::WireEncryptedShare> for JsonWireEncryptedShare {
+    fn from(s: voting::WireEncryptedShare) -> Self {
+        Self {
+            c1: s.c1,
+            c2: s.c2,
+            share_index: s.share_index,
         }
     }
 }
@@ -1591,7 +1609,7 @@ pub unsafe extern "C" fn zcashlc_voting_encrypt_shares(
             .encrypt_shares(&round_id_str, &shares)
             .map_err(|e| anyhow!("encrypt_shares failed: {}", e))?;
 
-        let json_shares: Vec<JsonEncryptedShare> =
+        let json_shares: Vec<JsonWireEncryptedShare> =
             encrypted.into_iter().map(Into::into).collect();
         json_to_boxed_slice(&json_shares)
     });
@@ -1679,7 +1697,7 @@ pub unsafe extern "C" fn zcashlc_voting_build_vote_commitment(
 
 /// Build share payloads for delegated share submission.
 ///
-/// `enc_shares_json` is JSON-encoded `Vec<EncryptedShare>`.
+/// `enc_shares_json` is JSON-encoded `Vec<WireEncryptedShare>`.
 /// `commitment_json` is JSON-encoded `VoteCommitmentBundle`.
 ///
 /// Returns JSON-encoded `Vec<SharePayload>` as `*mut FfiBoxedSlice`, or null on error.
@@ -1704,8 +1722,8 @@ pub unsafe extern "C" fn zcashlc_voting_build_share_payloads(
             unsafe { db.as_ref() }.ok_or_else(|| anyhow!("VotingDatabaseHandle is null"))?;
 
         let shares_bytes = unsafe { bytes_from_ptr(enc_shares_json, enc_shares_json_len) };
-        let json_shares: Vec<JsonEncryptedShare> = serde_json::from_slice(shares_bytes)?;
-        let core_shares: Vec<voting::EncryptedShare> =
+        let json_shares: Vec<JsonWireEncryptedShare> = serde_json::from_slice(shares_bytes)?;
+        let wire_shares: Vec<voting::WireEncryptedShare> =
             json_shares.into_iter().map(Into::into).collect();
 
         let commitment_bytes = unsafe { bytes_from_ptr(commitment_json, commitment_json_len) };
@@ -1716,7 +1734,7 @@ pub unsafe extern "C" fn zcashlc_voting_build_share_payloads(
         let payloads = handle
             .db
             .build_share_payloads(
-                &core_shares,
+                &wire_shares,
                 &core_commitment,
                 vote_decision,
                 num_options,

--- a/rust/src/voting.rs
+++ b/rust/src/voting.rs
@@ -1108,8 +1108,8 @@ pub unsafe extern "C" fn zcashlc_voting_get_wallet_notes(
 
         let height = zcash_protocol::consensus::BlockHeight::from_u32(snapshot_height as u32);
         let received_notes = wallet_db
-            .get_orchard_notes_at_historical_height(account_uuid, height)
-            .map_err(|e| anyhow!("get_orchard_notes_at_historical_height failed: {}", e))?;
+            .get_unspent_orchard_notes_at_historical_height(account_uuid, height)
+            .map_err(|e| anyhow!("get_unspent_orchard_notes_at_historical_height failed: {}", e))?;
 
         let mut json_notes = Vec::with_capacity(received_notes.len());
         for rn in &received_notes {

--- a/rust/src/voting.rs
+++ b/rust/src/voting.rs
@@ -1383,13 +1383,9 @@ pub unsafe extern "C" fn zcashlc_voting_generate_note_witnesses(
             .collect();
         let checkpoint_height = zcash_protocol::consensus::BlockHeight::from_u32(params.snapshot_height as u32);
 
-        let merkle_paths = voting::orchard_witnesses::generate_orchard_witnesses_at_frontier(
-            wallet_db.conn(),
-            &positions,
-            nonempty_frontier,
-            checkpoint_height,
-        )
-        .map_err(|e| anyhow!("generate_orchard_witnesses_at_frontier failed: {}", e))?;
+        let merkle_paths = wallet_db
+            .generate_orchard_witnesses_at_frontier(&positions, nonempty_frontier, checkpoint_height)
+            .map_err(|e| anyhow!("generate_orchard_witnesses_at_frontier failed: {}", e))?;
 
         // Convert MerklePaths to WitnessData
         let root_bytes = frontier_root.to_bytes().to_vec();


### PR DESCRIPTION
## Overview 
[Shielded Voting — Integration Architecture Changes Proposal](https://hackmd.io/@greg-nagy/voting-integration-architecture-changes-proposal)

## Summary

Adds a complete voting integration layer to the SDK: hand-rolled C FFI for librustvoting, Swift wrappers, and wallet↔voting data plumbing. This enables the full shielded voting lifecycle from a Swift client.

- **52 extern "C" FFI functions** in `rust/src/voting.rs` covering round management, wallet note queries, hotkey generation, delegation proof construction, vote commitment, share encryption, submission, recovery state persistence, and commitment tree sync
- **Swift wrappers** (`VotingRustBackend.swift`, `VotingTypes.swift`) with thread-safe handle management, JSON deserialization for complex types, and secret stripping at the FFI boundary
- **New SDK API** `getTreeState(height:)` on `Synchronizer` for commitment tree witness generation
- **Build integration** — `build.rs` watches all Rust source files for cbindgen rebuild; SystemConfiguration framework linked for macOS reqwest proxy detection

## Architecture

The SDK is the glue layer between librustzcash (wallet) and librustvoting (voting):

```
zodl-ios (Swift/TCA)
  └─ zcash-swift-wallet-sdk (SPM)
       ├─ VotingRustBackend.swift (wraps C FFI)
       └─ libzcashlc.a (Rust staticlib)
            ├─ librustzcash  ← wallet DB queries
            └─ librustvoting ← voting DB, ZKP proofs, encryption
```

librustvoting never touches the wallet DB. The SDK FFI queries notes/witnesses via librustzcash and passes them to librustvoting as arguments. Four FFI functions do this wallet↔voting plumbing; the remaining ~48 are thin pass-throughs to librustvoting.

Complex types cross the FFI boundary via JSON serde (`serde_json` ↔ `Codable`). Simple types use `#[repr(C)]` structs. Encrypted share secrets are stripped at the boundary — only ciphertext components (`c1`, `c2`) are exposed to Swift.

## Voting workflow

1. **Round init** → hotkey generation (from seed or standalone)
2. **Bundle setup** → note selection at snapshot height, per-wallet isolation via account UUID
3. **Delegation** → voting PCZT construction, witness generation, ZKP proof, keystone signature
4. **Voting** → vote commitment (second ZKP), share encryption, submission with cast-vote signature
5. **Recovery** — persistent state for TX hashes, commitment bundles, and keystone signatures across app restarts

## Dependencies

All patched from valargroup forks for voting extension compatibility:

- [librustzcash](https://github.com/valargroup/librustzcash/tree/shielded-voting-wallet-support) — PCZT/key visibility changes for delegation flows ([upstream PR](https://github.com/zcash/librustzcash/pull/2212))
- [librustvoting](https://github.com/valargroup/librustvoting) — voting business logic, storage, tree sync
- [voting-circuits](https://github.com/valargroup/voting-circuits) — orchard fork with voting ZKP gadgets

## Key files

| File | Purpose |
|------|---------|
| `rust/src/voting.rs` | 52 extern "C" FFI functions + helpers |
| `Sources/.../VotingTypes.swift` | Codable Swift types matching Rust JSON serde |
| `Sources/.../VotingRustBackend.swift` | Thread-safe Swift wrapper over opaque VotingDatabaseHandle |
| `Cargo.toml` | librustvoting, voting-circuits deps + patch.crates-io alignment |
| `Scripts/prepare-fork-release.sh` | Lightweight iOS arm64 dev release script |

Closes #1661.
Closes MOB-983.