### PR TITLE
[#1663] Add walletBirthday parameter to importAccount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
+## Added
+- Optional `walletBirthday` parameter on `Synchronizer.importAccount()` to sync from an earlier block height instead of the chain tip. Existing callers are unaffected (defaults to `nil`).
+
 # 2.4.9 - 2026-04-04
 
 ## Checkpoints

--- a/Sources/ZcashLightClientKit/ClosureSynchronizer.swift
+++ b/Sources/ZcashLightClientKit/ClosureSynchronizer.swift
@@ -134,6 +134,7 @@ public protocol ClosureSynchronizer {
         purpose: AccountPurpose,
         name: String,
         keySource: String?,
+        walletBirthday: BlockHeight?,
         completion: @escaping (Result<AccountUUID, Error>) -> Void
     ) async throws
 
@@ -168,4 +169,28 @@ public protocol ClosureSynchronizer {
      */
     func rewind(_ policy: RewindPolicy) -> CompletablePublisher<Error>
     func wipe() -> CompletablePublisher<Error>
+}
+
+extension ClosureSynchronizer {
+    // swiftlint:disable:next function_parameter_count
+    public func importAccount(
+        ufvk: String,
+        seedFingerprint: [UInt8]?,
+        zip32AccountIndex: Zip32AccountIndex?,
+        purpose: AccountPurpose,
+        name: String,
+        keySource: String?,
+        completion: @escaping (Result<AccountUUID, Error>) -> Void
+    ) async throws {
+        try await importAccount(
+            ufvk: ufvk,
+            seedFingerprint: seedFingerprint,
+            zip32AccountIndex: zip32AccountIndex,
+            purpose: purpose,
+            name: name,
+            keySource: keySource,
+            walletBirthday: nil,
+            completion: completion
+        )
+    }
 }

--- a/Sources/ZcashLightClientKit/CombineSynchronizer.swift
+++ b/Sources/ZcashLightClientKit/CombineSynchronizer.swift
@@ -128,7 +128,8 @@ public protocol CombineSynchronizer {
         zip32AccountIndex: Zip32AccountIndex?,
         purpose: AccountPurpose,
         name: String,
-        keySource: String?
+        keySource: String?,
+        walletBirthday: BlockHeight?
     ) async throws -> SinglePublisher<AccountUUID, Error>
 
     var allTransactions: SinglePublisher<[ZcashTransaction.Overview], Never> { get }
@@ -155,4 +156,26 @@ public protocol CombineSynchronizer {
     
     func rewind(_ policy: RewindPolicy) -> CompletablePublisher<Error>
     func wipe() -> CompletablePublisher<Error>
+}
+
+extension CombineSynchronizer {
+    // swiftlint:disable:next function_parameter_count
+    public func importAccount(
+        ufvk: String,
+        seedFingerprint: [UInt8]?,
+        zip32AccountIndex: Zip32AccountIndex?,
+        purpose: AccountPurpose,
+        name: String,
+        keySource: String?
+    ) async throws -> SinglePublisher<AccountUUID, Error> {
+        try await importAccount(
+            ufvk: ufvk,
+            seedFingerprint: seedFingerprint,
+            zip32AccountIndex: zip32AccountIndex,
+            purpose: purpose,
+            name: name,
+            keySource: keySource,
+            walletBirthday: nil
+        )
+    }
 }

--- a/Sources/ZcashLightClientKit/Synchronizer.swift
+++ b/Sources/ZcashLightClientKit/Synchronizer.swift
@@ -358,7 +358,8 @@ public protocol Synchronizer: AnyObject {
         zip32AccountIndex: Zip32AccountIndex?,
         purpose: AccountPurpose,
         name: String,
-        keySource: String?
+        keySource: String?,
+        walletBirthday: BlockHeight?
     ) async throws -> AccountUUID
 
     func fetchTxidsWithMemoContaining(searchTerm: String) async throws -> [Data]
@@ -526,6 +527,28 @@ public protocol Synchronizer: AnyObject {
     ///
     /// - Throws rustDeleteAccount as a common indicator of the operation failure
     func deleteAccount(_ accountUUID: AccountUUID) async throws -> Void
+}
+
+extension Synchronizer {
+    // swiftlint:disable:next function_parameter_count
+    public func importAccount(
+        ufvk: String,
+        seedFingerprint: [UInt8]?,
+        zip32AccountIndex: Zip32AccountIndex?,
+        purpose: AccountPurpose,
+        name: String,
+        keySource: String?
+    ) async throws -> AccountUUID {
+        try await importAccount(
+            ufvk: ufvk,
+            seedFingerprint: seedFingerprint,
+            zip32AccountIndex: zip32AccountIndex,
+            purpose: purpose,
+            name: name,
+            keySource: keySource,
+            walletBirthday: nil
+        )
+    }
 }
 
 public enum SyncStatus: Equatable {

--- a/Sources/ZcashLightClientKit/Synchronizer/ClosureSDKSynchronizer.swift
+++ b/Sources/ZcashLightClientKit/Synchronizer/ClosureSDKSynchronizer.swift
@@ -99,6 +99,7 @@ extension ClosureSDKSynchronizer: ClosureSynchronizer {
         purpose: AccountPurpose,
         name: String,
         keySource: String?,
+        walletBirthday: BlockHeight? = nil,
         completion: @escaping (Result<AccountUUID, Error>) -> Void
     ) async throws {
         AsyncToClosureGateway.executeThrowingAction(completion) {
@@ -108,7 +109,8 @@ extension ClosureSDKSynchronizer: ClosureSynchronizer {
                 zip32AccountIndex: zip32AccountIndex,
                 purpose: purpose,
                 name: name,
-                keySource: keySource
+                keySource: keySource,
+                walletBirthday: walletBirthday
             )
         }
     }

--- a/Sources/ZcashLightClientKit/Synchronizer/CombineSDKSynchronizer.swift
+++ b/Sources/ZcashLightClientKit/Synchronizer/CombineSDKSynchronizer.swift
@@ -186,7 +186,8 @@ extension CombineSDKSynchronizer: CombineSynchronizer {
         zip32AccountIndex: Zip32AccountIndex?,
         purpose: AccountPurpose,
         name: String,
-        keySource: String?
+        keySource: String?,
+        walletBirthday: BlockHeight? = nil
     ) async throws -> SinglePublisher<AccountUUID, Error> {
         AsyncToCombineGateway.executeThrowingAction() {
             try await self.synchronizer.importAccount(
@@ -195,7 +196,8 @@ extension CombineSDKSynchronizer: CombineSynchronizer {
                 zip32AccountIndex: zip32AccountIndex,
                 purpose: purpose,
                 name: name,
-                keySource: keySource
+                keySource: keySource,
+                walletBirthday: walletBirthday
             )
         }
     }

--- a/Sources/ZcashLightClientKit/Synchronizer/SDKSynchronizer.swift
+++ b/Sources/ZcashLightClientKit/Synchronizer/SDKSynchronizer.swift
@@ -337,7 +337,8 @@ public class SDKSynchronizer: Synchronizer {
         zip32AccountIndex: Zip32AccountIndex?,
         purpose: AccountPurpose,
         name: String,
-        keySource: String?
+        keySource: String?,
+        walletBirthday: BlockHeight? = nil
     ) async throws -> AccountUUID {
         // called when a new account is imported
         let chainTip = try? await UInt32(
@@ -351,9 +352,9 @@ public class SDKSynchronizer: Synchronizer {
         guard let chainTip else {
             throw ZcashError.synchronizerNotPrepared
         }
-        
-        let checkpoint = checkpointSource.birthday(for: BlockHeight(chainTip))
-            
+
+        let checkpoint = checkpointSource.birthday(for: walletBirthday ?? BlockHeight(chainTip))
+
         return try await initializer.rustBackend.importAccount(
             ufvk: ufvk,
             seedFingerprint: seedFingerprint,

--- a/Tests/TestUtils/Sourcery/GeneratedMocks/AutoMockable.generated.swift
+++ b/Tests/TestUtils/Sourcery/GeneratedMocks/AutoMockable.generated.swift
@@ -2088,18 +2088,18 @@ class SynchronizerMock: Synchronizer {
     var importAccountUfvkSeedFingerprintZip32AccountIndexPurposeNameKeySourceCalled: Bool {
         return importAccountUfvkSeedFingerprintZip32AccountIndexPurposeNameKeySourceCallsCount > 0
     }
-    var importAccountUfvkSeedFingerprintZip32AccountIndexPurposeNameKeySourceReceivedArguments: (ufvk: String, seedFingerprint: [UInt8]?, zip32AccountIndex: Zip32AccountIndex?, purpose: AccountPurpose, name: String, keySource: String?)?
+    var importAccountUfvkSeedFingerprintZip32AccountIndexPurposeNameKeySourceReceivedArguments: (ufvk: String, seedFingerprint: [UInt8]?, zip32AccountIndex: Zip32AccountIndex?, purpose: AccountPurpose, name: String, keySource: String?, walletBirthday: BlockHeight?)?
     var importAccountUfvkSeedFingerprintZip32AccountIndexPurposeNameKeySourceReturnValue: AccountUUID!
-    var importAccountUfvkSeedFingerprintZip32AccountIndexPurposeNameKeySourceClosure: ((String, [UInt8]?, Zip32AccountIndex?, AccountPurpose, String, String?) async throws -> AccountUUID)?
+    var importAccountUfvkSeedFingerprintZip32AccountIndexPurposeNameKeySourceClosure: ((String, [UInt8]?, Zip32AccountIndex?, AccountPurpose, String, String?, BlockHeight?) async throws -> AccountUUID)?
 
-    func importAccount(ufvk: String, seedFingerprint: [UInt8]?, zip32AccountIndex: Zip32AccountIndex?, purpose: AccountPurpose, name: String, keySource: String?) async throws -> AccountUUID {
+    func importAccount(ufvk: String, seedFingerprint: [UInt8]?, zip32AccountIndex: Zip32AccountIndex?, purpose: AccountPurpose, name: String, keySource: String?, walletBirthday: BlockHeight?) async throws -> AccountUUID {
         if let error = importAccountUfvkSeedFingerprintZip32AccountIndexPurposeNameKeySourceThrowableError {
             throw error
         }
         importAccountUfvkSeedFingerprintZip32AccountIndexPurposeNameKeySourceCallsCount += 1
-        importAccountUfvkSeedFingerprintZip32AccountIndexPurposeNameKeySourceReceivedArguments = (ufvk: ufvk, seedFingerprint: seedFingerprint, zip32AccountIndex: zip32AccountIndex, purpose: purpose, name: name, keySource: keySource)
+        importAccountUfvkSeedFingerprintZip32AccountIndexPurposeNameKeySourceReceivedArguments = (ufvk: ufvk, seedFingerprint: seedFingerprint, zip32AccountIndex: zip32AccountIndex, purpose: purpose, name: name, keySource: keySource, walletBirthday: walletBirthday)
         if let closure = importAccountUfvkSeedFingerprintZip32AccountIndexPurposeNameKeySourceClosure {
-            return try await closure(ufvk, seedFingerprint, zip32AccountIndex, purpose, name, keySource)
+            return try await closure(ufvk, seedFingerprint, zip32AccountIndex, purpose, name, keySource, walletBirthday)
         } else {
             return importAccountUfvkSeedFingerprintZip32AccountIndexPurposeNameKeySourceReturnValue
         }


### PR DESCRIPTION
Closes: https://github.com/zcash/zcash-swift-wallet-sdk/issues/1663

## Summary
- Adds optional `walletBirthday: BlockHeight?` parameter to `importAccount()`
- When provided, uses the given birthday for the checkpoint instead of the current chain tip, enabling sync from an earlier block height
- Backward compatible. Existing callers default to `nil` (current chain tip behavior)

## Motivation
When importing a Keystone wallet, the birthday is hardcoded to the chain tip, causing the wallet to miss all historical transactions.

## Testing
Manual testing this change in conjunction with a modified zodl + my keystone and was able to sync the notes that I was previously not able to get without the hacky hot wallet import work around.

<table>
  <tr>
    <td><img width="330" alt="IMG_0664" src="https://github.com/user-attachments/assets/622e276f-37d1-4d29-924f-01c1ee4b4e81" /></td>
    <td><img width="330" alt="IMG_0665" src="https://github.com/user-attachments/assets/07e0ef48-1472-468a-8a85-e926d6986bb5" /></td>
  </tr>
</table>

---

This code review checklist is intended to serve as a starting point for the author and reviewer, although it may not be appropriate for all types of changes (e.g. fixing a spelling typo in documentation).  For more in-depth discussion of how we think about code review, please see [Code Review Guidelines](../blob/main/CODE_REVIEW_GUIDELINES.md).

# Author
<!-- NOTE: Do not modify these when initially opening the pull request.  This is a checklist template that you tick off AFTER the pull request is created. -->
- [x] Self-review: Did you review your own code in GitHub's web interface? Code often looks different when reviewing the diff in a browser, making it easier to spot potential bugs.
- [x] Automated tests: Did you add appropriate automated tests for any code changes?
- [x] Code coverage: Did you check the code coverage report for the automated tests?  While we are not looking for perfect coverage, the tool can point out potential cases that have been missed.
- [x] Documentation: Did you update Docs as appropiate? (E.g [README.md](../blob/main/README.md), etc.)
- [x] Run the app: Did you run the app and try the changes? 
- [x] Did you provide Screenshots of what the App looks like before and after your changes as part of the description of this PR? (only applicable to UI Changes)
- [x] Rebase and squash: Did you pull in the latest changes from the main branch and squash your commits before assigning a reviewer? Having your code up to date and squashed will make it easier for others to review. Use best judgement when squashing commits, as some changes (such as refactoring) might be easier to review as a separate commit.


# Reviewer

- [ ] Checklist review: Did you go through the code with the [Code Review Guidelines](../blob/main/CODE_REVIEW_GUIDELINES.md) checklist?
- [ ] Ad hoc review: Did you perform an ad hoc review?  _In addition to a first pass using the code review guidelines, do a second pass using your best judgement and experience which may identify additional questions or comments. Research shows that code review is most effective when done in multiple passes, where reviewers look for different things through each pass._
- [ ] Automated tests: Did you review the automated tests?
- [ ] Manual tests: Did you review the manual tests?_You will find manual testing guidelines under our [manual testing section](../blob/mater/docs/testing/manual_testing)_
- [ ] How is Code Coverage affected by this PR? _We encourage you to compare coverage befor and after your changes and when possible, leave it in a better place. [Learn More...](../blob/master/docs/testing/local_coverage.md)_
- [ ] Documentation: Did you review Docs, [README.md](../blob/master/README.md), [LICENSE.md](../blob/master/LICENSE.md), and [Architecture.md](../blob/master/docs/Architecture.md) as appropriate?
- [ ] Run the app: Did you run the app and try the changes? While the CI server runs the app to look for build failures or crashes, humans running the app are more likely to notice unexpected log messages, UI inconsistencies, or bad output data.