### PR TITLE
Add UIVK field to FFI Account type

### DIFF
--- a/Sources/ZcashLightClientKit/Error/ZcashError.swift
+++ b/Sources/ZcashLightClientKit/Error/ZcashError.swift
@@ -626,6 +626,9 @@ public enum ZcashError: Equatable, Error {
     /// Can't create `UnifiedFullViewingKey` because input is invalid.
     /// ZWLTP0002
     case unifiedFullViewingKeyInvalidInput
+    /// Can't create `UnifiedIncomingViewingKey` because input is invalid.
+    /// ZWLTP0009
+    case unifiedIncomingViewingKeyInvalidInput
     /// Can't create `SaplingExtendedFullViewingKey` because input is invalid.
     /// ZWLTP0003
     case extetendedFullViewingKeyInvalidInput
@@ -927,6 +930,7 @@ public enum ZcashError: Equatable, Error {
         case .unspentTransactionOutputDAOBalance: return "SQLite query failed when getting balance."
         case .spendingKeyInvalidInput: return "Can't create `SaplingExtendedSpendingKey` because input is invalid."
         case .unifiedFullViewingKeyInvalidInput: return "Can't create `UnifiedFullViewingKey` because input is invalid."
+        case .unifiedIncomingViewingKeyInvalidInput: return "Can't create `UnifiedIncomingViewingKey` because input is invalid."
         case .extetendedFullViewingKeyInvalidInput: return "Can't create `SaplingExtendedFullViewingKey` because input is invalid."
         case .transparentAddressInvalidInput: return "Can't create `TransparentAddress` because input is invalid."
         case .saplingAddressInvalidInput: return "Can't create `SaplingAddress` because input is invalid."
@@ -1144,6 +1148,7 @@ public enum ZcashError: Equatable, Error {
         case .unspentTransactionOutputDAOBalance: return .unspentTransactionOutputDAOBalance
         case .spendingKeyInvalidInput: return .spendingKeyInvalidInput
         case .unifiedFullViewingKeyInvalidInput: return .unifiedFullViewingKeyInvalidInput
+        case .unifiedIncomingViewingKeyInvalidInput: return .unifiedIncomingViewingKeyInvalidInput
         case .extetendedFullViewingKeyInvalidInput: return .extetendedFullViewingKeyInvalidInput
         case .transparentAddressInvalidInput: return .transparentAddressInvalidInput
         case .saplingAddressInvalidInput: return .saplingAddressInvalidInput

--- a/Sources/ZcashLightClientKit/Error/ZcashErrorCode.swift
+++ b/Sources/ZcashLightClientKit/Error/ZcashErrorCode.swift
@@ -347,6 +347,8 @@ public enum ZcashErrorCode: String {
     case spendingKeyInvalidInput = "ZWLTP0001"
     /// Can't create `UnifiedFullViewingKey` because input is invalid.
     case unifiedFullViewingKeyInvalidInput = "ZWLTP0002"
+    /// Can't create `UnifiedIncomingViewingKey` because input is invalid.
+    case unifiedIncomingViewingKeyInvalidInput = "ZWLTP0009"
     /// Can't create `SaplingExtendedFullViewingKey` because input is invalid.
     case extetendedFullViewingKeyInvalidInput = "ZWLTP0003"
     /// Can't create `TransparentAddress` because input is invalid.

--- a/Sources/ZcashLightClientKit/Error/ZcashErrorCodeDefinition.swift
+++ b/Sources/ZcashLightClientKit/Error/ZcashErrorCodeDefinition.swift
@@ -685,6 +685,9 @@ enum ZcashErrorDefinition {
     /// Can't create `UnifiedFullViewingKey` because input is invalid.
     // sourcery: code="ZWLTP0002"
     case unifiedFullViewingKeyInvalidInput
+    /// Can't create `UnifiedIncomingViewingKey` because input is invalid.
+    // sourcery: code="ZWLTP0009"
+    case unifiedIncomingViewingKeyInvalidInput
     /// Can't create `SaplingExtendedFullViewingKey` because input is invalid.
     // sourcery: code="ZWLTP0003"
     case extetendedFullViewingKeyInvalidInput

--- a/Sources/ZcashLightClientKit/Model/WalletTypes.swift
+++ b/Sources/ZcashLightClientKit/Model/WalletTypes.swift
@@ -17,6 +17,7 @@ public struct Account: Equatable, Hashable, Codable, Identifiable {
     public let seedFingerprint: [UInt8]?
     public let hdAccountIndex: Zip32AccountIndex?
     public let ufvk: UnifiedFullViewingKey?
+    public let uivk: UnifiedIncomingViewingKey?
 }
 
 public struct UnifiedSpendingKey: Equatable, Undescribable {
@@ -64,6 +65,26 @@ public struct UnifiedFullViewingKey: Equatable, StringEncoded, Undescribable, Ha
     public init(encoding: String, network: NetworkType) throws {
         guard DerivationTool(networkType: network).isValidUnifiedFullViewingKey(encoding) else {
             throw ZcashError.unifiedFullViewingKeyInvalidInput
+        }
+
+        self.encoding = encoding
+    }
+}
+
+/// A ZIP 316 Unified Incoming Viewing Key.
+public struct UnifiedIncomingViewingKey: Equatable, StringEncoded, Undescribable, Hashable, Codable {
+    let encoding: String
+
+    public var stringEncoded: String { encoding }
+
+    /// Initializes a new UnifiedIncomingViewingKey (UIVK) from the provided string encoding
+    /// - Parameters:
+    ///  - parameter encoding: String encoding of unified incoming viewing key
+    ///  - parameter network: `NetworkType` corresponding to the encoding (Mainnet or Testnet)
+    /// - Throws: `unifiedIncomingViewingKeyInvalidInput` when the provided encoding is found to be invalid
+    public init(encoding: String, network: NetworkType) throws {
+        guard DerivationTool(networkType: network).isValidUnifiedIncomingViewingKey(encoding) else {
+            throw ZcashError.unifiedIncomingViewingKeyInvalidInput
         }
 
         self.encoding = encoding

--- a/Sources/ZcashLightClientKit/Rust/ZcashKeyDerivationBackend.swift
+++ b/Sources/ZcashLightClientKit/Rust/ZcashKeyDerivationBackend.swift
@@ -91,6 +91,14 @@ struct ZcashKeyDerivationBackend: ZcashKeyDerivationBackendWelding {
         return zcashlc_is_valid_unified_full_viewing_key([CChar](key.utf8CString), networkType.networkId)
     }
 
+    func isValidUnifiedIncomingViewingKey(_ key: String) -> Bool {
+        guard !key.containsCStringNullBytesBeforeStringEnding() else {
+            return false
+        }
+
+        return zcashlc_is_valid_unified_incoming_viewing_key([CChar](key.utf8CString), networkType.networkId)
+    }
+
     // MARK: Address Derivation
 
     func deriveUnifiedAddressFrom(ufvk: String) throws -> UnifiedAddress {

--- a/Sources/ZcashLightClientKit/Rust/ZcashKeyDerivationBackendWelding.swift
+++ b/Sources/ZcashLightClientKit/Rust/ZcashKeyDerivationBackendWelding.swift
@@ -40,6 +40,11 @@ protocol ZcashKeyDerivationBackendWelding {
     /// - Returns: true when the encoded string is a valid UFVK. false in any other case
     func isValidUnifiedFullViewingKey(_ ufvk: String) -> Bool
 
+    /// Verifies that the given string-encoded `UnifiedIncomingViewingKey` is valid.
+    /// - Parameter uivk: UTF-8 encoded String to validate
+    /// - Returns: true when the encoded string is a valid UIVK. false in any other case
+    func isValidUnifiedIncomingViewingKey(_ uivk: String) -> Bool
+
     /// Derives and returns a UnifiedAddress from a UnifiedFullViewingKey
     /// - Parameter ufvk: UTF-8 encoded String containing a valid UFVK
     /// - Returns: the corresponding default `UnifiedAddress`

--- a/Sources/ZcashLightClientKit/Rust/ZcashRustBackend.swift
+++ b/Sources/ZcashLightClientKit/Rust/ZcashRustBackend.swift
@@ -1377,11 +1377,13 @@ extension FfiAccount {
                 keySource: key_source != nil ? String(cString: key_source) : nil,
                 seedFingerprint: nil,
                 hdAccountIndex: nil,
-                ufvk: nil
+                ufvk: nil,
+                uivk: nil
             )
         }
-        
+
         let ufvkTyped = ufvk.map { UnifiedFullViewingKey(validatedEncoding: String(cString: $0)) }
+        let uivkTyped = uivk.map { UnifiedIncomingViewingKey(validatedEncoding: String(cString: $0)) }
 
         // Valid ZIP32 account index
         return .init(
@@ -1390,7 +1392,8 @@ extension FfiAccount {
             keySource: key_source != nil ? String(cString: key_source) : nil,
             seedFingerprint: seedFingerprintArray,
             hdAccountIndex: Zip32AccountIndex(hd_account_index),
-            ufvk: ufvkTyped
+            ufvk: ufvkTyped,
+            uivk: uivkTyped
         )
     }
 }

--- a/Sources/ZcashLightClientKit/Tool/DerivationTool.swift
+++ b/Sources/ZcashLightClientKit/Tool/DerivationTool.swift
@@ -10,6 +10,7 @@ import Foundation
 
 public protocol KeyValidation {
     func isValidUnifiedFullViewingKey(_ ufvk: String) -> Bool
+    func isValidUnifiedIncomingViewingKey(_ uivk: String) -> Bool
     func isValidTransparentAddress(_ tAddress: String) -> Bool
     func isValidSaplingAddress(_ zAddress: String) -> Bool
     func isValidSaplingExtendedSpendingKey(_ extsk: String) -> Bool
@@ -165,6 +166,10 @@ extension DerivationTool: KeyValidation {
         backend.isValidUnifiedFullViewingKey(ufvk)
     }
 
+    public func isValidUnifiedIncomingViewingKey(_ uivk: String) -> Bool {
+        backend.isValidUnifiedIncomingViewingKey(uivk)
+    }
+
     public func isValidUnifiedAddress(_ unifiedAddress: String) -> Bool {
         DerivationTool.getAddressMetadata(unifiedAddress).map {
             $0.networkType == backend.networkType && $0.addressType == AddressType.unified
@@ -238,6 +243,16 @@ extension TexAddress {
 }
 
 extension UnifiedFullViewingKey {
+    /// This constructor is for internal use for Strings encodings that are assumed to be
+    /// already validated by another function. only for internal use. Unless you are
+    /// constructing an address from a primitive function of the FFI, you probably
+    /// shouldn't be using this.
+    init(validatedEncoding: String) {
+        self.encoding = validatedEncoding
+    }
+}
+
+extension UnifiedIncomingViewingKey {
     /// This constructor is for internal use for Strings encodings that are assumed to be
     /// already validated by another function. only for internal use. Unless you are
     /// constructing an address from a primitive function of the FFI, you probably

--- a/rust/src/derivation.rs
+++ b/rust/src/derivation.rs
@@ -297,6 +297,28 @@ pub unsafe extern "C" fn zcashlc_is_valid_unified_full_viewing_key(
     unwrap_exc_or(res, false)
 }
 
+/// Returns true when the provided key encoding is a valid unified incoming viewing key for the
+/// given network, false in any other case.
+///
+/// # Safety
+///
+/// - `uivk` must be non-null and must point to a null-terminated UTF-8 string.
+/// - The memory referenced by `uivk` must not be mutated for the duration of the
+///   function call.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn zcashlc_is_valid_unified_incoming_viewing_key(
+    uivk: *const c_char,
+    network_id: u32,
+) -> bool {
+    let res = catch_panic(|| {
+        let network = parse_network(network_id)?;
+        let uivkstr = unsafe { CStr::from_ptr(uivk).to_str()? };
+
+        Ok(UnifiedIncomingViewingKey::decode(&network, uivkstr).is_ok())
+    });
+    unwrap_exc_or(res, false)
+}
+
 /// Derives and returns a unified spending key from the given seed for the given account ID.
 ///
 /// Returns the binary encoding of the spending key. The caller should manage the memory of (and

--- a/rust/src/ffi.rs
+++ b/rust/src/ffi.rs
@@ -28,6 +28,7 @@ pub struct Account {
     seed_fingerprint: [u8; 32],
     hd_account_index: u32,
     ufvk: *mut c_char,
+    uivk: *mut c_char,
 }
 
 impl Account {
@@ -38,6 +39,7 @@ impl Account {
         seed_fingerprint: [0u8; 32],
         hd_account_index: u32::MAX,
         ufvk: ptr::null_mut(),
+        uivk: ptr::null_mut(),
     };
 
     pub(crate) fn from_account(
@@ -58,6 +60,10 @@ impl Account {
             hd_account_index: derivation.map_or(u32::MAX, |d| d.account_index().into()),
             ufvk: account.ufvk().map_or(ptr::null_mut(), |ufvk| {
                 CString::new(ufvk.encode(params)).unwrap().into_raw()
+            }),
+            uivk: account.ufvk().map_or(ptr::null_mut(), |ufvk| {
+                let uivk = ufvk.to_unified_incoming_viewing_key();
+                CString::new(uivk.encode(params)).unwrap().into_raw()
             }),
         }
     }
@@ -80,6 +86,9 @@ pub unsafe extern "C" fn zcashlc_free_account(ptr: *mut Account) {
         }
         if !(account.ufvk.is_null()) {
             unsafe { zcashlc_string_free(account.ufvk) }
+        }
+        if !(account.uivk.is_null()) {
+            unsafe { zcashlc_string_free(account.uivk) }
         }
         drop(account);
     }


### PR DESCRIPTION
Derives the Unified Incoming Viewing Key from the UFVK in the Rust FFI layer and exposes it through the Swift Account struct, enabling clients to access the UIVK without needing the full viewing key.

# Author
<!-- NOTE: Do not modify these when initially opening the pull request.  This is a checklist template that you tick off AFTER the pull request is created. -->
- [x] Self-review: Did you review your own code in GitHub's web interface? Code often looks different when reviewing the diff in a browser, making it easier to spot potential bugs.
- [ ] Automated tests: Did you add appropriate automated tests for any code changes?
- [ ] Code coverage: Did you check the code coverage report for the automated tests?  While we are not looking for perfect coverage, the tool can point out potential cases that have been missed.
- [ ] Documentation: Did you update Docs as appropiate? (E.g [README.md](../blob/main/README.md), etc.)
- [ ] Run the app: Did you run the app and try the changes? 
- [ ] Did you provide Screenshots of what the App looks like before and after your changes as part of the description of this PR? (only applicable to UI Changes)
- [x] Rebase and squash: Did you pull in the latest changes from the main branch and squash your commits before assigning a reviewer? Having your code up to date and squashed will make it easier for others to review. Use best judgement when squashing commits, as some changes (such as refactoring) might be easier to review as a separate commit.


# Reviewer

- [ ] Checklist review: Did you go through the code with the [Code Review Guidelines](../blob/main/CODE_REVIEW_GUIDELINES.md) checklist?
- [ ] Ad hoc review: Did you perform an ad hoc review?  _In addition to a first pass using the code review guidelines, do a second pass using your best judgement and experience which may identify additional questions or comments. Research shows that code review is most effective when done in multiple passes, where reviewers look for different things through each pass._
- [ ] Automated tests: Did you review the automated tests?
- [ ] Manual tests: Did you review the manual tests?_You will find manual testing guidelines under our [manual testing section](../blob/mater/docs/testing/manual_testing)_
- [ ] How is Code Coverage affected by this PR? _We encourage you to compare coverage befor and after your changes and when possible, leave it in a better place. [Learn More...](../blob/master/docs/testing/local_coverage.md)_
- [ ] Documentation: Did you review Docs, [README.md](../blob/master/README.md), [LICENSE.md](../blob/master/LICENSE.md), and [Architecture.md](../blob/master/docs/Architecture.md) as appropriate?
- [ ] Run the app: Did you run the app and try the changes? While the CI server runs the app to look for build failures or crashes, humans running the app are more likely to notice unexpected log messages, UI inconsistencies, or bad output data.