### PR TITLE
feat: use chain-tip tree state for new wallet birthday

### DIFF
--- a/Sources/ZcashLightClientKit/Initializer.swift
+++ b/Sources/ZcashLightClientKit/Initializer.swift
@@ -450,19 +450,33 @@ public class Initializer {
         // If there are no accounts it must be created, the default amount of accounts is 1
         if let seed, try await rustBackend.listAccounts().isEmpty {
             var chainTip: UInt32?
-            
+            var accountTreeState = checkpoint.treeState()
+
             let sdkFlags = container.resolve(SDKFlags.self)
-            
-            // called when client starts and restore of the wallet is in progress
-            if walletMode == .restoreWallet {
+
+            if walletMode == .restoreWallet || walletMode == .newWallet {
                 if let latestBlockHeight = try? await lightWalletService.latestBlockHeight(mode: await sdkFlags.ifTor(.uniqueTor)) {
-                    chainTip = UInt32(latestBlockHeight)
+                    if walletMode == .restoreWallet {
+                        chainTip = UInt32(latestBlockHeight)
+                    }
+
+                    // For new wallets, fetch the tree state at the chain tip so the birthday
+                    // equals chain_tip + 1, producing zero scan ranges. This eliminates
+                    // unnecessary block scanning for wallets with no transaction history.
+                    if walletMode == .newWallet {
+                        var blockID = BlockID()
+                        blockID.height = UInt64(latestBlockHeight)
+                        if let serverTreeState = try? await lightWalletService.getTreeState(blockID, mode: await sdkFlags.ifTor(.uniqueTor)) {
+                            accountTreeState = serverTreeState
+                            self.walletBirthday = latestBlockHeight
+                        }
+                    }
                 }
             }
-            
+
             _ = try await rustBackend.createAccount(
                 seed: seed,
-                treeState: checkpoint.treeState(),
+                treeState: accountTreeState,
                 recoverUntil: chainTip,
                 name: name,
                 keySource: keySource


### PR DESCRIPTION
## Summary

- For `WalletInitMode.newWallet`, fetches the chain tip height and tree state from the lightwalletd server during `Initializer.initialize()`
- Uses the server-provided tree state (instead of the bundled checkpoint) when calling `createAccount`, setting the wallet birthday to the chain tip height
- This produces zero scan ranges in the Rust backend, eliminating unnecessary block scanning for wallets with no transaction history
- Falls back to the bundled checkpoint if the server is unreachable (preserving current behavior)

## Context

When creating a new wallet, the birthday was previously set to the latest checkpoint bundled in the SDK at build time. This could be days to months behind the actual chain tip, causing the SDK to trial-decrypt thousands of compact blocks for a wallet that provably has zero history.

Refs ZCA148

## Test plan

- [ ] Unit test: mock light wallet service to return tree state for height N; verify `createAccount` is called with server tree state
- [ ] Unit test: mock server failure; verify fallback to bundled checkpoint
- [ ] Integration test: create new wallet; verify `suggestScanRanges()` returns empty after init
- [ ] Manual test: create new wallet on device; observe sync completes in <1s instead of minutes