### PR TITLE
Fix network error after wallet restore

### DIFF
--- a/Sources/ZcashLightClientKit/Modules/Service/GRPC/LightWalletGRPCService.swift
+++ b/Sources/ZcashLightClientKit/Modules/Service/GRPC/LightWalletGRPCService.swift
@@ -122,8 +122,7 @@ class LightWalletGRPCService: LightWalletService {
     }
 
     deinit {
-        _ = channel?.close()
-        _ = compactTxStreamer.channel.close()
+        stop()
     }
 
     func resolveLazyConnect() -> CompactTxStreamerAsyncClient {
@@ -159,6 +158,8 @@ class LightWalletGRPCService: LightWalletService {
 
     func stop() {
         _ = channel?.close()
+        channel = nil
+        compactTxStreamerInternal = nil
     }
 
     func latestBlock(mode: ServiceMode) async throws -> BlockID {
@@ -450,7 +451,7 @@ class LightWalletGRPCService: LightWalletService {
     }
     
     func closeConnections() async {
-        _ = channel?.close()
+        stop()
     }
 }
 


### PR DESCRIPTION
**Problem:** 
If you reset Zodl and restore a wallet, Zodl will not connect to a server, and requires quitting. If you quit Zodl after resetting but before restoring, Zodl connects to server.

**Steps to replicate:**
- Reset Zodl (I unchecked keeping a backup)
- Wallet goes back to the main screen, choose restore wallet.
- Input seed and height, click restore (chose to keep Tor off)
- Unexpectedly, wallet throws 'Error encountered while syncing, attempting to resolve'

Important part of the thrown message is: `unavailable (14): Connection was shutdown by the user`. This is error from inside the GRPC library. It means that our code is using channel that was already shut down

**What is going on:**
1. After the restore app asks user if tor should be enabled or not. And after that this function from SDK is called: `public func tor(enabled: Bool) async throws`. 
2. Ultimately `LightWalletGRPCService.closeConnection()` is called. In this function GRPC channel is closed but it's instance is not destroyed.
3. Next call via closed channel fails. Channel instance is created in `resolveLazyConnect()`. But this function creates new channel only when `self.channel` is nil. So if channel is closed but not destroyed code doesn't create new channel and use closed one.

**Fix:**
Not only close GRPC channel but also destroy it's instance in `LightWalletGRPCService.closeConnection()` and `LightWalletGRPCService.stop()` functions. 