### PR TITLE
zcash-swift-wallet-sdk: Nullifier PIR integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
+## Added
+- Nullifier PIR (Private Information Retrieval) integration for Orchard note spendability detection without waiting for shard-tree scanning.
+  - `SpendabilityBackend` / `SpendabilityTypes` — Swift wrappers for the new Rust FFI.
+  - `Synchronizer.checkWalletSpendability` / `getPIRPendingSpends` — public API surface.
+  - `SDKFlags.pirCompleted` lifecycle flag.
+
 # 2.4.8 - 2026-03-25
 
 ## Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,7 +48,7 @@ dependencies = [
  "amplify_derive",
  "amplify_num",
  "ascii",
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
  "getrandom 0.3.4",
  "wasm-bindgen",
 ]
@@ -102,9 +102,9 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
-version = "0.6.21"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -117,15 +117,15 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
@@ -152,9 +152,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.100"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "arrayref"
@@ -191,7 +191,7 @@ dependencies = [
  "rand 0.9.2",
  "safelog",
  "serde",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "time",
  "tor-async-utils",
  "tor-basic-utils",
@@ -235,7 +235,7 @@ dependencies = [
  "nom",
  "num-traits",
  "rusticata-macros",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -246,7 +246,7 @@ checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -258,7 +258,7 @@ checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -291,7 +291,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -351,9 +351,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "axum"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b098575ebe77cb6d14fc7f32749631a6e44edbef6b796f89b020e99ba20d425"
+checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
 dependencies = [
  "axum-core",
  "bytes",
@@ -376,9 +376,9 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
-version = "0.5.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59446ce19cd142f8833f856eb31f3eb097812d1479ab224f54d72428ca21ea22"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
 dependencies = [
  "bytes",
  "futures-core",
@@ -406,15 +406,15 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64ct"
-version = "1.8.0"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bech32"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d965446196e3b7decd44aa7ee49e31d630118f90ef12f97900f262eb915c951d"
+checksum = "32637268377fc7b10a8c6d51de3e7fba1ce5dd371a96e342b34e6078db558e7f"
 
 [[package]]
 name = "bellman"
@@ -453,7 +453,7 @@ version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
@@ -464,7 +464,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -491,9 +491,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "bitvec"
@@ -509,9 +509,9 @@ dependencies = [
 
 [[package]]
 name = "blake2b_simd"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06e903a20b159e944f91ec8499fe1e55651480c541ea0a584f5d967c49ad9d99"
+checksum = "b79834656f71332577234b50bfc009996f7449e0c056884e6a02492ded0ca2f3"
 dependencies = [
  "arrayref",
  "arrayvec",
@@ -520,9 +520,9 @@ dependencies = [
 
 [[package]]
 name = "blake2s_simd"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e90f7deecfac93095eb874a40febd69427776e24e1bd7f87f33ac62d6f0174df"
+checksum = "ee29928bad1e3f94c9d1528da29e07a1d3d04817ae8332de1e8b846c8439f4b3"
 dependencies = [
  "arrayref",
  "arrayvec",
@@ -537,7 +537,7 @@ checksum = "e0b121a9fe0df916e362fb3271088d071159cdf11db0e4182d02152850756eff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -577,7 +577,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09dc0086e469182132244e9b8d313a0742e1132da43a08c24b9dd3c18e0faf3a"
 dependencies = [
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -603,9 +603,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.19.0"
+version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "by_address"
@@ -615,9 +615,9 @@ checksum = "64fa3c856b712db6612c019f14756e64e4bcea13337a6b33b696333a9eaa2d06"
 
 [[package]]
 name = "bytemuck"
-version = "1.24.0"
+version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fbdf580320f38b612e485521afda1ee26d10cc9884efaaa750d383e13e3c5f4"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 
 [[package]]
 name = "byteorder"
@@ -627,9 +627,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "caret"
@@ -660,22 +660,22 @@ checksum = "befbfd072a8e81c02f8c507aefce431fe5e7d051f83d48a23ffc9b9fe5a11799"
 dependencies = [
  "clap",
  "heck",
- "indexmap 2.12.1",
+ "indexmap 2.13.1",
  "log",
  "proc-macro2",
  "quote",
  "serde",
  "serde_json",
- "syn 2.0.111",
+ "syn 2.0.117",
  "tempfile",
- "toml 0.9.8",
+ "toml 0.9.12+spec-1.1.0",
 ]
 
 [[package]]
 name = "cc"
-version = "1.2.47"
+version = "1.2.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd405d82c84ff7f35739f175f67d8b9fb7687a0e84ccdc78bd3568839827cf07"
+checksum = "b7a4d3ec6524d28a329fc53654bbadc9bdd7b0431f5d65f1a56ffb28a1ee5283"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -697,6 +697,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chacha20"
@@ -724,9 +730,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.42"
+version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
  "num-traits",
@@ -785,18 +791,19 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.53"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9e340e012a1bf4935f5282ed1436d1489548e8f72308207ea5df0e23d2d03f8"
+checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
 dependencies = [
  "clap_builder",
+ "clap_derive",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.53"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d76b5d13eaa18c901fd2f7fca939fefe3a0727a953561fefdf3b2922b8569d00"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
  "anstream",
  "anstyle",
@@ -805,16 +812,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "clap_lex"
-version = "0.7.6"
+name = "clap_derive"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
+checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "coarsetime"
-version = "0.1.36"
+version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91849686042de1b41cd81490edc83afbcb0abe5a9b6f2c4114f23ce8cca1bcf4"
+checksum = "e58eb270476aa4fc7843849f8a35063e8743b4dbcdf6dd0f8ea0886980c204c2"
 dependencies = [
  "libc",
  "wasix",
@@ -827,14 +846,14 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
 dependencies = [
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "colorchoice"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "concurrent-queue"
@@ -853,15 +872,15 @@ checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "constant_time_eq"
-version = "0.3.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
+checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
 name = "convert_case"
-version = "0.7.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb402b8d4c85569410425650ce3eddc7d698ed96d39a73f941b08fb63082f1e7"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
 dependencies = [
  "unicode-segmentation",
 ]
@@ -1064,7 +1083,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1073,7 +1092,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70def8d72740e44d9f676d8dab2c933a236663d86dd24319b57a2bed4d694774"
 dependencies = [
- "petgraph",
+ "petgraph 0.7.1",
 ]
 
 [[package]]
@@ -1121,7 +1140,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.11.1",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1143,14 +1162,14 @@ checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
  "darling_core 0.21.3",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "data-encoding"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
+checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
 name = "der"
@@ -1204,14 +1223,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd5f2b7218a51c827a11d22d1439b598121fac94bf9b99452e4afffe512d78c9"
 dependencies = [
  "heck",
- "indexmap 2.12.1",
+ "indexmap 2.13.1",
  "itertools 0.14.0",
  "proc-macro-crate",
  "proc-macro2",
  "quote",
  "sha3",
  "strum",
- "syn 2.0.111",
+ "syn 2.0.117",
  "void",
 ]
 
@@ -1248,23 +1267,24 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
-version = "2.0.1"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "093242cf7570c207c83073cf82f79706fe7b8317e98620a47d5be7c3d8497678"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
 dependencies = [
  "derive_more-impl",
 ]
 
 [[package]]
 name = "derive_more-impl"
-version = "2.0.1"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
 dependencies = [
  "convert_case",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "rustc_version",
+ "syn 2.0.117",
  "unicode-xid",
 ]
 
@@ -1329,7 +1349,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1370,7 +1390,7 @@ checksum = "0b0713d5c1d52e774c5cd7bb8b043d7c0fc4f921abfb678556140bfbe6ab2364"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1472,7 +1492,7 @@ dependencies = [
  "num-traits",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1484,20 +1504,36 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
-name = "env_home"
-version = "0.1.0"
+name = "env_filter"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7f84e12ccf0a7ddc17a6c41c93326024c42920d7ee630d04950e6926645c0fe"
+checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "jiff",
+ "log",
+]
 
 [[package]]
 name = "equihash"
 version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca4f333d4ccc9d23c06593733673026efa71a332e028b00f12cf427b9677dce9"
+source = "git+https://github.com/p0mvn/librustzcash.git?rev=301e20e7f3c697a73b66b11a3a6cd28dca63968b#301e20e7f3c697a73b66b11a3a6cd28dca63968b"
 dependencies = [
  "blake2b_simd",
  "core2",
@@ -1533,8 +1569,7 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d42773cb15447644d170be20231a3268600e0c4cea8987d013b93ac973d3cf7"
+source = "git+https://github.com/p0mvn/librustzcash.git?rev=301e20e7f3c697a73b66b11a3a6cd28dca63968b#301e20e7f3c697a73b66b11a3a6cd28dca63968b"
 dependencies = [
  "blake2b_simd",
 ]
@@ -1600,21 +1635,20 @@ dependencies = [
 
 [[package]]
 name = "filetime"
-version = "0.2.26"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc0505cd1b6fa6580283f6bdf70a73fcf4aba1184038c90902b92b3dd0df63ed"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
 dependencies = [
  "cfg-if",
  "libc",
  "libredox",
- "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.5"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a3076410a55c90011c298b04d0cfa770b00fa04e1e3c97d3f6c9de105a03844"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "fixedbitset"
@@ -1624,9 +1658,9 @@ checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flate2"
-version = "1.1.5"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfe33edd8e85a12a67454e37f8c75e730830d83e313556ab9ebf9ee7fbeb3bfb"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -1649,6 +1683,15 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
 
 [[package]]
 name = "fpe"
@@ -1675,7 +1718,7 @@ dependencies = [
  "libc",
  "pwd-grp",
  "serde",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "walkdir",
 ]
 
@@ -1697,9 +1740,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1712,9 +1755,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1722,15 +1765,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1739,19 +1782,19 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1767,21 +1810,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-util"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1791,7 +1834,6 @@ dependencies = [
  "futures-task",
  "memchr",
  "pin-project-lite",
- "pin-utils",
  "slab",
 ]
 
@@ -1808,9 +1850,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -1828,9 +1870,22 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "wasip2",
+ "wasip3",
 ]
 
 [[package]]
@@ -1842,7 +1897,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1871,9 +1926,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3c0b69cfcb4e1b9f1bf2f53f95f766e4661169728ec61cd3fe5a0166f2d1386"
+checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1881,7 +1936,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap 2.12.1",
+ "indexmap 2.13.1",
  "slab",
  "tokio",
  "tokio-util",
@@ -1939,9 +1994,9 @@ dependencies = [
 
 [[package]]
 name = "halo2_proofs"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "019561b5f3be60731e7b72f3f7878c5badb4174362d860b03d3cf64cb47f90db"
+checksum = "05713f117155643ce10975e0bee44a274bcda2f4bb5ef29a999ad67c1fa8d4d3"
 dependencies = [
  "blake2b_simd",
  "ff",
@@ -2116,9 +2171,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2131,10 +2186,26 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "pin-utils",
  "smallvec",
  "tokio",
  "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -2152,18 +2223,20 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.18"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52e9a2a24dc5c6821e71a7030e1e14b7b632acac55c40e9d2e082c621261bb56"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
+ "base64",
  "bytes",
  "futures-channel",
- "futures-core",
  "futures-util",
  "http",
  "http-body",
  "hyper",
+ "ipnet",
  "libc",
+ "percent-encoding",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -2173,9 +2246,9 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.64"
+version = "0.1.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33e57f83510bb73707521ebaffa789ec8caf86f9657cad665b092b581d40e9fb"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -2196,10 +2269,119 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
 
 [[package]]
 name = "incrementalmerkletree"
@@ -2223,9 +2405,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.12.1"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ad4bb2b565bca0645f4d68c5c9af97fba094e9791da685bf83cb5f3ce74acf2"
+checksum = "45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff"
 dependencies = [
  "equivalent",
  "hashbrown 0.16.1",
@@ -2235,11 +2417,11 @@ dependencies = [
 
 [[package]]
 name = "inotify"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f37dccff2791ab604f9babef0ba14fbe0be30bd368dc541e2b08d07c8aa908f3"
+checksum = "bd5b3eaf1a28b758ac0faa5a4254e8ab2705605496f1b1f3fbbc3988ad73d199"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "inotify-sys",
  "libc",
 ]
@@ -2264,11 +2446,27 @@ dependencies = [
 
 [[package]]
 name = "inventory"
-version = "0.3.21"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc61209c082fbeb19919bee74b176221b27223e27b65d781eb91af24eb1fb46e"
+checksum = "a4f0c30c76f2f4ccee3fe55a2435f691ca00c0e4bd87abe4f4a851b1d4dac39b"
 dependencies = [
  "rustversion",
+]
+
+[[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
+name = "iri-string"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
+dependencies = [
+ "memchr",
+ "serde",
 ]
 
 [[package]]
@@ -2297,9 +2495,33 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.15"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "jiff"
+version = "0.2.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a3546dc96b6d42c5f24902af9e2538e82e39ad350b0c766eb3fbf2d8f3d8359"
+dependencies = [
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a8c8b344124222efd714b73bb41f8b5120b27a7cc1c75593a6ff768d9d05aa4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "jobserver"
@@ -2313,10 +2535,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.82"
+version = "0.3.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b011eec8cc36da2aab2d5cff675ec18454fad408585853910a202391cf9f8e65"
+checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -2337,18 +2561,18 @@ dependencies = [
 
 [[package]]
 name = "keccak"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654"
+checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
 dependencies = [
  "cpufeatures",
 ]
 
 [[package]]
 name = "known-folders"
-version = "1.4.0"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d463f34ca3c400fde3a054da0e0b8c6ffa21e4590922f3e18281bb5eeef4cbdc"
+checksum = "7a1886916523694cd6ea3d175f03a1e5010699a2a4cc13696d83d7bea1d80638"
 dependencies = [
  "windows-sys 0.61.2",
 ]
@@ -2383,10 +2607,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "libc"
-version = "0.2.177"
+name = "leb128fmt"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "libc"
+version = "0.2.184"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
 name = "libloading"
@@ -2400,19 +2630,20 @@ dependencies = [
 
 [[package]]
 name = "libm"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.10"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "416f7e718bdb06000964960ffa43b4335ad4012ae8b99060261aa4a8088d5ccb"
+checksum = "7ddbf48fd451246b1f8c2610bd3b4ac0cc6e149d89832867093ab69a17194f08"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "libc",
- "redox_syscall",
+ "plain",
+ "redox_syscall 0.7.3",
 ]
 
 [[package]]
@@ -2432,7 +2663,7 @@ version = "2.4.6"
 dependencies = [
  "anyhow",
  "bindgen",
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "bytes",
  "cbindgen",
  "cc",
@@ -2453,7 +2684,11 @@ dependencies = [
  "rust_decimal",
  "sapling-crypto",
  "secrecy",
+ "serde",
+ "serde_json",
  "sharded-slab",
+ "spend-client",
+ "spend-types",
  "tonic",
  "tor-rtcompat",
  "tracing",
@@ -2474,9 +2709,15 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "litrs"
@@ -2495,9 +2736,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.28"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "log-panics"
@@ -2507,6 +2748,12 @@ checksum = "68f9dd8546191c1850ecf67d22f5ff00a935b890d0e84713159a55495cc2ac5f"
 dependencies = [
  "log",
 ]
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lzma-sys"
@@ -2546,15 +2793,15 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.6"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "memmap2"
-version = "0.9.9"
+version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "744133e4a0e0a658e1374cf3bf8e415c4052a15a111acd372764c55b4177d490"
+checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
 dependencies = [
  "libc",
 ]
@@ -2601,9 +2848,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69d83b0086dc8ecf3ce9ae2874b2d1290252e2a30720bea58a5c6639b0092873"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "log",
@@ -2645,7 +2892,7 @@ version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "inotify",
  "kqueue",
  "libc",
@@ -2658,15 +2905,18 @@ dependencies = [
 
 [[package]]
 name = "notify-types"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e0826a989adedc2a244799e823aece04662b66609d96af8dff7ac6df9a8925d"
+checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
+dependencies = [
+ "bitflags 2.11.0",
+]
 
 [[package]]
 name = "ntapi"
-version = "0.4.1"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8a3895c6391c39d7fe7ebc444a87eb2991b2a0bc718fdabd071eec617fc68e4"
+checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
 dependencies = [
  "winapi",
 ]
@@ -2754,9 +3004,9 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1207a7e20ad57b847bbddc6776b968420d38292bbfe2089accff5e19e82454c"
+checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
 dependencies = [
  "num_enum_derive",
  "rustversion",
@@ -2764,14 +3014,14 @@ dependencies = [
 
 [[package]]
 name = "num_enum_derive"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff32365de1b6743cb203b710788263c44a03de03802daf96092f2da4fe6ba4d7"
+checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2780,7 +3030,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -2795,9 +3045,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -2956,7 +3206,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
  "windows-link 0.2.1",
 ]
@@ -2984,9 +3234,8 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pczt"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20367012e2faad5dd99ad6fcb1efcc3332e8ac83a7653854c3ae3889c517197c"
+version = "0.5.1"
+source = "git+https://github.com/p0mvn/librustzcash.git?rev=301e20e7f3c697a73b66b11a3a6cd28dca63968b#301e20e7f3c697a73b66b11a3a6cd28dca63968b"
 dependencies = [
  "blake2b_simd",
  "bls12_381",
@@ -3033,7 +3282,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
 dependencies = [
  "fixedbitset",
- "indexmap 2.12.1",
+ "indexmap 2.13.1",
+]
+
+[[package]]
+name = "petgraph"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
+dependencies = [
+ "fixedbitset",
+ "hashbrown 0.15.5",
+ "indexmap 2.13.1",
 ]
 
 [[package]]
@@ -3067,7 +3327,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3081,35 +3341,29 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.10"
+version = "1.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
+checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.10"
+version = "1.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
+checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
-
-[[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pkcs1"
@@ -3137,6 +3391,12 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plotters"
@@ -3178,6 +3438,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "091397be61a01d4be58e7841595bd4bfedb15f1cd54977d79b8271e94ed799a3"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
 name = "postage"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3205,6 +3480,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
 name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3226,7 +3510,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3245,17 +3529,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93980406f12d9f8140ed5abe7155acb10bb1e69ea55c88960b9c2f117445ef96"
 dependencies = [
  "equivalent",
- "indexmap 2.12.1",
+ "indexmap 2.13.1",
  "serde",
 ]
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit 0.23.7",
+ "toml_edit 0.25.10+spec-1.1.0",
 ]
 
 [[package]]
@@ -3277,23 +3561,23 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.103"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "prost"
-version = "0.14.1"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7231bd9b3d3d33c86b58adbac74b5ec0ad9f496b19d22801d773636feaa95f3d"
+checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -3301,42 +3585,41 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.14.1"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac6c3320f9abac597dcbc668774ef006702672474aad53c6d596b62e487b40b1"
+checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
  "heck",
  "itertools 0.14.0",
  "log",
  "multimap",
- "once_cell",
- "petgraph",
+ "petgraph 0.8.3",
  "prettyplease",
  "prost",
  "prost-types",
  "regex",
- "syn 2.0.111",
+ "syn 2.0.117",
  "tempfile",
 ]
 
 [[package]]
 name = "prost-derive"
-version = "0.14.1"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9120690fafc389a67ba3803df527d0ec9cbbc9cc45e4cc20b332996dfb672425"
+checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "prost-types"
-version = "0.14.1"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9b4db3d6da204ed77bb26ba83b6122a73aeb2e87e25fbf7ad2e84c4ccbf8f72"
+checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
 dependencies = [
  "prost",
 ]
@@ -3350,14 +3633,69 @@ dependencies = [
  "derive-deftly",
  "libc",
  "paste",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.2",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.42"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -3367,6 +3705,12 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "radium"
@@ -3392,7 +3736,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha 0.9.0",
- "rand_core 0.9.3",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -3412,7 +3756,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.9.3",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -3421,14 +3765,14 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
 ]
 
 [[package]]
 name = "rand_core"
-version = "0.9.3"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
@@ -3450,7 +3794,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b16df48f071248e67b8fc5e866d9448d45c08ad8b672baaaf796e2f15e606ff0"
 dependencies = [
  "libc",
- "rand_core 0.9.3",
+ "rand_core 0.9.5",
  "winapi",
 ]
 
@@ -3519,7 +3863,16 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
+dependencies = [
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -3528,9 +3881,9 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
  "libredox",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -3550,14 +3903,14 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "regex"
-version = "1.12.2"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3567,9 +3920,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3578,9 +3931,47 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.8"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+]
 
 [[package]]
 name = "retry-error"
@@ -3606,7 +3997,7 @@ checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
@@ -3632,9 +4023,9 @@ dependencies = [
 
 [[package]]
 name = "rsa"
-version = "0.9.9"
+version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40a0376c50d0358279d9d643e4bf7b7be212f1f4ff1da9070a7b54d22ef75c88"
+checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
 dependencies = [
  "const-oid",
  "digest 0.10.7",
@@ -3657,7 +4048,7 @@ version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "165ca6e57b20e1351573e3729b958bc62f0e48025386970b6e4d29e7a7e71f3f"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "fallible-iterator",
  "fallible-streaming-iterator",
  "hashlink",
@@ -3669,20 +4060,21 @@ dependencies = [
 
 [[package]]
 name = "rust_decimal"
-version = "1.39.0"
+version = "1.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35affe401787a9bd846712274d97654355d21b2a2c092a3139aabe31e9022282"
+checksum = "2ce901f9a19d251159075a4c37af514c3b8ef99c22e02dd8c19161cf397ee94a"
 dependencies = [
  "arrayvec",
  "num-traits",
  "serde",
+ "wasm-bindgen",
 ]
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustc_version"
@@ -3704,11 +4096,11 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.1.2"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -3717,9 +4109,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.35"
+version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "533f54bc6a7d4f647e46ad909549eda97bf5afc1585190ef692b4286b198bd8f"
+checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
  "log",
  "once_cell",
@@ -3732,10 +4124,11 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.13.0"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94182ad936a0c91c324cd46c6511b9510ed16af436d7b5bab34beab0afd55f7a"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -3758,9 +4151,9 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
-version = "1.0.20"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "safelog"
@@ -3772,7 +4165,7 @@ dependencies = [
  "educe",
  "either",
  "fluid-let",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -3840,9 +4233,9 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "1.1.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9558e172d4e8533736ba97870c4b2cd63f84b382a3d6eb063da41b91cce17289"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
 dependencies = [
  "dyn-clone",
  "ref-cast",
@@ -3964,7 +4357,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3979,15 +4372,15 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.145"
+version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
  "itoa",
  "memchr",
- "ryu",
  "serde",
  "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -4001,26 +4394,38 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "1.0.3"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e24345aa0fe688594e73770a5f6d1b216508b4f93484c0026d521acd30134392"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
-name = "serde_with"
-version = "3.16.0"
+name = "serde_urlencoded"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10574371d41b0d9b2cff89418eda27da52bcaff2cc8741db26382a77c29131f1"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_with"
+version = "3.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "381b283ce7bc6b476d903296fb59d0d36633652b633b27f64db4fb46dcbfc3b9"
 dependencies = [
  "base64",
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.12.1",
+ "indexmap 2.13.1",
  "schemars 0.9.0",
- "schemars 1.1.0",
+ "schemars 1.2.1",
  "serde_core",
  "serde_json",
  "serde_with_macros",
@@ -4029,14 +4434,14 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.16.0"
+version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08a72d8216842fdd57820dc78d840bef99248e35fb2554ff923319e60f2d686b"
+checksum = "a6d4e30573c8cb306ed6ab1dca8423eec9a463ea0e155f45399455e0368b27e0"
 dependencies = [
  "darling 0.21.3",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4097,7 +4502,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "359e552886ae54d1642091645980d83f7db465fd9b5b0248e3680713c1773388"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "either",
  "incrementalmerkletree",
  "tracing",
@@ -4105,9 +4510,9 @@ dependencies = [
 
 [[package]]
 name = "shellexpand"
-version = "3.1.1"
+version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b1fdf65dd6331831494dd616b30351c38e96e45921a27745cf98490458b90bb"
+checksum = "32824fab5e16e6c4d86dc1ba84489390419a39f97699852b66480bb87d297ed8"
 dependencies = [
  "bstr",
  "dirs",
@@ -4122,10 +4527,11 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.7"
+version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7664a098b8e616bdfcc2dc0e9ac44eb231eedf41db4e9fe95d8d32ec728dedad"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
+ "errno",
  "libc",
 ]
 
@@ -4141,9 +4547,9 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.7"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "sinsemilla"
@@ -4158,21 +4564,21 @@ dependencies = [
 
 [[package]]
 name = "siphasher"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
+checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "slab"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "slotmap"
-version = "1.0.7"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbff4acf519f630b3a3ddcfaea6c06b42174d9a44bc70c620e9ed1649d58b82a"
+checksum = "bdd58c3c93c3d278ca835519292445cb4b0d4dc59ccfdf7ceadaab3f8aeb4038"
 dependencies = [
  "serde",
  "version_check",
@@ -4187,7 +4593,7 @@ dependencies = [
  "paste",
  "serde",
  "slotmap",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "void",
 ]
 
@@ -4199,12 +4605,35 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "spend-client"
+version = "0.1.0"
+source = "git+https://github.com/valargroup/sync-nullifier-pir.git?rev=ab81f9811e8281855e27bdd3e89bce644674b326#ab81f9811e8281855e27bdd3e89bce644674b326"
+dependencies = [
+ "reqwest",
+ "serde_json",
+ "spend-types",
+ "spiral-rs",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "ypir",
+]
+
+[[package]]
+name = "spend-types"
+version = "0.1.0"
+source = "git+https://github.com/valargroup/sync-nullifier-pir.git?rev=ab81f9811e8281855e27bdd3e89bce644674b326#ab81f9811e8281855e27bdd3e89bce644674b326"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -4212,6 +4641,20 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
+name = "spiral-rs"
+version = "0.4.0"
+source = "git+https://github.com/valargroup/spiral-rs.git?branch=valar%2Favoid-avx512#e06c730f958ddd0717fda43ae43eb7c628290bd4"
+dependencies = [
+ "fastrand",
+ "getrandom 0.2.17",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "serde_json",
+ "sha2 0.10.9",
+ "subtle",
+]
 
 [[package]]
 name = "spki"
@@ -4266,6 +4709,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4301,7 +4750,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4323,9 +4772,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.111"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "390cc9a294ab71bdb1aa2e99d13be9c753cd2d7bd6560c77118597410c4d2e87"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4337,6 +4786,9 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
 
 [[package]]
 name = "synstructure"
@@ -4346,7 +4798,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4371,15 +4823,37 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
-version = "3.23.0"
+version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "test-log"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37d53ac171c92a39e4769491c4b4dde7022c60042254b5fc044ae409d34a24d4"
+dependencies = [
+ "env_logger",
+ "test-log-macros",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "test-log-macros"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be35209fd0781c5401458ab66e4f98accf63553e8fae7425503e92fdd319783b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4393,11 +4867,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.17",
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -4408,18 +4882,18 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4464,9 +4938,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "serde_core",
@@ -4485,9 +4959,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -4500,13 +4974,14 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.48.0"
+version = "1.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff360e02eab121e0bc37a2d3b4d4dc622e6eda3a8e5253d5435ecf5bd4c68408"
+checksum = "2bd1c4c0fc4a7ab90fc15ef6daaa3ec3b893f004f915f2392557ed23237820cd"
 dependencies = [
  "bytes",
  "libc",
  "mio",
+ "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
@@ -4516,13 +4991,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4537,9 +5012,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -4548,9 +5023,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.17"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2efa149fe76073d6e8fd97ef4f4eca7b67f599660115591483572e406e165594"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
 dependencies = [
  "bytes",
  "futures-core",
@@ -4574,17 +5049,17 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.9.8"
+version = "0.9.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0dc8b1fb61449e27716ec0e1bdf0f6b8f3e8f6b05391e8497b8b6d7804ea6d8"
+checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
- "indexmap 2.12.1",
+ "indexmap 2.13.1",
  "serde_core",
- "serde_spanned 1.0.3",
- "toml_datetime 0.7.3",
+ "serde_spanned 1.1.1",
+ "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow",
+ "winnow 0.7.15",
 ]
 
 [[package]]
@@ -4598,9 +5073,18 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.7.3"
+version = "0.7.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2cdb639ebbc97961c51720f858597f7f24c4fc295327923af55b74c3c724533"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
 ]
@@ -4611,33 +5095,33 @@ version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap 2.12.1",
+ "indexmap 2.13.1",
  "serde",
  "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
  "toml_write",
- "winnow",
+ "winnow 0.7.15",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.23.7"
+version = "0.25.10+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6485ef6d0d9b5d0ec17244ff7eb05310113c3f316f2d14200d4de56b3cb98f8d"
+checksum = "a82418ca169e235e6c399a84e395ab6debeb3bc90edc959bf0f48647c6a32d1b"
 dependencies = [
- "indexmap 2.12.1",
- "toml_datetime 0.7.3",
+ "indexmap 2.13.1",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
- "winnow",
+ "winnow 1.0.1",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.0.4"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0cbe268d35bdb4bb5a56a2de88d0ad0eb70af5384a99d648cd4b3d04039800e"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow",
+ "winnow 1.0.1",
 ]
 
 [[package]]
@@ -4648,15 +5132,15 @@ checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "toml_writer"
-version = "1.0.4"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df8b2b54733674ad286d16267dcfc7a71ed5c776e4ac7aa3c3e2561f7c637bf2"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tonic"
-version = "0.14.2"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb7613188ce9f7df5bfe185db26c5814347d110db17920415cf2fbcad85e7203"
+checksum = "fec7c61a0695dc1887c1b53952990f3ad2e3a31453e1f49f10e75424943a93ec"
 dependencies = [
  "async-trait",
  "axum",
@@ -4685,21 +5169,21 @@ dependencies = [
 
 [[package]]
 name = "tonic-build"
-version = "0.14.2"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c40aaccc9f9eccf2cd82ebc111adc13030d23e887244bc9cfa5d1d636049de3"
+checksum = "1882ac3bf5ef12877d7ed57aad87e75154c11931c2ba7e6cde5e22d63522c734"
 dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "tonic-prost"
-version = "0.14.2"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66bd50ad6ce1252d87ef024b3d64fe4c3cf54a86fb9ef4c631fdd0ded7aeaa67"
+checksum = "a55376a0bbaa4975a3f10d009ad763d8f4108f067c7c2e74f3001fb49778d309"
 dependencies = [
  "bytes",
  "prost",
@@ -4708,16 +5192,16 @@ dependencies = [
 
 [[package]]
 name = "tonic-prost-build"
-version = "0.14.2"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4a16cba4043dc3ff43fcb3f96b4c5c154c64cbd18ca8dce2ab2c6a451d058a2"
+checksum = "f3144df636917574672e93d0f56d7edec49f90305749c668df5101751bb8f95a"
 dependencies = [
  "prettyplease",
  "proc-macro2",
  "prost-build",
  "prost-types",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
  "tempfile",
  "tonic-build",
 ]
@@ -4734,7 +5218,7 @@ dependencies = [
  "oneshot-fused-workaround",
  "pin-project",
  "postage",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "void",
 ]
 
@@ -4754,7 +5238,7 @@ dependencies = [
  "serde",
  "slab",
  "smallvec",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -4769,7 +5253,7 @@ dependencies = [
  "educe",
  "getrandom 0.3.4",
  "safelog",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tor-error",
  "tor-llcrypto",
  "zeroize",
@@ -4782,7 +5266,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79ba1b43f22fab2daee3e0c902f1455b3aed8e086b2d83d8c60b36523b173d25"
 dependencies = [
  "amplify",
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "bytes",
  "caret",
  "derive-deftly",
@@ -4792,7 +5276,7 @@ dependencies = [
  "paste",
  "rand 0.9.2",
  "smallvec",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tor-basic-utils",
  "tor-bytes",
  "tor-cert",
@@ -4815,7 +5299,7 @@ dependencies = [
  "derive_builder_fork_arti",
  "derive_more",
  "digest 0.10.7",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tor-bytes",
  "tor-checkable",
  "tor-llcrypto",
@@ -4838,7 +5322,7 @@ dependencies = [
  "rand 0.9.2",
  "safelog",
  "serde",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tor-async-utils",
  "tor-basic-utils",
  "tor-cell",
@@ -4865,7 +5349,7 @@ checksum = "7c9839e9bb302f17447c350e290bb107084aca86c640882a91522f2059f6a686"
 dependencies = [
  "humantime",
  "signature",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tor-llcrypto",
 ]
 
@@ -4894,7 +5378,7 @@ dependencies = [
  "retry-error",
  "safelog",
  "serde",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tor-async-utils",
  "tor-basic-utils",
  "tor-cell",
@@ -4942,8 +5426,8 @@ dependencies = [
  "serde-value",
  "serde_ignored",
  "strum",
- "thiserror 2.0.17",
- "toml 0.9.8",
+ "thiserror 2.0.18",
+ "toml 0.9.12+spec-1.1.0",
  "tor-basic-utils",
  "tor-error",
  "tor-rtcompat",
@@ -4960,7 +5444,7 @@ dependencies = [
  "directories",
  "serde",
  "shellexpand",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tor-error",
  "tor-general-addr",
 ]
@@ -4973,7 +5457,7 @@ checksum = "c1690438c1fc778fc7c89c132e529365b1430d6afe03aeecbc2508324807bf0b"
 dependencies = [
  "digest 0.10.7",
  "hex",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tor-llcrypto",
 ]
 
@@ -4993,7 +5477,7 @@ dependencies = [
  "httpdate",
  "itertools 0.14.0",
  "memchr",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tor-circmgr",
  "tor-error",
  "tor-linkspec",
@@ -5058,7 +5542,7 @@ dependencies = [
  "signature",
  "static_assertions",
  "strum",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "time",
  "tor-async-utils",
  "tor-basic-utils",
@@ -5092,7 +5576,7 @@ dependencies = [
  "retry-error",
  "static_assertions",
  "strum",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tracing",
  "void",
 ]
@@ -5104,7 +5588,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c42cb5b5aec0584db2fba4a88c4e08fb09535ef61e4ef5674315a89e69ec31a2"
 dependencies = [
  "derive_more",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "void",
 ]
 
@@ -5133,7 +5617,7 @@ dependencies = [
  "safelog",
  "serde",
  "strum",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tor-async-utils",
  "tor-basic-utils",
  "tor-config",
@@ -5170,7 +5654,7 @@ dependencies = [
  "serde",
  "signature",
  "subtle",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tor-basic-utils",
  "tor-bytes",
  "tor-error",
@@ -5194,7 +5678,7 @@ dependencies = [
  "rsa",
  "signature",
  "ssh-key",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tor-bytes",
  "tor-cert",
  "tor-checkable",
@@ -5226,7 +5710,7 @@ dependencies = [
  "serde",
  "signature",
  "ssh-key",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tor-basic-utils",
  "tor-bytes",
  "tor-config",
@@ -5260,7 +5744,7 @@ dependencies = [
  "serde",
  "serde_with",
  "strum",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tor-basic-utils",
  "tor-bytes",
  "tor-config",
@@ -5290,7 +5774,7 @@ dependencies = [
  "rand 0.9.2",
  "rand_chacha 0.9.0",
  "rand_core 0.6.4",
- "rand_core 0.9.3",
+ "rand_core 0.9.5",
  "rand_jitter",
  "rdrand",
  "rsa",
@@ -5301,7 +5785,7 @@ dependencies = [
  "sha3",
  "signature",
  "subtle",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tor-error",
  "tor-memquota",
  "visibility",
@@ -5317,7 +5801,7 @@ checksum = "845d65304be6a614198027c4b2d1b35aaf073335c26df619d17e5f4027f2657f"
 dependencies = [
  "futures",
  "humantime",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tor-error",
  "tor-rtcompat",
  "tracing",
@@ -5343,7 +5827,7 @@ dependencies = [
  "slotmap-careful",
  "static_assertions",
  "sysinfo",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tor-async-utils",
  "tor-basic-utils",
  "tor-config",
@@ -5361,7 +5845,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "638b4e6507e3786488859d3c463fa73addbad4f788806c6972603727e527672e"
 dependencies = [
  "async-trait",
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "derive_more",
  "futures",
  "humantime",
@@ -5370,7 +5854,7 @@ dependencies = [
  "rand 0.9.2",
  "serde",
  "strum",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tor-basic-utils",
  "tor-error",
  "tor-linkspec",
@@ -5390,7 +5874,7 @@ checksum = "1dbc32d89e7ea2e2799168d0c453061647a727e39fc66f52e1bcb4c38c8dc433"
 dependencies = [
  "amplify",
  "base64ct",
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "cipher",
  "derive-deftly",
  "derive_builder_fork_arti",
@@ -5409,7 +5893,7 @@ dependencies = [
  "smallvec",
  "strum",
  "subtle",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "time",
  "tinystr",
  "tor-basic-utils",
@@ -5443,7 +5927,7 @@ dependencies = [
  "sanitize-filename",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "time",
  "tor-async-utils",
  "tor-basic-utils",
@@ -5483,14 +5967,14 @@ dependencies = [
  "pin-project",
  "postage",
  "rand 0.9.2",
- "rand_core 0.9.3",
+ "rand_core 0.9.5",
  "safelog",
  "slotmap-careful",
  "smallvec",
  "static_assertions",
  "subtle",
  "sync_wrapper",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-util",
  "tor-async-utils",
@@ -5525,7 +6009,7 @@ dependencies = [
  "caret",
  "paste",
  "serde_with",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tor-bytes",
 ]
 
@@ -5564,7 +6048,7 @@ dependencies = [
  "pin-project",
  "rustls-pki-types",
  "rustls-webpki",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-util",
  "tor-error",
@@ -5593,7 +6077,7 @@ dependencies = [
  "priority-queue",
  "slotmap-careful",
  "strum",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tor-error",
  "tor-general-addr",
  "tor-rtcompat",
@@ -5614,7 +6098,7 @@ dependencies = [
  "educe",
  "safelog",
  "subtle",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tor-bytes",
  "tor-error",
 ]
@@ -5628,19 +6112,19 @@ dependencies = [
  "derive-deftly",
  "derive_more",
  "serde",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tor-memquota",
 ]
 
 [[package]]
 name = "tower"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap 2.12.1",
+ "indexmap 2.13.1",
  "pin-project-lite",
  "slab",
  "sync_wrapper",
@@ -5649,6 +6133,24 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+dependencies = [
+ "bitflags 2.11.0",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "iri-string",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]
@@ -5665,9 +6167,9 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
-version = "0.1.41"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
  "tracing-attributes",
@@ -5676,20 +6178,20 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.30"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.34"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
  "valuable",
@@ -5708,9 +6210,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.20"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2054a14f5307d601f88daf0553e1cbf472acc4f2c51afab632431cdcd72124d5"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -5726,9 +6228,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-test"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "557b891436fe0d5e0e363427fc7f217abf9ccd510d5136549847bdcbcd011d68"
+checksum = "19a4c448db514d4f24c5ddb9f73f2ee71bfb24c526cf0c570ba142d1119e0051"
 dependencies = [
  "tracing-core",
  "tracing-subscriber",
@@ -5737,12 +6239,12 @@ dependencies = [
 
 [[package]]
 name = "tracing-test-macro"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04659ddb06c87d233c566112c1c9c5b9e98256d9af50ec3bc9c8327f873a7568"
+checksum = "ad06847b7afb65c7866a36664b75c40b895e318cea4f71299f013fb22965329d"
 dependencies = [
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5753,7 +6255,7 @@ checksum = "70977707304198400eb4835a78f6a9f928bf41bba420deb8fdb175cd965d77a7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5764,9 +6266,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typed-index-collections"
-version = "3.3.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fd393dbd1e7b23e0cab7396570309b4068aa504e9dac2cd41d827583b4e9ab7"
+checksum = "898160f1dfd383b4e92e17f0512a7d62f3c51c44937b23b6ffc3a1614a8eaccd"
 dependencies = [
  "bincode",
  "serde",
@@ -5801,15 +6303,15 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.22"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.12.0"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
 name = "unicode-xid"
@@ -5840,6 +6342,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
 
 [[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5847,13 +6367,13 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.18.1"
+version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f87b8aa10b915a06587d0dec516c282ff295b475d94abf425d62b57710070a2"
+checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
 dependencies = [
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "js-sys",
- "serde",
+ "serde_core",
  "wasm-bindgen",
 ]
 
@@ -5883,7 +6403,7 @@ checksum = "d674d135b4a8c1d7e813e2f8d1c9a58308aee4a680323066025e53132218bd91"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5919,40 +6439,60 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.1+wasi-0.2.4"
+version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen",
 ]
 
 [[package]]
 name = "wasix"
-version = "0.12.21"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1fbb4ef9bbca0c1170e0b00dd28abc9e3b68669821600cad1caaed606583c6d"
+checksum = "1757e0d1f8456693c7e5c6c629bdb54884e032aa0bb53c155f6a39f94440d332"
 dependencies = [
  "wasi",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.105"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da95793dfc411fbbd93f5be7715b0578ec61fe87cb1a42b12eb625caa5c5ea60"
+checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
 dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
+ "serde",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
-name = "wasm-bindgen-macro"
-version = "0.2.105"
+name = "wasm-bindgen-futures"
+version = "0.4.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04264334509e04a7bf8690f2384ef5265f05143a4bff3889ab7a3269adab59c2"
+checksum = "03623de6905b7206edd0a75f69f747f134b7f0a2323392d664448bf2d3c5d87e"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5960,24 +6500,58 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.105"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "420bc339d9f322e562942d52e115d57e950d12d88983a14c79b86859ee6c7ebc"
+checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.105"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76f218a38c84bcb33c25ec7059b07847d465ce0e0a76b995e134a45adcb6af76"
+checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap 2.13.1",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags 2.11.0",
+ "hashbrown 0.15.5",
+ "indexmap 2.13.1",
+ "semver",
 ]
 
 [[package]]
@@ -5988,9 +6562,19 @@ checksum = "323f4da9523e9a669e1eaf9c6e763892769b1d38c623913647bfdc1532fe4549"
 
 [[package]]
 name = "web-sys"
-version = "0.3.82"
+version = "0.3.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a1f95c0d03a47f4ae1f7a64643a6bb97465d9b740f0fa8f90ea33915c99a9a1"
+checksum = "cd70027e39b12f0849461e08ffc50b9cd7688d942c1c8e3c7b22273236b4dd0a"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5998,22 +6582,20 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.4"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2878ef029c47c6e8cf779119f20fcf52bde7ad42a731b2a304bc221df17571e"
+checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
 dependencies = [
  "rustls-pki-types",
 ]
 
 [[package]]
 name = "which"
-version = "8.0.0"
+version = "8.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3fabb953106c3c8eea8306e4393700d7657561cb43122571b172bbfb7c7ba1d"
+checksum = "81995fafaaaf6ae47a7d0cc83c67caf92aeb7e5331650ae6ff856f7c0c60c459"
 dependencies = [
- "env_home",
- "rustix",
- "winsafe",
+ "libc",
 ]
 
 [[package]]
@@ -6114,7 +6696,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6125,7 +6707,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6353,24 +6935,115 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "0.7.13"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
-name = "winsafe"
-version = "0.0.19"
+name = "winnow"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
+checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen"
-version = "0.46.0"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap 2.13.1",
+ "prettyplease",
+ "syn 2.0.117",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags 2.11.0",
+ "indexmap 2.13.1",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap 2.13.1",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
+
+[[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "wyz"
@@ -6395,9 +7068,9 @@ dependencies = [
 
 [[package]]
 name = "xdg"
-version = "2.5.2"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "213b7324336b53d2414b2db8537e56544d981803139155afa84f76eeebb7a546"
+checksum = "2fb433233f2df9344722454bc7e96465c9d03bff9d77c248f9e7523fe79585b5"
 
 [[package]]
 name = "xz2"
@@ -6409,10 +7082,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "yoke"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
+name = "ypir"
+version = "0.1.0"
+source = "git+https://github.com/valargroup/ypir.git?branch=valar%2Fartifact#bb4d68bf0022b1b6cefc1fda8bf25ea8bce36fef"
+dependencies = [
+ "cc",
+ "clap",
+ "env_logger",
+ "fastrand",
+ "log",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "serde",
+ "serde_json",
+ "sha1",
+ "spiral-rs",
+ "test-log",
+]
+
+[[package]]
 name = "zcash_address"
 version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee4491dddd232de02df42481757054dc19c8bc51cf709cfec58feebfef7c3c9a"
+source = "git+https://github.com/p0mvn/librustzcash.git?rev=301e20e7f3c697a73b66b11a3a6cd28dca63968b#301e20e7f3c697a73b66b11a3a6cd28dca63968b"
 dependencies = [
  "bech32",
  "bs58",
@@ -6424,9 +7138,8 @@ dependencies = [
 
 [[package]]
 name = "zcash_client_backend"
-version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60385c0fce292b87ecff619b52b70221b2b948c341d7dd1f6bbb4fd849befead"
+version = "0.21.2"
+source = "git+https://github.com/p0mvn/librustzcash.git?rev=301e20e7f3c697a73b66b11a3a6cd28dca63968b#301e20e7f3c697a73b66b11a3a6cd28dca63968b"
 dependencies = [
  "arti-client",
  "base64",
@@ -6493,12 +7206,11 @@ dependencies = [
 
 [[package]]
 name = "zcash_client_sqlite"
-version = "0.19.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04ef4c41fe87933c996e8d77ae602ed3f7bf0f056b219c1044f6e7742d4e5cf1"
+version = "0.19.5"
+source = "git+https://github.com/p0mvn/librustzcash.git?rev=301e20e7f3c697a73b66b11a3a6cd28dca63968b#301e20e7f3c697a73b66b11a3a6cd28dca63968b"
 dependencies = [
  "bip32",
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "bs58",
  "byteorder",
  "document-features",
@@ -6541,8 +7253,7 @@ dependencies = [
 [[package]]
 name = "zcash_encoding"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bca38087e6524e5f51a5b0fb3fc18f36d7b84bf67b2056f494ca0c281590953d"
+source = "git+https://github.com/p0mvn/librustzcash.git?rev=301e20e7f3c697a73b66b11a3a6cd28dca63968b#301e20e7f3c697a73b66b11a3a6cd28dca63968b"
 dependencies = [
  "core2",
  "nonempty",
@@ -6551,8 +7262,7 @@ dependencies = [
 [[package]]
 name = "zcash_keys"
 version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c115531caa1b7ca5ccd82dc26dbe3ba44b7542e928a3f77cd04abbe3cde4a4f2"
+source = "git+https://github.com/p0mvn/librustzcash.git?rev=301e20e7f3c697a73b66b11a3a6cd28dca63968b#301e20e7f3c697a73b66b11a3a6cd28dca63968b"
 dependencies = [
  "bech32",
  "bip32",
@@ -6594,8 +7304,7 @@ dependencies = [
 [[package]]
 name = "zcash_primitives"
 version = "0.26.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0e6912efdae984166ec0dc580049699026795328dcea4fc8cc077d51fce350c"
+source = "git+https://github.com/p0mvn/librustzcash.git?rev=301e20e7f3c697a73b66b11a3a6cd28dca63968b#301e20e7f3c697a73b66b11a3a6cd28dca63968b"
 dependencies = [
  "bip32",
  "blake2b_simd",
@@ -6637,8 +7346,7 @@ dependencies = [
 [[package]]
 name = "zcash_proofs"
 version = "0.26.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a2c13bb673d542608a0e6502ac5494136e7ce4ce97e92dd239489b2523eed9"
+source = "git+https://github.com/p0mvn/librustzcash.git?rev=301e20e7f3c697a73b66b11a3a6cd28dca63968b#301e20e7f3c697a73b66b11a3a6cd28dca63968b"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -6648,7 +7356,6 @@ dependencies = [
  "home",
  "jubjub",
  "known-folders",
- "lazy_static",
  "rand_core 0.6.4",
  "redjubjub",
  "sapling-crypto",
@@ -6660,8 +7367,7 @@ dependencies = [
 [[package]]
 name = "zcash_protocol"
 version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deb4c8d0530fd7a3d65358010f1e0a1ccfe6cc5f1ad63447af089ccc82ae9edf"
+source = "git+https://github.com/p0mvn/librustzcash.git?rev=301e20e7f3c697a73b66b11a3a6cd28dca63968b#301e20e7f3c697a73b66b11a3a6cd28dca63968b"
 dependencies = [
  "core2",
  "document-features",
@@ -6671,19 +7377,19 @@ dependencies = [
 
 [[package]]
 name = "zcash_script"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bed6cf5b2b4361105d4ea06b2752f0c8af4641756c7fbc9858a80af186c234f"
+checksum = "c6ef9d04e0434a80b62ad06c5a610557be358ef60a98afa5dbc8ecaf19ad72e7"
 dependencies = [
  "bip32",
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "bounded-vec",
  "hex",
  "ripemd 0.1.3",
  "secp256k1",
  "sha1",
  "sha2 0.10.9",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -6698,8 +7404,7 @@ dependencies = [
 [[package]]
 name = "zcash_transparent"
 version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91df4a3a377d478f94e4a00ff36a4963dc641ccd8ed2455554b8cb6914721562"
+source = "git+https://github.com/p0mvn/librustzcash.git?rev=301e20e7f3c697a73b66b11a3a6cd28dca63968b#301e20e7f3c697a73b66b11a3a6cd28dca63968b"
 dependencies = [
  "bip32",
  "blake2b_simd",
@@ -6721,29 +7426,44 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.30"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ea879c944afe8a2b25fef16bb4ba234f47c694565e97383b36f3a878219065c"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.30"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf955aa904d6040f70dc8e9384444cb1030aed272ba3cb09bbc4ab9e7c1f34f5"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
+]
 
 [[package]]
 name = "zeroize"
@@ -6756,23 +7476,47 @@ dependencies = [
 
 [[package]]
 name = "zeroize_derive"
-version = "1.4.2"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
 ]
 
 [[package]]
 name = "zerovec"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "serde",
+ "yoke",
  "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6791,8 +7535,7 @@ dependencies = [
 [[package]]
 name = "zip321"
 version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3090953750ce1d56aa213710765eb14997868f463c45dae115cf1ebe09fe39eb"
+source = "git+https://github.com/p0mvn/librustzcash.git?rev=301e20e7f3c697a73b66b11a3a6cd28dca63968b#301e20e7f3c697a73b66b11a3a6cd28dca63968b"
 dependencies = [
  "base64",
  "nom",
@@ -6800,6 +7543,12 @@ dependencies = [
  "zcash_address",
  "zcash_protocol",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
 
 [[package]]
 name = "zstd"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ zcash_client_backend = { version = "0.21", features = [
     "transparent-inputs",
     "unstable",
 ] }
-zcash_client_sqlite = { version = "0.19", features = ["orchard", "transparent-inputs", "unstable", "serde"] }
+zcash_client_sqlite = { version = "0.19", features = ["orchard", "transparent-inputs", "unstable", "serde", "sync-nullifier-pir"] }
 zcash_note_encryption = "0.4.1"
 zcash_primitives = "0.26"
 zcash_proofs = "0.26"
@@ -75,6 +75,12 @@ rust_decimal = { version = "1", default-features = false, features = ["c-repr"] 
 # - The "static" feature is required for the "compression" default feature of arti-client.
 xz2 = { version = "0.1", features = ["static"] }
 
+# Spendability PIR
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+spend-client = { git = "https://github.com/valargroup/sync-nullifier-pir.git", rev = "ab81f9811e8281855e27bdd3e89bce644674b326" }
+spend-types = { git = "https://github.com/valargroup/sync-nullifier-pir.git", rev = "ab81f9811e8281855e27bdd3e89bce644674b326" }
+
 [build-dependencies]
 bindgen = "0.72"
 cbindgen = "0.29"
@@ -87,3 +93,13 @@ crate-type = ["staticlib"]
 
 [profile.release]
 lto = true
+
+[patch.crates-io]
+zcash_address        = { git = "https://github.com/valargroup/librustzcash.git", rev = "9861871296d1e8ee80ebb00704e489ffc9914f92" }
+zcash_client_backend = { git = "https://github.com/valargroup/librustzcash.git", rev = "9861871296d1e8ee80ebb00704e489ffc9914f92" }
+zcash_client_sqlite  = { git = "https://github.com/valargroup/librustzcash.git", rev = "9861871296d1e8ee80ebb00704e489ffc9914f92" }
+zcash_primitives     = { git = "https://github.com/valargroup/librustzcash.git", rev = "9861871296d1e8ee80ebb00704e489ffc9914f92" }
+zcash_proofs         = { git = "https://github.com/valargroup/librustzcash.git", rev = "9861871296d1e8ee80ebb00704e489ffc9914f92" }
+zcash_protocol       = { git = "https://github.com/valargroup/librustzcash.git", rev = "9861871296d1e8ee80ebb00704e489ffc9914f92" }
+zcash_transparent    = { git = "https://github.com/valargroup/librustzcash.git", rev = "9861871296d1e8ee80ebb00704e489ffc9914f92" }
+pczt                 = { git = "https://github.com/valargroup/librustzcash.git", rev = "9861871296d1e8ee80ebb00704e489ffc9914f92" }

--- a/Package.resolved
+++ b/Package.resolved
@@ -28,24 +28,6 @@
       }
     },
     {
-      "identity" : "swift-asn1",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-asn1.git",
-      "state" : {
-        "revision" : "810496cf121e525d660cd0ea89a758740476b85f",
-        "version" : "1.5.1"
-      }
-    },
-    {
-      "identity" : "swift-async-algorithms",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-async-algorithms.git",
-      "state" : {
-        "revision" : "9d349bcc328ac3c31ce40e746b5882742a0d1272",
-        "version" : "1.1.3"
-      }
-    },
-    {
       "identity" : "swift-atomics",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-atomics.git",
@@ -55,30 +37,12 @@
       }
     },
     {
-      "identity" : "swift-certificates",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-certificates.git",
-      "state" : {
-        "revision" : "24ccdeeeed4dfaae7955fcac9dbf5489ed4f1a25",
-        "version" : "1.18.0"
-      }
-    },
-    {
       "identity" : "swift-collections",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections.git",
       "state" : {
         "revision" : "7b847a3b7008b2dc2f47ca3110d8c782fb2e5c7e",
         "version" : "1.3.0"
-      }
-    },
-    {
-      "identity" : "swift-crypto",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-crypto.git",
-      "state" : {
-        "revision" : "6f70fa9eab24c1fd982af18c281c4525d05e3095",
-        "version" : "4.2.0"
       }
     },
     {
@@ -169,15 +133,6 @@
       "state" : {
         "revision" : "5596511fce902e649c403cd4d6d5da1254f142b7",
         "version" : "1.35.1"
-      }
-    },
-    {
-      "identity" : "swift-service-lifecycle",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/swift-server/swift-service-lifecycle.git",
-      "state" : {
-        "revision" : "89888196dd79c61c50bca9a103d8114f32e1e598",
-        "version" : "2.10.1"
       }
     },
     {

--- a/Sources/ZcashLightClientKit/Block/DatabaseStorage/SimpleConnectionProvider.swift
+++ b/Sources/ZcashLightClientKit/Block/DatabaseStorage/SimpleConnectionProvider.swift
@@ -24,6 +24,7 @@ class SimpleConnectionProvider: ConnectionProvider {
         guard let conn = db else {
             do {
                 let conn = try Connection(path, readonly: readonly)
+                conn.busyTimeout = 5
                 self.db = conn
                 return conn
             } catch {
@@ -37,6 +38,7 @@ class SimpleConnectionProvider: ConnectionProvider {
     func debugConnection() throws -> Connection {
         do {
             let conn = try Connection(path, readonly: true)
+            conn.busyTimeout = 5
             try addDebugFunctions(conn: conn)
             return conn
         } catch {

--- a/Sources/ZcashLightClientKit/Rust/Spendability/SpendabilityBackend.swift
+++ b/Sources/ZcashLightClientKit/Rust/Spendability/SpendabilityBackend.swift
@@ -1,0 +1,124 @@
+// Swift wrapper for the spendability PIR C FFI in spendability.rs.
+// Stateless — each call connects to the PIR server, checks nullifiers, and returns.
+
+import Foundation
+import libzcashlc
+
+// MARK: - Error
+
+public enum SpendabilityBackendError: LocalizedError, Equatable {
+    case rustError(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .rustError(let message):
+            return "Spendability backend error: \(message)"
+        }
+    }
+}
+
+// MARK: - SpendabilityBackend
+
+/// Wraps the spendability PIR C FFI. Stateless — no persistent handle needed.
+public struct SpendabilityBackend: Sendable {
+    public init() {}
+
+    /// Check spendability of all unspent orchard notes in the wallet database.
+    /// Opens the wallet DB read-write, extracts nullifiers, checks each via PIR,
+    /// and records spent notes in `pir_spent_notes`.
+    ///
+    /// - Parameters:
+    ///   - walletDbPath: Path to the wallet SQLite database.
+    ///   - pirServerUrl: Base URL of the spend-server.
+    ///   - progress: Optional progress callback (0.0..1.0).
+    /// - Returns: A `SpendabilityResult` with spent note IDs and total spent value.
+    public func checkWalletSpendability(
+        walletDbPath: String,
+        pirServerUrl: String,
+        progress: SpendabilityProgressHandler?
+    ) throws -> SpendabilityResult {
+        let dbPathBytes = [UInt8](walletDbPath.utf8)
+        let urlBytes = [UInt8](pirServerUrl.utf8)
+
+        var context = SpendabilityProgressContext(handler: progress)
+
+        let ptr: UnsafeMutablePointer<FfiBoxedSlice>? = dbPathBytes.withUnsafeBufferPointer { dbBuf in
+            urlBytes.withUnsafeBufferPointer { urlBuf in
+                withUnsafeMutablePointer(to: &context) { ctxPtr in
+                    let callback: (@convention(c) (Double, UnsafeMutableRawPointer?) -> Void)? =
+                        progress != nil ? spendabilityProgressTrampoline : nil
+                    return zcashlc_check_wallet_spendability(
+                        dbBuf.baseAddress,
+                        UInt(dbBuf.count),
+                        urlBuf.baseAddress,
+                        UInt(urlBuf.count),
+                        callback,
+                        UnsafeMutableRawPointer(ctxPtr)
+                    )
+                }
+            }
+        }
+
+        guard let ptr else {
+            throw SpendabilityBackendError.rustError(lastErrorMessage(fallback: "`check_wallet_spendability` failed"))
+        }
+        defer { zcashlc_free_boxed_slice(ptr) }
+
+        let data = Data(bytes: ptr.pointee.ptr, count: Int(ptr.pointee.len))
+        return try JSONDecoder().decode(SpendabilityResult.self, from: data)
+    }
+
+    /// Query PIR-detected spent notes whose spends have not yet been confirmed
+    /// by the block scanner. Opens the wallet DB read-only.
+    public func getPIRPendingSpends(
+        walletDbPath: String
+    ) throws -> PIRPendingSpends {
+        let dbPathBytes = [UInt8](walletDbPath.utf8)
+
+        let ptr: UnsafeMutablePointer<FfiBoxedSlice>? = dbPathBytes.withUnsafeBufferPointer { dbBuf in
+            zcashlc_get_pir_pending_spends(
+                dbBuf.baseAddress,
+                UInt(dbBuf.count)
+            )
+        }
+
+        guard let ptr else {
+            throw SpendabilityBackendError.rustError(lastErrorMessage(fallback: "`get_pir_pending_spends` failed"))
+        }
+        defer { zcashlc_free_boxed_slice(ptr) }
+
+        let data = Data(bytes: ptr.pointee.ptr, count: Int(ptr.pointee.len))
+        return try JSONDecoder().decode(PIRPendingSpends.self, from: data)
+    }
+}
+
+// MARK: - Private helpers
+
+private extension SpendabilityBackend {
+    func lastErrorMessage(fallback: String) -> String {
+        let errorLen = zcashlc_last_error_length()
+        defer { zcashlc_clear_last_error() }
+
+        if errorLen > 0 {
+            let error = UnsafeMutablePointer<Int8>.allocate(capacity: Int(errorLen))
+            defer { error.deallocate() }
+            zcashlc_error_message_utf8(error, errorLen)
+            if let msg = String(validatingUTF8: error) {
+                return msg
+            }
+        }
+        return fallback
+    }
+}
+
+// MARK: - Progress callback trampoline
+
+private struct SpendabilityProgressContext {
+    let handler: SpendabilityProgressHandler?
+}
+
+private func spendabilityProgressTrampoline(progress: Double, context: UnsafeMutableRawPointer?) {
+    guard let context else { return }
+    let ctx = context.assumingMemoryBound(to: SpendabilityProgressContext.self).pointee
+    ctx.handler?(progress)
+}

--- a/Sources/ZcashLightClientKit/Rust/Spendability/SpendabilityBackend.swift
+++ b/Sources/ZcashLightClientKit/Rust/Spendability/SpendabilityBackend.swift
@@ -19,39 +19,39 @@ public enum SpendabilityBackendError: LocalizedError, Equatable {
 
 // MARK: - SpendabilityBackend
 
-/// Wraps the spendability PIR C FFI. Stateless — no persistent handle needed.
+/// Wraps the PIR network FFI. Stateless — no DB handle, no persistent connection.
 public struct SpendabilityBackend: Sendable {
     public init() {}
 
-    /// Check spendability of all unspent orchard notes in the wallet database.
-    /// Opens the wallet DB read-write, extracts nullifiers, checks each via PIR,
-    /// and records spent notes in `pir_spent_notes`.
+    /// Check nullifiers against the PIR server. No database access.
     ///
     /// - Parameters:
-    ///   - walletDbPath: Path to the wallet SQLite database.
+    ///   - notes: Unspent notes with nullifiers (from phase 1 DB read).
     ///   - pirServerUrl: Base URL of the spend-server.
     ///   - progress: Optional progress callback (0.0..1.0).
-    /// - Returns: A `SpendabilityResult` with spent note IDs and total spent value.
-    public func checkWalletSpendability(
-        walletDbPath: String,
+    /// - Returns: A `PIRNullifierCheckResult` with spent flags and server metadata.
+    public func checkNullifiersPIR(
+        notes: [PIRUnspentNote],
         pirServerUrl: String,
         progress: SpendabilityProgressHandler?
-    ) throws -> SpendabilityResult {
-        let dbPathBytes = [UInt8](walletDbPath.utf8)
+    ) throws -> PIRNullifierCheckResult {
         let urlBytes = [UInt8](pirServerUrl.utf8)
+
+        let nullifiers: [[UInt8]] = notes.map { $0.nf }
+        let nullifiersJSON = try JSONEncoder().encode(nullifiers)
 
         var context = SpendabilityProgressContext(handler: progress)
 
-        let ptr: UnsafeMutablePointer<FfiBoxedSlice>? = dbPathBytes.withUnsafeBufferPointer { dbBuf in
-            urlBytes.withUnsafeBufferPointer { urlBuf in
+        let ptr: UnsafeMutablePointer<FfiBoxedSlice>? = urlBytes.withUnsafeBufferPointer { urlBuf in
+            nullifiersJSON.withUnsafeBytes { nfBuf in
                 withUnsafeMutablePointer(to: &context) { ctxPtr in
                     let callback: (@convention(c) (Double, UnsafeMutableRawPointer?) -> Void)? =
                         progress != nil ? spendabilityProgressTrampoline : nil
-                    return zcashlc_check_wallet_spendability(
-                        dbBuf.baseAddress,
-                        UInt(dbBuf.count),
+                    return zcashlc_check_nullifiers_pir(
                         urlBuf.baseAddress,
                         UInt(urlBuf.count),
+                        nfBuf.baseAddress?.assumingMemoryBound(to: UInt8.self),
+                        UInt(nfBuf.count),
                         callback,
                         UnsafeMutableRawPointer(ctxPtr)
                     )
@@ -60,35 +60,12 @@ public struct SpendabilityBackend: Sendable {
         }
 
         guard let ptr else {
-            throw SpendabilityBackendError.rustError(lastErrorMessage(fallback: "`check_wallet_spendability` failed"))
+            throw SpendabilityBackendError.rustError(lastErrorMessage(fallback: "`checkNullifiersPIR` failed"))
         }
         defer { zcashlc_free_boxed_slice(ptr) }
 
         let data = Data(bytes: ptr.pointee.ptr, count: Int(ptr.pointee.len))
-        return try JSONDecoder().decode(SpendabilityResult.self, from: data)
-    }
-
-    /// Query PIR-detected spent notes whose spends have not yet been confirmed
-    /// by the block scanner. Opens the wallet DB read-only.
-    public func getPIRPendingSpends(
-        walletDbPath: String
-    ) throws -> PIRPendingSpends {
-        let dbPathBytes = [UInt8](walletDbPath.utf8)
-
-        let ptr: UnsafeMutablePointer<FfiBoxedSlice>? = dbPathBytes.withUnsafeBufferPointer { dbBuf in
-            zcashlc_get_pir_pending_spends(
-                dbBuf.baseAddress,
-                UInt(dbBuf.count)
-            )
-        }
-
-        guard let ptr else {
-            throw SpendabilityBackendError.rustError(lastErrorMessage(fallback: "`get_pir_pending_spends` failed"))
-        }
-        defer { zcashlc_free_boxed_slice(ptr) }
-
-        let data = Data(bytes: ptr.pointee.ptr, count: Int(ptr.pointee.len))
-        return try JSONDecoder().decode(PIRPendingSpends.self, from: data)
+        return try JSONDecoder().decode(PIRNullifierCheckResult.self, from: data)
     }
 }
 

--- a/Sources/ZcashLightClientKit/Rust/Spendability/SpendabilityTypes.swift
+++ b/Sources/ZcashLightClientKit/Rust/Spendability/SpendabilityTypes.swift
@@ -31,6 +31,44 @@ public struct SpendabilityResult: Codable, Sendable, Equatable {
     }
 }
 
+// MARK: - Unspent note
+
+/// An unspent Orchard note with its nullifier, for PIR spend-checking.
+public struct PIRUnspentNote: Codable, Sendable, Equatable {
+    public let id: Int64
+    /// Raw nullifier bytes (32 bytes).
+    public let nf: [UInt8]
+    public let value: UInt64
+
+    public init(id: Int64, nf: [UInt8], value: UInt64) {
+        self.id = id
+        self.nf = nf
+        self.value = value
+    }
+}
+
+// MARK: - Nullifier check result
+
+/// Result of checking nullifiers against the PIR server.
+public struct PIRNullifierCheckResult: Codable, Sendable, Equatable {
+    public let earliestHeight: UInt64
+    public let latestHeight: UInt64
+    /// Parallel to the input nullifiers: true = spent.
+    public let spent: [Bool]
+
+    enum CodingKeys: String, CodingKey {
+        case earliestHeight = "earliest_height"
+        case latestHeight = "latest_height"
+        case spent
+    }
+
+    public init(earliestHeight: UInt64, latestHeight: UInt64, spent: [Bool]) {
+        self.earliestHeight = earliestHeight
+        self.latestHeight = latestHeight
+        self.spent = spent
+    }
+}
+
 // MARK: - Pending spends (PIR-detected but not yet confirmed by scanning)
 
 /// A single note detected as spent by PIR that scanning has not yet confirmed.

--- a/Sources/ZcashLightClientKit/Rust/Spendability/SpendabilityTypes.swift
+++ b/Sources/ZcashLightClientKit/Rust/Spendability/SpendabilityTypes.swift
@@ -1,0 +1,71 @@
+// Swift types matching the JSON serde types in spendability.rs.
+// All types are Codable for JSON serialization across the FFI boundary.
+
+import Foundation
+
+// MARK: - Result
+
+/// Result of a spendability PIR check.
+public struct SpendabilityResult: Codable, Sendable, Equatable {
+    /// Earliest block height covered by the PIR database.
+    public let earliestHeight: UInt64
+    /// Latest block height covered by the PIR database.
+    public let latestHeight: UInt64
+    /// Note IDs whose nullifiers were found in the PIR database (i.e. spent).
+    public let spentNoteIds: [Int64]
+    /// Total zatoshi value of notes found spent by PIR.
+    public let totalSpentValue: UInt64
+
+    enum CodingKeys: String, CodingKey {
+        case earliestHeight = "earliest_height"
+        case latestHeight = "latest_height"
+        case spentNoteIds = "spent_note_ids"
+        case totalSpentValue = "total_spent_value"
+    }
+
+    public init(earliestHeight: UInt64, latestHeight: UInt64, spentNoteIds: [Int64], totalSpentValue: UInt64) {
+        self.earliestHeight = earliestHeight
+        self.latestHeight = latestHeight
+        self.spentNoteIds = spentNoteIds
+        self.totalSpentValue = totalSpentValue
+    }
+}
+
+// MARK: - Pending spends (PIR-detected but not yet confirmed by scanning)
+
+/// A single note detected as spent by PIR that scanning has not yet confirmed.
+public struct PIRPendingNote: Codable, Sendable, Equatable {
+    public let noteId: Int64
+    public let value: UInt64
+
+    enum CodingKeys: String, CodingKey {
+        case noteId = "note_id"
+        case value
+    }
+
+    public init(noteId: Int64, value: UInt64) {
+        self.noteId = noteId
+        self.value = value
+    }
+}
+
+/// Aggregated result of PIR-detected spends not yet confirmed by scanning.
+public struct PIRPendingSpends: Codable, Sendable, Equatable {
+    public let notes: [PIRPendingNote]
+    public let totalValue: UInt64
+
+    enum CodingKeys: String, CodingKey {
+        case notes
+        case totalValue = "total_value"
+    }
+
+    public init(notes: [PIRPendingNote], totalValue: UInt64) {
+        self.notes = notes
+        self.totalValue = totalValue
+    }
+}
+
+// MARK: - Progress
+
+/// Closure type for spendability check progress reporting.
+public typealias SpendabilityProgressHandler = @Sendable (Double) -> Void

--- a/Sources/ZcashLightClientKit/Rust/ZcashRustBackend.swift
+++ b/Sources/ZcashLightClientKit/Rust/ZcashRustBackend.swift
@@ -960,21 +960,31 @@ struct ZcashRustBackend: ZcashRustBackendWelding {
         
         // Modify spendable `accountBalances` if chainTip hasn't been updated yet
         if await !sdkFlags.chainTipUpdated {
+            let pirDone = await sdkFlags.pirCompleted
             accountBalances.forEach { key, _ in
                 if let accountBalance = accountBalances[key] {
-                    accountBalances[key] = AccountBalance(
-                        saplingBalance: PoolBalance(
-                            spendableValue: .zero,
-                            changePendingConfirmation: accountBalance.saplingBalance.changePendingConfirmation,
-                            valuePendingSpendability: accountBalance.saplingBalance.valuePendingSpendability
-                            + accountBalance.saplingBalance.spendableValue
-                        ),
-                        orchardBalance: PoolBalance(
+                    // Sapling is always zeroed when chainTip is stale
+                    let saplingBalance = PoolBalance(
+                        spendableValue: .zero,
+                        changePendingConfirmation: accountBalance.saplingBalance.changePendingConfirmation,
+                        valuePendingSpendability: accountBalance.saplingBalance.valuePendingSpendability
+                        + accountBalance.saplingBalance.spendableValue
+                    )
+                    // Orchard is preserved if PIR has confirmed spendability
+                    let orchardBalance: PoolBalance
+                    if pirDone {
+                        orchardBalance = accountBalance.orchardBalance
+                    } else {
+                        orchardBalance = PoolBalance(
                             spendableValue: .zero,
                             changePendingConfirmation: accountBalance.orchardBalance.changePendingConfirmation,
                             valuePendingSpendability: accountBalance.orchardBalance.valuePendingSpendability
                             + accountBalance.orchardBalance.spendableValue
-                        ),
+                        )
+                    }
+                    accountBalances[key] = AccountBalance(
+                        saplingBalance: saplingBalance,
+                        orchardBalance: orchardBalance,
                         unshielded: .zero,
                         awaitingResolution: accountBalance.unshielded
                     )

--- a/Sources/ZcashLightClientKit/Rust/ZcashRustBackend.swift
+++ b/Sources/ZcashLightClientKit/Rust/ZcashRustBackend.swift
@@ -1295,6 +1295,67 @@ struct ZcashRustBackend: ZcashRustBackendWelding {
             )
         }
     }
+
+    // MARK: - PIR (serialized through @DBActor)
+
+    @DBActor
+    func getUnspentOrchardNotesForPIR() async throws -> [PIRUnspentNote] {
+        let ptr = zcashlc_get_unspent_orchard_notes_for_pir(
+            dbData.0,
+            dbData.1,
+            networkType.networkId
+        )
+
+        guard let ptr else {
+            throw SpendabilityBackendError.rustError(
+                lastErrorMessage(fallback: "`getUnspentOrchardNotesForPIR` failed")
+            )
+        }
+        defer { zcashlc_free_boxed_slice(ptr) }
+
+        let data = Data(bytes: ptr.pointee.ptr, count: Int(ptr.pointee.len))
+        return try JSONDecoder().decode([PIRUnspentNote].self, from: data)
+    }
+
+    @DBActor
+    func insertPIRSpentNotes(_ noteIds: [Int64]) async throws {
+        let json = try JSONEncoder().encode(noteIds)
+
+        let result = json.withUnsafeBytes { buf in
+            zcashlc_insert_pir_spent_notes(
+                dbData.0,
+                dbData.1,
+                networkType.networkId,
+                buf.baseAddress?.assumingMemoryBound(to: UInt8.self),
+                UInt(buf.count)
+            )
+        }
+
+        guard result == 0 else {
+            throw SpendabilityBackendError.rustError(
+                lastErrorMessage(fallback: "`insertPIRSpentNotes` failed")
+            )
+        }
+    }
+
+    @DBActor
+    func getPIRPendingSpends() async throws -> PIRPendingSpends {
+        let ptr = zcashlc_get_pir_pending_spends_v2(
+            dbData.0,
+            dbData.1,
+            networkType.networkId
+        )
+
+        guard let ptr else {
+            throw SpendabilityBackendError.rustError(
+                lastErrorMessage(fallback: "`getPIRPendingSpends` failed")
+            )
+        }
+        defer { zcashlc_free_boxed_slice(ptr) }
+
+        let data = Data(bytes: ptr.pointee.ptr, count: Int(ptr.pointee.len))
+        return try JSONDecoder().decode(PIRPendingSpends.self, from: data)
+    }
 }
 
 private extension ZcashRustBackend {

--- a/Sources/ZcashLightClientKit/Rust/ZcashRustBackendWelding.swift
+++ b/Sources/ZcashLightClientKit/Rust/ZcashRustBackendWelding.swift
@@ -391,4 +391,15 @@ protocol ZcashRustBackendWelding {
     
     /// Attempts to delete an account defined by UUID
     func deleteAccount(_ accountUUID: AccountUUID) async throws
+
+    // MARK: - PIR (serialized through @DBActor, no standalone connections)
+
+    /// Returns unspent Orchard notes with nullifiers for PIR spend-checking.
+    func getUnspentOrchardNotesForPIR() async throws -> [PIRUnspentNote]
+
+    /// Inserts PIR-detected spent note IDs into the wallet DB.
+    func insertPIRSpentNotes(_ noteIds: [Int64]) async throws
+
+    /// Returns PIR-detected spent notes not yet confirmed by the block scanner.
+    func getPIRPendingSpends() async throws -> PIRPendingSpends
 }

--- a/Sources/ZcashLightClientKit/Synchronizer.swift
+++ b/Sources/ZcashLightClientKit/Synchronizer.swift
@@ -526,6 +526,22 @@ public protocol Synchronizer: AnyObject {
     ///
     /// - Throws rustDeleteAccount as a common indicator of the operation failure
     func deleteAccount(_ accountUUID: AccountUUID) async throws -> Void
+
+    /// Check spendability of all unspent orchard notes in the wallet using a PIR server.
+    /// Queries the wallet DB for unspent notes, checks each via PIR, and returns
+    /// which are spent along with total spent value.
+    ///
+    /// - Parameters:
+    ///   - pirServerUrl: Base URL of the spend-server.
+    ///   - progress: Optional progress callback (0.0..1.0).
+    func checkWalletSpendability(
+        pirServerUrl: String,
+        progress: SpendabilityProgressHandler?
+    ) async throws -> SpendabilityResult
+
+    /// Return PIR-detected spent notes whose spends have not yet been confirmed
+    /// by the block scanner. Queries the wallet DB read-only.
+    func getPIRPendingSpends() async throws -> PIRPendingSpends
 }
 
 public enum SyncStatus: Equatable {

--- a/Sources/ZcashLightClientKit/Synchronizer/SDKSynchronizer.swift
+++ b/Sources/ZcashLightClientKit/Synchronizer/SDKSynchronizer.swift
@@ -1028,7 +1028,7 @@ public class SDKSynchronizer: Synchronizer {
     public func debugDatabase(sql: String) -> String {
         transactionRepository.debugDatabase(sql: sql)
     }
-    
+
     public func getSingleUseTransparentAddress(accountUUID: AccountUUID) async throws -> SingleUseTransparentAddress {
         try await initializer.rustBackend.getSingleUseTransparentAddress(accountUUID: accountUUID)
     }
@@ -1089,6 +1089,31 @@ public class SDKSynchronizer: Synchronizer {
     
     public func deleteAccount(_ accountUUID: AccountUUID) async throws {
         try await initializer.rustBackend.deleteAccount(accountUUID)
+    }
+
+    public func checkWalletSpendability(
+        pirServerUrl: String,
+        progress: SpendabilityProgressHandler?
+    ) async throws -> SpendabilityResult {
+        let dbPath = initializer.dataDbURL.path
+        let result = try await Task.detached(priority: .userInitiated) {
+            try SpendabilityBackend().checkWalletSpendability(
+                walletDbPath: dbPath,
+                pirServerUrl: pirServerUrl,
+                progress: progress
+            )
+        }.value
+        await sdkFlags.markPIRCompleted()
+        return result
+    }
+
+    public func getPIRPendingSpends() async throws -> PIRPendingSpends {
+        let dbPath = initializer.dataDbURL.path
+        return try await Task.detached(priority: .userInitiated) {
+            try SpendabilityBackend().getPIRPendingSpends(
+                walletDbPath: dbPath
+            )
+        }.value
     }
 
     // MARK: Server switch

--- a/Sources/ZcashLightClientKit/Synchronizer/SDKSynchronizer.swift
+++ b/Sources/ZcashLightClientKit/Synchronizer/SDKSynchronizer.swift
@@ -1095,25 +1095,42 @@ public class SDKSynchronizer: Synchronizer {
         pirServerUrl: String,
         progress: SpendabilityProgressHandler?
     ) async throws -> SpendabilityResult {
-        let dbPath = initializer.dataDbURL.path
-        let result = try await Task.detached(priority: .userInitiated) {
-            try SpendabilityBackend().checkWalletSpendability(
-                walletDbPath: dbPath,
+        // Read unspent notes (@DBActor — serialized with sync)
+        let notes = try await initializer.rustBackend.getUnspentOrchardNotesForPIR()
+        guard !notes.isEmpty else {
+            return SpendabilityResult(earliestHeight: 0, latestHeight: 0, spentNoteIds: [], totalSpentValue: 0)
+        }
+
+        // Check nullifiers against PIR server (detached — no DB connection held)
+        let checkResult = try await Task.detached(priority: .userInitiated) {
+            try SpendabilityBackend().checkNullifiersPIR(
+                notes: notes,
                 pirServerUrl: pirServerUrl,
                 progress: progress
             )
         }.value
+
+        // Identify spent notes
+        let spentNotes = zip(notes, checkResult.spent).filter { $0.1 }
+        let spentNoteIds = spentNotes.map(\.0.id)
+        let totalSpentValue = spentNotes.map(\.0.value).reduce(0, +)
+
+        // Insert spent notes (@DBActor — serialized with sync)
+        if !spentNoteIds.isEmpty {
+            try await initializer.rustBackend.insertPIRSpentNotes(spentNoteIds)
+        }
+
         await sdkFlags.markPIRCompleted()
-        return result
+        return SpendabilityResult(
+            earliestHeight: checkResult.earliestHeight,
+            latestHeight: checkResult.latestHeight,
+            spentNoteIds: spentNoteIds,
+            totalSpentValue: totalSpentValue
+        )
     }
 
     public func getPIRPendingSpends() async throws -> PIRPendingSpends {
-        let dbPath = initializer.dataDbURL.path
-        return try await Task.detached(priority: .userInitiated) {
-            try SpendabilityBackend().getPIRPendingSpends(
-                walletDbPath: dbPath
-            )
-        }.value
+        try await initializer.rustBackend.getPIRPendingSpends()
     }
 
     // MARK: Server switch

--- a/Sources/ZcashLightClientKit/Utils/SDKFlags.swift
+++ b/Sources/ZcashLightClientKit/Utils/SDKFlags.swift
@@ -28,6 +28,11 @@ actor SDKFlags {
     /// Runtime helper flag used to mark whether chainTip CBP action has been done.
     var chainTipUpdated = false
     var chainTipUpdatedTimestamp: TimeInterval = 0.0
+
+    /// Set after `checkWalletSpendability` succeeds. When true, Orchard
+    /// spendableValue is preserved even before `chainTipUpdated` is set.
+    var pirCompleted = false
+    var pirCompletedTimestamp: TimeInterval = 0.0
     
     init(
         torEnabled: Bool,
@@ -64,12 +69,22 @@ actor SDKFlags {
         chainTipUpdatedTimestamp = Date().timeIntervalSince1970
     }
 
+    /// Use to mark PIR spendability check as completed
+    func markPIRCompleted() {
+        pirCompleted = true
+        pirCompletedTimestamp = Date().timeIntervalSince1970
+    }
+
     /// The client using the SDK called `start()`.
     /// Use this to reset or update any relevant flags if needed.
     func sdkStarted() {
+        let now = Date().timeIntervalSince1970
         // If chain tip has been updated recently and is set to false, re-enable it
-        if !chainTipUpdated && Date().timeIntervalSince1970 - chainTipUpdatedTimestamp < 120 {
+        if !chainTipUpdated && now - chainTipUpdatedTimestamp < 120 {
             chainTipUpdated = true
+        }
+        if !pirCompleted && now - pirCompletedTimestamp < 120 {
+            pirCompleted = true
         }
     }
 
@@ -80,5 +95,6 @@ actor SDKFlags {
         // The chain tip might be old enough to cause issues when attempting to send or shield funds before the next chain tip update call finishes.
         // Therefore, it is reset here.
         chainTipUpdated = false
+        pirCompleted = false
     }
 }

--- a/Tests/OfflineTests/SpendabilityTypesTests.swift
+++ b/Tests/OfflineTests/SpendabilityTypesTests.swift
@@ -1,0 +1,292 @@
+//
+//  SpendabilityTypesTests.swift
+//
+//
+//  Tests for spendability PIR types used across the FFI boundary.
+//  Verifies JSON encoding/decoding matches the Rust serde format
+//  produced by spendability.rs and the PIR FFI functions in lib.rs.
+//
+
+import XCTest
+@testable import ZcashLightClientKit
+
+final class SpendabilityTypesTests: XCTestCase {
+    let decoder = JSONDecoder()
+    let encoder = JSONEncoder()
+
+    // MARK: - PIRUnspentNote
+
+    func testPIRUnspentNoteDecodesFromRustJSON() throws {
+        let json = """
+        {"id":42,"nf":[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31],"value":50000}
+        """.data(using: .utf8)!
+
+        let note = try decoder.decode(PIRUnspentNote.self, from: json)
+
+        XCTAssertEqual(note.id, 42)
+        XCTAssertEqual(note.nf, Array(0...31))
+        XCTAssertEqual(note.value, 50_000)
+    }
+
+    func testPIRUnspentNoteArrayDecodesFromRustJSON() throws {
+        let json = """
+        [
+          {"id":1,"nf":[170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170],"value":10000},
+          {"id":2,"nf":[187,187,187,187,187,187,187,187,187,187,187,187,187,187,187,187,187,187,187,187,187,187,187,187,187,187,187,187,187,187,187,187],"value":20000}
+        ]
+        """.data(using: .utf8)!
+
+        let notes = try decoder.decode([PIRUnspentNote].self, from: json)
+
+        XCTAssertEqual(notes.count, 2)
+        XCTAssertEqual(notes[0].id, 1)
+        XCTAssertEqual(notes[0].nf, [UInt8](repeating: 0xAA, count: 32))
+        XCTAssertEqual(notes[0].value, 10_000)
+        XCTAssertEqual(notes[1].id, 2)
+        XCTAssertEqual(notes[1].nf, [UInt8](repeating: 0xBB, count: 32))
+        XCTAssertEqual(notes[1].value, 20_000)
+    }
+
+    func testPIRUnspentNoteRoundTrip() throws {
+        let note = PIRUnspentNote(id: 7, nf: [UInt8](repeating: 0xFF, count: 32), value: 100_000)
+        let data = try encoder.encode(note)
+        let decoded = try decoder.decode(PIRUnspentNote.self, from: data)
+
+        XCTAssertEqual(note, decoded)
+    }
+
+    func testPIRUnspentNoteEmptyArray() throws {
+        let json = "[]".data(using: .utf8)!
+        let notes = try decoder.decode([PIRUnspentNote].self, from: json)
+        XCTAssertTrue(notes.isEmpty)
+    }
+
+    // MARK: - PIRNullifierCheckResult
+
+    func testPIRNullifierCheckResultDecodesFromRustJSON() throws {
+        let json = """
+        {"earliest_height":100,"latest_height":200,"spent":[true,false,true]}
+        """.data(using: .utf8)!
+
+        let result = try decoder.decode(PIRNullifierCheckResult.self, from: json)
+
+        XCTAssertEqual(result.earliestHeight, 100)
+        XCTAssertEqual(result.latestHeight, 200)
+        XCTAssertEqual(result.spent, [true, false, true])
+    }
+
+    func testPIRNullifierCheckResultEmptySpent() throws {
+        let json = """
+        {"earliest_height":0,"latest_height":0,"spent":[]}
+        """.data(using: .utf8)!
+
+        let result = try decoder.decode(PIRNullifierCheckResult.self, from: json)
+
+        XCTAssertEqual(result.earliestHeight, 0)
+        XCTAssertEqual(result.latestHeight, 0)
+        XCTAssertTrue(result.spent.isEmpty)
+    }
+
+    func testPIRNullifierCheckResultEncodesSnakeCaseKeys() throws {
+        let result = PIRNullifierCheckResult(earliestHeight: 500, latestHeight: 1000, spent: [false, true])
+        let data = try encoder.encode(result)
+        let jsonObject = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+
+        XCTAssertNotNil(jsonObject["earliest_height"], "Expected snake_case key 'earliest_height'")
+        XCTAssertNotNil(jsonObject["latest_height"], "Expected snake_case key 'latest_height'")
+        XCTAssertNotNil(jsonObject["spent"])
+        XCTAssertNil(jsonObject["earliestHeight"], "Should not use camelCase key")
+    }
+
+    func testPIRNullifierCheckResultRoundTrip() throws {
+        let result = PIRNullifierCheckResult(earliestHeight: 42, latestHeight: 99, spent: [true, true, false])
+        let data = try encoder.encode(result)
+        let decoded = try decoder.decode(PIRNullifierCheckResult.self, from: data)
+
+        XCTAssertEqual(result, decoded)
+    }
+
+    // MARK: - SpendabilityResult
+
+    func testSpendabilityResultDecodesFromRustJSON() throws {
+        let json = """
+        {"earliest_height":100,"latest_height":200,"spent_note_ids":[1,3],"total_spent_value":50000}
+        """.data(using: .utf8)!
+
+        let result = try decoder.decode(SpendabilityResult.self, from: json)
+
+        XCTAssertEqual(result.earliestHeight, 100)
+        XCTAssertEqual(result.latestHeight, 200)
+        XCTAssertEqual(result.spentNoteIds, [1, 3])
+        XCTAssertEqual(result.totalSpentValue, 50_000)
+    }
+
+    func testSpendabilityResultEmpty() throws {
+        let result = SpendabilityResult(earliestHeight: 0, latestHeight: 0, spentNoteIds: [], totalSpentValue: 0)
+        let data = try encoder.encode(result)
+        let decoded = try decoder.decode(SpendabilityResult.self, from: data)
+
+        XCTAssertEqual(result, decoded)
+        XCTAssertTrue(decoded.spentNoteIds.isEmpty)
+        XCTAssertEqual(decoded.totalSpentValue, 0)
+    }
+
+    func testSpendabilityResultEncodesSnakeCaseKeys() throws {
+        let result = SpendabilityResult(earliestHeight: 1, latestHeight: 2, spentNoteIds: [5], totalSpentValue: 999)
+        let data = try encoder.encode(result)
+        let jsonObject = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+
+        XCTAssertNotNil(jsonObject["earliest_height"])
+        XCTAssertNotNil(jsonObject["latest_height"])
+        XCTAssertNotNil(jsonObject["spent_note_ids"])
+        XCTAssertNotNil(jsonObject["total_spent_value"])
+    }
+
+    // MARK: - PIRPendingNote
+
+    func testPIRPendingNoteDecodesFromRustJSON() throws {
+        let json = """
+        {"note_id":5,"value":10000}
+        """.data(using: .utf8)!
+
+        let note = try decoder.decode(PIRPendingNote.self, from: json)
+
+        XCTAssertEqual(note.noteId, 5)
+        XCTAssertEqual(note.value, 10_000)
+    }
+
+    func testPIRPendingNoteRoundTrip() throws {
+        let note = PIRPendingNote(noteId: 99, value: 500_000)
+        let data = try encoder.encode(note)
+        let decoded = try decoder.decode(PIRPendingNote.self, from: data)
+
+        XCTAssertEqual(note, decoded)
+    }
+
+    // MARK: - PIRPendingSpends
+
+    func testPIRPendingSpendsDecodesFromRustJSON() throws {
+        let json = """
+        {"notes":[{"note_id":5,"value":10000},{"note_id":8,"value":30000}],"total_value":40000}
+        """.data(using: .utf8)!
+
+        let result = try decoder.decode(PIRPendingSpends.self, from: json)
+
+        XCTAssertEqual(result.notes.count, 2)
+        XCTAssertEqual(result.notes[0].noteId, 5)
+        XCTAssertEqual(result.notes[0].value, 10_000)
+        XCTAssertEqual(result.notes[1].noteId, 8)
+        XCTAssertEqual(result.notes[1].value, 30_000)
+        XCTAssertEqual(result.totalValue, 40_000)
+    }
+
+    func testPIRPendingSpendsEmpty() throws {
+        let json = """
+        {"notes":[],"total_value":0}
+        """.data(using: .utf8)!
+
+        let result = try decoder.decode(PIRPendingSpends.self, from: json)
+
+        XCTAssertTrue(result.notes.isEmpty)
+        XCTAssertEqual(result.totalValue, 0)
+    }
+
+    func testPIRPendingSpendsRoundTrip() throws {
+        let result = PIRPendingSpends(
+            notes: [PIRPendingNote(noteId: 1, value: 5000), PIRPendingNote(noteId: 2, value: 15000)],
+            totalValue: 20000
+        )
+        let data = try encoder.encode(result)
+        let decoded = try decoder.decode(PIRPendingSpends.self, from: data)
+
+        XCTAssertEqual(result, decoded)
+    }
+
+    func testPIRPendingSpendsEncodesSnakeCaseKeys() throws {
+        let result = PIRPendingSpends(
+            notes: [PIRPendingNote(noteId: 1, value: 100)],
+            totalValue: 100
+        )
+        let data = try encoder.encode(result)
+        let jsonObject = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+
+        XCTAssertNotNil(jsonObject["total_value"])
+        XCTAssertNil(jsonObject["totalValue"], "Should not use camelCase key")
+
+        let notesArray = jsonObject["notes"] as! [[String: Any]]
+        XCTAssertNotNil(notesArray[0]["note_id"])
+        XCTAssertNil(notesArray[0]["noteId"], "Should not use camelCase key")
+    }
+
+    // MARK: - Cross-type consistency: notes → check → result pipeline
+
+    func testThreePhasePipelineTypes() throws {
+        let notes = [
+            PIRUnspentNote(id: 1, nf: [UInt8](repeating: 0xAA, count: 32), value: 10_000),
+            PIRUnspentNote(id: 2, nf: [UInt8](repeating: 0xBB, count: 32), value: 20_000),
+            PIRUnspentNote(id: 3, nf: [UInt8](repeating: 0xCC, count: 32), value: 30_000)
+        ]
+
+        let checkResult = PIRNullifierCheckResult(
+            earliestHeight: 100,
+            latestHeight: 200,
+            spent: [true, false, true]
+        )
+
+        XCTAssertEqual(notes.count, checkResult.spent.count, "Spent flags must be parallel to notes")
+
+        let spentNotes = zip(notes, checkResult.spent).filter { $0.1 }
+        let spentNoteIds = spentNotes.map(\.0.id)
+        let totalSpentValue = spentNotes.map(\.0.value).reduce(0, +)
+
+        XCTAssertEqual(spentNoteIds, [1, 3])
+        XCTAssertEqual(totalSpentValue, 40_000)
+
+        let finalResult = SpendabilityResult(
+            earliestHeight: checkResult.earliestHeight,
+            latestHeight: checkResult.latestHeight,
+            spentNoteIds: spentNoteIds,
+            totalSpentValue: totalSpentValue
+        )
+
+        XCTAssertEqual(finalResult.earliestHeight, 100)
+        XCTAssertEqual(finalResult.latestHeight, 200)
+        XCTAssertEqual(finalResult.spentNoteIds, [1, 3])
+        XCTAssertEqual(finalResult.totalSpentValue, 40_000)
+    }
+
+    func testThreePhasePipelineNoNotesSpent() throws {
+        let notes = [
+            PIRUnspentNote(id: 1, nf: [UInt8](repeating: 0xAA, count: 32), value: 10_000),
+            PIRUnspentNote(id: 2, nf: [UInt8](repeating: 0xBB, count: 32), value: 20_000)
+        ]
+
+        let checkResult = PIRNullifierCheckResult(
+            earliestHeight: 50,
+            latestHeight: 150,
+            spent: [false, false]
+        )
+
+        let spentNotes = zip(notes, checkResult.spent).filter { $0.1 }
+        XCTAssertTrue(spentNotes.isEmpty)
+        XCTAssertEqual(spentNotes.map(\.0.value).reduce(0, +), 0)
+    }
+
+    func testThreePhasePipelineAllNotesSpent() throws {
+        let notes = [
+            PIRUnspentNote(id: 1, nf: [UInt8](repeating: 0xAA, count: 32), value: 10_000),
+            PIRUnspentNote(id: 2, nf: [UInt8](repeating: 0xBB, count: 32), value: 20_000)
+        ]
+
+        let checkResult = PIRNullifierCheckResult(
+            earliestHeight: 50,
+            latestHeight: 150,
+            spent: [true, true]
+        )
+
+        let spentNotes = zip(notes, checkResult.spent).filter { $0.1 }
+        XCTAssertEqual(spentNotes.count, 2)
+        XCTAssertEqual(spentNotes.map(\.0.id), [1, 2])
+        XCTAssertEqual(spentNotes.map(\.0.value).reduce(0, +), 30_000)
+    }
+}

--- a/Tests/TestUtils/Sourcery/GeneratedMocks/AutoMockable.generated.swift
+++ b/Tests/TestUtils/Sourcery/GeneratedMocks/AutoMockable.generated.swift
@@ -2504,6 +2504,52 @@ class SynchronizerMock: Synchronizer {
         try await deleteAccountClosure!(accountUUID)
     }
 
+    // MARK: - checkWalletSpendability
+
+    var checkWalletSpendabilityThrowableError: Error?
+    var checkWalletSpendabilityCallsCount = 0
+    var checkWalletSpendabilityCalled: Bool {
+        return checkWalletSpendabilityCallsCount > 0
+    }
+    var checkWalletSpendabilityReturnValue: SpendabilityResult!
+    var checkWalletSpendabilityClosure: ((String, SpendabilityProgressHandler?) async throws -> SpendabilityResult)?
+
+    func checkWalletSpendability(
+        pirServerUrl: String,
+        progress: SpendabilityProgressHandler?
+    ) async throws -> SpendabilityResult {
+        if let error = checkWalletSpendabilityThrowableError {
+            throw error
+        }
+        checkWalletSpendabilityCallsCount += 1
+        if let closure = checkWalletSpendabilityClosure {
+            return try await closure(pirServerUrl, progress)
+        } else {
+            return checkWalletSpendabilityReturnValue
+        }
+    }
+
+    // MARK: - getPIRPendingSpends
+
+    var getPIRPendingSpendsThrowableError: Error?
+    var getPIRPendingSpendsCallsCount = 0
+    var getPIRPendingSpendsCalled: Bool {
+        return getPIRPendingSpendsCallsCount > 0
+    }
+    var getPIRPendingSpendsReturnValue: PIRPendingSpends!
+    var getPIRPendingSpendsClosure: (() async throws -> PIRPendingSpends)?
+
+    func getPIRPendingSpends() async throws -> PIRPendingSpends {
+        if let error = getPIRPendingSpendsThrowableError {
+            throw error
+        }
+        getPIRPendingSpendsCallsCount += 1
+        if let closure = getPIRPendingSpendsClosure {
+            return try await closure()
+        } else {
+            return getPIRPendingSpendsReturnValue
+        }
+    }
 }
 class TransactionRepositoryMock: TransactionRepository {
 

--- a/Tests/TestUtils/Sourcery/GeneratedMocks/AutoMockable.generated.swift
+++ b/Tests/TestUtils/Sourcery/GeneratedMocks/AutoMockable.generated.swift
@@ -3984,4 +3984,58 @@ class ZcashRustBackendWeldingMock: ZcashRustBackendWelding {
         try await deleteAccountClosure!(accountUUID)
     }
 
+    // MARK: - getUnspentOrchardNotesForPIR
+
+    var getUnspentOrchardNotesForPIRThrowableError: Error?
+    var getUnspentOrchardNotesForPIRCallsCount = 0
+    var getUnspentOrchardNotesForPIRReturnValue: [PIRUnspentNote] = []
+    var getUnspentOrchardNotesForPIRClosure: (() async throws -> [PIRUnspentNote])?
+
+    func getUnspentOrchardNotesForPIR() async throws -> [PIRUnspentNote] {
+        if let error = getUnspentOrchardNotesForPIRThrowableError {
+            throw error
+        }
+        getUnspentOrchardNotesForPIRCallsCount += 1
+        if let closure = getUnspentOrchardNotesForPIRClosure {
+            return try await closure()
+        } else {
+            return getUnspentOrchardNotesForPIRReturnValue
+        }
+    }
+
+    // MARK: - insertPIRSpentNotes
+
+    var insertPIRSpentNotesThrowableError: Error?
+    var insertPIRSpentNotesCallsCount = 0
+    var insertPIRSpentNotesReceivedNoteIds: [Int64]?
+    var insertPIRSpentNotesClosure: (([Int64]) async throws -> Void)?
+
+    func insertPIRSpentNotes(_ noteIds: [Int64]) async throws {
+        if let error = insertPIRSpentNotesThrowableError {
+            throw error
+        }
+        insertPIRSpentNotesCallsCount += 1
+        insertPIRSpentNotesReceivedNoteIds = noteIds
+        try await insertPIRSpentNotesClosure?(noteIds)
+    }
+
+    // MARK: - getPIRPendingSpends
+
+    var getPIRPendingSpendsThrowableError: Error?
+    var getPIRPendingSpendsCallsCount = 0
+    var getPIRPendingSpendsReturnValue: PIRPendingSpends = PIRPendingSpends(notes: [], totalValue: 0)
+    var getPIRPendingSpendsClosure: (() async throws -> PIRPendingSpends)?
+
+    func getPIRPendingSpends() async throws -> PIRPendingSpends {
+        if let error = getPIRPendingSpendsThrowableError {
+            throw error
+        }
+        getPIRPendingSpendsCallsCount += 1
+        if let closure = getPIRPendingSpendsClosure {
+            return try await closure()
+        } else {
+            return getPIRPendingSpendsReturnValue
+        }
+    }
+
 }

--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -6,6 +6,10 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+- `zcashlc_check_wallet_spendability` — queries a PIR server for spent Orchard nullifiers and records results in `pir_spent_notes`.
+- `zcashlc_get_pir_pending_spends` — returns PIR-detected spends not yet confirmed by the block scanner.
+
 ## 2.4.6 - 2026-03-12
 
 ### Changed

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -94,6 +94,7 @@ use zip32::fingerprint::SeedFingerprint;
 
 mod derivation;
 mod ffi;
+mod spendability;
 mod tor;
 
 #[cfg(target_vendor = "apple")]

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -4122,6 +4122,141 @@ fn free_ptr_from_vec_with<T>(ptr: *mut T, len: usize, f: impl Fn(&mut T)) {
     }
 }
 
+// ---------------------------------------------------------------------------
+// PIR FFI — DB-touching operations that go through wallet_db() so they share
+// the same connection pattern as every other zcashlc_* function.
+// ---------------------------------------------------------------------------
+
+/// Returns unspent Orchard notes with nullifiers for PIR spend-checking.
+///
+/// Returns JSON `[{"id":i64,"nf":"hex","value":u64}, ...]`, or null on error.
+///
+/// # Safety
+///
+/// - `db_data` must be non-null and valid for reads for `db_data_len` bytes.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn zcashlc_get_unspent_orchard_notes_for_pir(
+    db_data: *const u8,
+    db_data_len: usize,
+    network_id: u32,
+) -> *mut ffi::BoxedSlice {
+    let res = catch_panic(|| {
+        let network = parse_network(network_id)?;
+        let db_data = unsafe { wallet_db(db_data, db_data_len, network)? };
+
+        let notes = db_data
+            .get_unspent_orchard_notes_for_pir()
+            .map_err(|e| anyhow!("failed to query unspent orchard notes for PIR: {e}"))?;
+
+        #[derive(serde::Serialize)]
+        struct Note {
+            id: i64,
+            nf: Vec<u8>,
+            value: u64,
+        }
+
+        let out: Vec<Note> = notes
+            .into_iter()
+            .map(|n| Note {
+                id: n.id,
+                nf: n.nf.to_vec(),
+                value: n.value,
+            })
+            .collect();
+
+        let json = serde_json::to_vec(&out)?;
+        Ok(ffi::BoxedSlice::some(json))
+    });
+    unwrap_exc_or_null(res)
+}
+
+/// Inserts PIR-detected spent note IDs into the wallet DB.
+///
+/// `note_ids_json` / `note_ids_json_len` is a JSON array of i64 note IDs.
+/// Returns 0 on success, -1 on error.
+///
+/// # Safety
+///
+/// - `db_data` must be non-null and valid for reads for `db_data_len` bytes.
+/// - `note_ids_json` must be non-null and valid UTF-8 for `note_ids_json_len` bytes.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn zcashlc_insert_pir_spent_notes(
+    db_data: *const u8,
+    db_data_len: usize,
+    network_id: u32,
+    note_ids_json: *const u8,
+    note_ids_json_len: usize,
+) -> i32 {
+    let res = catch_panic(|| {
+        let network = parse_network(network_id)?;
+        let db_data = unsafe { wallet_db(db_data, db_data_len, network)? };
+
+        let ids_bytes =
+            unsafe { std::slice::from_raw_parts(note_ids_json, note_ids_json_len) };
+        let note_ids: Vec<i64> = serde_json::from_slice(ids_bytes)
+            .map_err(|e| anyhow!("failed to parse note_ids JSON: {e}"))?;
+
+        for note_id in note_ids {
+            db_data
+                .insert_pir_spent_note(note_id)
+                .map_err(|e| anyhow!("failed to insert PIR spent note {note_id}: {e}"))?;
+        }
+        Ok(0i32)
+    });
+    unwrap_exc_or(res, -1)
+}
+
+/// Returns PIR-detected spent notes not yet confirmed by the block scanner.
+///
+/// Uses `wallet_db()` so it shares the `@DBActor`-serialized connection.
+/// Returns JSON `PIRPendingSpendsResult`, or null on error.
+///
+/// # Safety
+///
+/// - `db_data` must be non-null and valid for reads for `db_data_len` bytes.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn zcashlc_get_pir_pending_spends_v2(
+    db_data: *const u8,
+    db_data_len: usize,
+    network_id: u32,
+) -> *mut ffi::BoxedSlice {
+    let res = catch_panic(|| {
+        let network = parse_network(network_id)?;
+        let db_data = unsafe { wallet_db(db_data, db_data_len, network)? };
+
+        let pir_result = db_data
+            .get_pir_pending_spends()
+            .map_err(|e| anyhow!("failed to query PIR pending spends: {e}"))?;
+
+        #[derive(serde::Serialize)]
+        struct PendingNote {
+            note_id: i64,
+            value: u64,
+        }
+        #[derive(serde::Serialize)]
+        struct PendingResult {
+            notes: Vec<PendingNote>,
+            total_value: u64,
+        }
+
+        let result = PendingResult {
+            notes: pir_result
+                .notes
+                .into_iter()
+                .map(|n| PendingNote {
+                    note_id: n.note_id,
+                    value: n.value,
+                })
+                .collect(),
+            total_value: pir_result.total_value,
+        };
+
+        let json = serde_json::to_vec(&result)?;
+        Ok(ffi::BoxedSlice::some(json))
+    });
+    unwrap_exc_or_null(res)
+}
+
 pub(crate) fn parse_optional_height(value: i64) -> anyhow::Result<Option<BlockHeight>> {
     Ok(match value {
         -1 => None,

--- a/rust/src/spendability.rs
+++ b/rust/src/spendability.rs
@@ -1,0 +1,343 @@
+//! C FFI for spendability PIR checks.
+
+use std::panic::AssertUnwindSafe;
+
+use anyhow::anyhow;
+use ffi_helpers::panic::catch_panic;
+use serde::Serialize;
+
+use crate::unwrap_exc_or_null;
+
+#[derive(Serialize)]
+/// Result of checking the spendability of all unspent Orchard notes in the wallet.
+struct SpendabilityCheckResult {
+    /// The earliest height at which the notes were spent.
+    earliest_height: u64,
+    /// The latest height at which the notes were spent.
+    latest_height: u64,
+    /// List of IDs of spent notes.
+    spent_note_ids: Vec<i64>,
+    /// Total zatoshi value of notes found spent by PIR.
+    total_spent_value: u64,
+}
+
+#[derive(Serialize)]
+/// A spent note found by PIR.
+struct PIRPendingNote {
+    /// The ID of the note.
+    note_id: i64,
+    /// The zatoshi value of the note.
+    value: u64,
+}
+
+#[derive(Serialize)]
+/// Result of querying the PIR server for all unspent Orchard notes in the wallet.
+struct PIRPendingSpendsResult {
+    /// List of spent notes.
+    notes: Vec<PIRPendingNote>,
+    /// Total zatoshi value of notes found spent by PIR.
+    total_value: u64,
+}
+
+/// Converts a pointer and length to a UTF-8 string.
+unsafe fn str_from_ptr(ptr: *const u8, len: usize) -> anyhow::Result<String> {
+    let bytes = unsafe { std::slice::from_raw_parts(ptr, len) };
+    Ok(std::str::from_utf8(bytes)?.to_string())
+}
+
+/// Converts a JSON value to a boxed slice.
+fn json_to_boxed_slice<T: Serialize>(value: &T) -> anyhow::Result<*mut crate::ffi::BoxedSlice> {
+    let json = serde_json::to_vec(value)?;
+    Ok(crate::ffi::BoxedSlice::some(json))
+}
+
+/// Retries `insert_pir_spent_note` with exponential backoff when the
+/// database is busy (concurrent access from the sync thread).
+fn insert_pir_spent_note_with_retry(
+    conn: &rusqlite::Connection,
+    note_id: i64,
+) -> anyhow::Result<()> {
+    const MAX_RETRIES: u32 = 8;
+    const BASE_DELAY_MS: u64 = 50;
+
+    for attempt in 0..=MAX_RETRIES {
+        match zcash_client_sqlite::wallet::pir::insert_pir_spent_note(conn, note_id) {
+            Ok(_) => return Ok(()),
+            Err(zcash_client_sqlite::error::SqliteClientError::DbError(
+                rusqlite::Error::SqliteFailure(err, _),
+            )) if err.code == rusqlite::ffi::ErrorCode::DatabaseBusy => {
+                if attempt == MAX_RETRIES {
+                    return Err(anyhow!(
+                        "pir_spent_notes insert for note_id={note_id} failed: \
+                         database busy after {MAX_RETRIES} retries"
+                    ));
+                }
+                let delay = BASE_DELAY_MS * 2u64.pow(attempt);
+                std::thread::sleep(std::time::Duration::from_millis(delay));
+            }
+            Err(e) => return Err(e.into()),
+        }
+    }
+    unreachable!()
+}
+
+/// Queries the PIR server for all unspent Orchard notes in the wallet and
+/// records any that are spent into `pir_spent_notes`.
+///
+/// Returns JSON `SpendabilityCheckResult`, or null on error.
+///
+/// # Safety
+///
+/// Pointer/length pairs must be valid UTF-8 slices.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn zcashlc_check_wallet_spendability(
+    wallet_db_path: *const u8,
+    wallet_db_path_len: usize,
+    pir_server_url: *const u8,
+    pir_server_url_len: usize,
+    progress_callback: Option<unsafe extern "C" fn(f64, *mut std::ffi::c_void)>,
+    progress_context: *mut std::ffi::c_void,
+) -> *mut crate::ffi::BoxedSlice {
+    let progress_context = AssertUnwindSafe(progress_context);
+    let res = catch_panic(|| {
+        let db_path = unsafe { str_from_ptr(wallet_db_path, wallet_db_path_len) }?;
+        let url = unsafe { str_from_ptr(pir_server_url, pir_server_url_len) }?;
+
+        // Open the wallet DB read-write.
+        let conn = rusqlite::Connection::open_with_flags(
+            &db_path,
+            rusqlite::OpenFlags::SQLITE_OPEN_READ_WRITE | rusqlite::OpenFlags::SQLITE_OPEN_NO_MUTEX,
+        )
+        .map_err(|e| anyhow!("failed to open wallet DB: {e}"))?;
+
+        // Query the PIR server for all unspent Orchard notes in the wallet.
+        let notes =
+            zcash_client_sqlite::wallet::pir::get_unspent_orchard_notes_for_pir(&conn)
+                .map_err(|e| anyhow!("failed to query unspent notes: {e}"))?;
+
+        // If there are no unspent Orchard notes, return an empty result.
+        if notes.is_empty() {
+            return json_to_boxed_slice(&SpendabilityCheckResult {
+                earliest_height: 0,
+                latest_height: 0,
+                spent_note_ids: vec![],
+                total_spent_value: 0,
+            });
+        }
+
+        let nullifiers: Vec<[u8; 32]> = notes.iter().map(|n| n.nf).collect();
+
+        // Connect to the PIR server.
+        let client = spend_client::SpendClientBlocking::connect(&url)
+            .map_err(|e| anyhow!("PIR connect failed: {e}"))?;
+
+        // Check the nullifiers with the PIR server.
+        let results = client
+            .check_nullifiers(&nullifiers, |progress| {
+                if let Some(cb) = progress_callback {
+                    unsafe { cb(progress, *progress_context) };
+                }
+            })
+            .map_err(|e| anyhow!("PIR check failed: {e}"))?;
+
+        // Record the spent notes.
+        let mut spent_note_ids = Vec::new();
+        let mut total_spent_value: u64 = 0;
+        for (note, spent) in notes.iter().zip(results.iter()) {
+            if *spent {
+                spent_note_ids.push(note.id);
+                total_spent_value += note.value;
+            }
+        }
+
+        // Insert the spent notes into the wallet DB.
+        for &note_id in &spent_note_ids {
+            insert_pir_spent_note_with_retry(&conn, note_id)?;
+        }
+
+        // Return the result.
+        let metadata = client.metadata();
+        let result = SpendabilityCheckResult {
+            earliest_height: metadata.earliest_height,
+            latest_height: metadata.latest_height,
+            spent_note_ids,
+            total_spent_value,
+        };
+
+        json_to_boxed_slice(&result)
+    });
+    unwrap_exc_or_null(res)
+}
+
+/// Returns PIR-detected spent notes not yet confirmed by the block scanner.
+///
+/// Returns JSON `PIRPendingSpendsResult`, or null on error.
+///
+/// # Safety
+///
+/// Pointer/length pair must be a valid UTF-8 slice.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn zcashlc_get_pir_pending_spends(
+    wallet_db_path: *const u8,
+    wallet_db_path_len: usize,
+) -> *mut crate::ffi::BoxedSlice {
+    let res = catch_panic(|| {
+        // Open the wallet DB read-only.
+        let db_path = unsafe { str_from_ptr(wallet_db_path, wallet_db_path_len) }?;
+
+        let conn = rusqlite::Connection::open_with_flags(
+            &db_path,
+            rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY | rusqlite::OpenFlags::SQLITE_OPEN_NO_MUTEX,
+        )
+        .map_err(|e| anyhow!("failed to open wallet DB: {e}"))?;
+
+        // Query the wallet DB for all spent notes not yet confirmed by the block scanner.
+        let pir_result = zcash_client_sqlite::wallet::pir::get_pir_pending_spends(&conn)
+            .map_err(|e| anyhow!("failed to query PIR pending spends: {e}"))?;
+
+        // Return the result.
+        let result = PIRPendingSpendsResult {
+            notes: pir_result
+                .notes
+                .into_iter()
+                .map(|n| PIRPendingNote {
+                    note_id: n.note_id,
+                    value: n.value,
+                })
+                .collect(),
+            total_value: pir_result.total_value,
+        };
+        json_to_boxed_slice(&result)
+    });
+    unwrap_exc_or_null(res)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use zcash_client_sqlite::wallet::pir::testing::{
+        create_pir_test_db_on_disk, insert_test_note,
+    };
+
+    #[test]
+    fn serialize_spendability_check_result() {
+        let result = SpendabilityCheckResult {
+            earliest_height: 100,
+            latest_height: 200,
+            spent_note_ids: vec![1, 3],
+            total_spent_value: 50_000,
+        };
+        let json: serde_json::Value = serde_json::to_value(&result).unwrap();
+        assert_eq!(json["earliest_height"], 100);
+        assert_eq!(json["latest_height"], 200);
+        assert_eq!(json["spent_note_ids"], serde_json::json!([1, 3]));
+        assert_eq!(json["total_spent_value"], 50_000);
+    }
+
+    #[test]
+    fn serialize_pir_pending_spends_result() {
+        let result = PIRPendingSpendsResult {
+            notes: vec![
+                PIRPendingNote { note_id: 5, value: 10_000 },
+                PIRPendingNote { note_id: 8, value: 30_000 },
+            ],
+            total_value: 40_000,
+        };
+        let json: serde_json::Value = serde_json::to_value(&result).unwrap();
+        assert_eq!(json["total_value"], 40_000);
+        let notes = json["notes"].as_array().unwrap();
+        assert_eq!(notes.len(), 2);
+        assert_eq!(notes[0]["note_id"], 5);
+        assert_eq!(notes[0]["value"], 10_000);
+        assert_eq!(notes[1]["note_id"], 8);
+        assert_eq!(notes[1]["value"], 30_000);
+    }
+
+    #[test]
+    fn serialize_empty_spendability_result() {
+        let result = SpendabilityCheckResult {
+            earliest_height: 0,
+            latest_height: 0,
+            spent_note_ids: vec![],
+            total_spent_value: 0,
+        };
+        let json: serde_json::Value = serde_json::to_value(&result).unwrap();
+        assert_eq!(json["spent_note_ids"], serde_json::json!([]));
+    }
+
+    #[test]
+    fn insert_succeeds_without_contention() {
+        // Create a test database with no contention.
+        let (conn, db_path) = create_pir_test_db_on_disk("no_contention");
+        // Insert a test note.
+        insert_test_note(&conn, 1, 10_000, Some(&[0xAA; 32]));
+        let result = insert_pir_spent_note_with_retry(&conn, 1);
+        assert!(result.is_ok());
+        // Verify the spent note was inserted.
+        let count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM pir_spent_notes", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(count, 1);
+        // Clean up.
+        drop(conn);
+        let _ = std::fs::remove_file(&db_path);
+    }
+
+    #[test]
+    fn insert_propagates_non_busy_error() {
+        let db_path = std::env::temp_dir().join(format!(
+            "pir_nonbusy_test_{}.db",
+            std::process::id()
+        ));
+        // Open the wallet DB read-write.
+        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        // Insert a test note.
+        let result = insert_pir_spent_note_with_retry(&conn, 999);
+        assert!(result.is_err());
+        // Verify the error is not a busy error.
+        let msg = format!("{}", result.unwrap_err());
+        assert!(
+            !msg.contains("database busy"),
+            "should not be a busy error: {msg}"
+        );
+        // Clean up.
+        drop(conn);
+        let _ = std::fs::remove_file(&db_path);
+    }
+
+    #[test]
+    fn insert_retries_on_busy() {
+        use std::sync::{Arc, Barrier};
+
+        // Create a test database with contention.
+        let (conn1, db_path) = create_pir_test_db_on_disk("busy");
+        // Insert a test note.
+        insert_test_note(&conn1, 1, 10_000, Some(&[0xAA; 32]));
+
+        // Create a barrier to synchronize the two threads.
+        let barrier = Arc::new(Barrier::new(2));
+        let barrier2 = barrier.clone();
+        let db_path2 = db_path.clone();
+
+        // Start the second thread.
+        let handle = std::thread::spawn(move || {
+            let conn2 = rusqlite::Connection::open(&db_path2).unwrap();
+            conn2.execute_batch("BEGIN EXCLUSIVE").unwrap();
+            barrier2.wait();
+            std::thread::sleep(std::time::Duration::from_millis(150));
+            conn2.execute_batch("COMMIT").unwrap();
+        });
+
+        // Wait for the second thread to start.
+        barrier.wait();
+        // Insert the test note.
+        let result = insert_pir_spent_note_with_retry(&conn1, 1);
+        handle.join().unwrap();
+
+        // Verify the spent note was inserted.
+        assert!(result.is_ok());
+        // Clean up.
+        drop(conn1);
+        let _ = std::fs::remove_file(&db_path);
+    }
+}

--- a/rust/src/spendability.rs
+++ b/rust/src/spendability.rs
@@ -1,4 +1,8 @@
-//! C FFI for spendability PIR checks.
+//! C FFI for spendability PIR — network-only call.
+//!
+//! DB read/write operations are handled by the new `zcashlc_*` functions
+//! in `lib.rs` that go through `wallet_db()` and share the `@DBActor`
+//! connection.
 
 use std::panic::AssertUnwindSafe;
 
@@ -7,37 +11,6 @@ use ffi_helpers::panic::catch_panic;
 use serde::Serialize;
 
 use crate::unwrap_exc_or_null;
-
-#[derive(Serialize)]
-/// Result of checking the spendability of all unspent Orchard notes in the wallet.
-struct SpendabilityCheckResult {
-    /// The earliest height at which the notes were spent.
-    earliest_height: u64,
-    /// The latest height at which the notes were spent.
-    latest_height: u64,
-    /// List of IDs of spent notes.
-    spent_note_ids: Vec<i64>,
-    /// Total zatoshi value of notes found spent by PIR.
-    total_spent_value: u64,
-}
-
-#[derive(Serialize)]
-/// A spent note found by PIR.
-struct PIRPendingNote {
-    /// The ID of the note.
-    note_id: i64,
-    /// The zatoshi value of the note.
-    value: u64,
-}
-
-#[derive(Serialize)]
-/// Result of querying the PIR server for all unspent Orchard notes in the wallet.
-struct PIRPendingSpendsResult {
-    /// List of spent notes.
-    notes: Vec<PIRPendingNote>,
-    /// Total zatoshi value of notes found spent by PIR.
-    total_value: u64,
-}
 
 /// Converts a pointer and length to a UTF-8 string.
 unsafe fn str_from_ptr(ptr: *const u8, len: usize) -> anyhow::Result<String> {
@@ -51,88 +24,54 @@ fn json_to_boxed_slice<T: Serialize>(value: &T) -> anyhow::Result<*mut crate::ff
     Ok(crate::ffi::BoxedSlice::some(json))
 }
 
-/// Retries `insert_pir_spent_note` with exponential backoff when the
-/// database is busy (concurrent access from the sync thread).
-fn insert_pir_spent_note_with_retry(
-    conn: &rusqlite::Connection,
-    note_id: i64,
-) -> anyhow::Result<()> {
-    const MAX_RETRIES: u32 = 8;
-    const BASE_DELAY_MS: u64 = 50;
-
-    for attempt in 0..=MAX_RETRIES {
-        match zcash_client_sqlite::wallet::pir::insert_pir_spent_note(conn, note_id) {
-            Ok(_) => return Ok(()),
-            Err(zcash_client_sqlite::error::SqliteClientError::DbError(
-                rusqlite::Error::SqliteFailure(err, _),
-            )) if err.code == rusqlite::ffi::ErrorCode::DatabaseBusy => {
-                if attempt == MAX_RETRIES {
-                    return Err(anyhow!(
-                        "pir_spent_notes insert for note_id={note_id} failed: \
-                         database busy after {MAX_RETRIES} retries"
-                    ));
-                }
-                let delay = BASE_DELAY_MS * 2u64.pow(attempt);
-                std::thread::sleep(std::time::Duration::from_millis(delay));
-            }
-            Err(e) => return Err(e.into()),
-        }
-    }
-    unreachable!()
+#[derive(Serialize)]
+struct NullifierCheckResult {
+    earliest_height: u64,
+    latest_height: u64,
+    /// Parallel to the input nullifiers: true = spent.
+    spent: Vec<bool>,
 }
 
-/// Queries the PIR server for all unspent Orchard notes in the wallet and
-/// records any that are spent into `pir_spent_notes`.
+/// Checks nullifiers against the PIR server. No database access.
 ///
-/// Returns JSON `SpendabilityCheckResult`, or null on error.
+/// `nullifiers_json` is a JSON array of byte arrays (each 32 elements),
+/// e.g. `[[0,1,...,31],[0,1,...,31]]`.
+///
+/// Returns JSON `NullifierCheckResult`, or null on error.
 ///
 /// # Safety
 ///
 /// Pointer/length pairs must be valid UTF-8 slices.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn zcashlc_check_wallet_spendability(
-    wallet_db_path: *const u8,
-    wallet_db_path_len: usize,
+pub unsafe extern "C" fn zcashlc_check_nullifiers_pir(
     pir_server_url: *const u8,
     pir_server_url_len: usize,
+    nullifiers_json: *const u8,
+    nullifiers_json_len: usize,
     progress_callback: Option<unsafe extern "C" fn(f64, *mut std::ffi::c_void)>,
     progress_context: *mut std::ffi::c_void,
 ) -> *mut crate::ffi::BoxedSlice {
     let progress_context = AssertUnwindSafe(progress_context);
     let res = catch_panic(|| {
-        let db_path = unsafe { str_from_ptr(wallet_db_path, wallet_db_path_len) }?;
         let url = unsafe { str_from_ptr(pir_server_url, pir_server_url_len) }?;
+        let nf_bytes =
+            unsafe { std::slice::from_raw_parts(nullifiers_json, nullifiers_json_len) };
 
-        // Open the wallet DB read-write.
-        let conn = rusqlite::Connection::open_with_flags(
-            &db_path,
-            rusqlite::OpenFlags::SQLITE_OPEN_READ_WRITE | rusqlite::OpenFlags::SQLITE_OPEN_NO_MUTEX,
-        )
-        .map_err(|e| anyhow!("failed to open wallet DB: {e}"))?;
+        let nf_vecs: Vec<Vec<u8>> = serde_json::from_slice(nf_bytes)
+            .map_err(|e| anyhow!("failed to parse nullifiers JSON: {e}"))?;
 
-        // Query the PIR server for all unspent Orchard notes in the wallet.
-        let notes =
-            zcash_client_sqlite::wallet::pir::get_unspent_orchard_notes_for_pir(&conn)
-                .map_err(|e| anyhow!("failed to query unspent notes: {e}"))?;
+        let nullifiers: Vec<[u8; 32]> = nf_vecs
+            .into_iter()
+            .map(|v| {
+                v.try_into()
+                    .map_err(|_| anyhow!("nullifier must be exactly 32 bytes"))
+            })
+            .collect::<anyhow::Result<Vec<_>>>()?;
 
-        // If there are no unspent Orchard notes, return an empty result.
-        if notes.is_empty() {
-            return json_to_boxed_slice(&SpendabilityCheckResult {
-                earliest_height: 0,
-                latest_height: 0,
-                spent_note_ids: vec![],
-                total_spent_value: 0,
-            });
-        }
-
-        let nullifiers: Vec<[u8; 32]> = notes.iter().map(|n| n.nf).collect();
-
-        // Connect to the PIR server.
         let client = spend_client::SpendClientBlocking::connect(&url)
             .map_err(|e| anyhow!("PIR connect failed: {e}"))?;
 
-        // Check the nullifiers with the PIR server.
-        let results = client
+        let spent = client
             .check_nullifiers(&nullifiers, |progress| {
                 if let Some(cb) = progress_callback {
                     unsafe { cb(progress, *progress_context) };
@@ -140,73 +79,13 @@ pub unsafe extern "C" fn zcashlc_check_wallet_spendability(
             })
             .map_err(|e| anyhow!("PIR check failed: {e}"))?;
 
-        // Record the spent notes.
-        let mut spent_note_ids = Vec::new();
-        let mut total_spent_value: u64 = 0;
-        for (note, spent) in notes.iter().zip(results.iter()) {
-            if *spent {
-                spent_note_ids.push(note.id);
-                total_spent_value += note.value;
-            }
-        }
-
-        // Insert the spent notes into the wallet DB.
-        for &note_id in &spent_note_ids {
-            insert_pir_spent_note_with_retry(&conn, note_id)?;
-        }
-
-        // Return the result.
         let metadata = client.metadata();
-        let result = SpendabilityCheckResult {
+        let result = NullifierCheckResult {
             earliest_height: metadata.earliest_height,
             latest_height: metadata.latest_height,
-            spent_note_ids,
-            total_spent_value,
+            spent,
         };
 
-        json_to_boxed_slice(&result)
-    });
-    unwrap_exc_or_null(res)
-}
-
-/// Returns PIR-detected spent notes not yet confirmed by the block scanner.
-///
-/// Returns JSON `PIRPendingSpendsResult`, or null on error.
-///
-/// # Safety
-///
-/// Pointer/length pair must be a valid UTF-8 slice.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn zcashlc_get_pir_pending_spends(
-    wallet_db_path: *const u8,
-    wallet_db_path_len: usize,
-) -> *mut crate::ffi::BoxedSlice {
-    let res = catch_panic(|| {
-        // Open the wallet DB read-only.
-        let db_path = unsafe { str_from_ptr(wallet_db_path, wallet_db_path_len) }?;
-
-        let conn = rusqlite::Connection::open_with_flags(
-            &db_path,
-            rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY | rusqlite::OpenFlags::SQLITE_OPEN_NO_MUTEX,
-        )
-        .map_err(|e| anyhow!("failed to open wallet DB: {e}"))?;
-
-        // Query the wallet DB for all spent notes not yet confirmed by the block scanner.
-        let pir_result = zcash_client_sqlite::wallet::pir::get_pir_pending_spends(&conn)
-            .map_err(|e| anyhow!("failed to query PIR pending spends: {e}"))?;
-
-        // Return the result.
-        let result = PIRPendingSpendsResult {
-            notes: pir_result
-                .notes
-                .into_iter()
-                .map(|n| PIRPendingNote {
-                    note_id: n.note_id,
-                    value: n.value,
-                })
-                .collect(),
-            total_value: pir_result.total_value,
-        };
         json_to_boxed_slice(&result)
     });
     unwrap_exc_or_null(res)
@@ -215,129 +94,28 @@ pub unsafe extern "C" fn zcashlc_get_pir_pending_spends(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use zcash_client_sqlite::wallet::pir::testing::{
-        create_pir_test_db_on_disk, insert_test_note,
-    };
 
     #[test]
-    fn serialize_spendability_check_result() {
-        let result = SpendabilityCheckResult {
+    fn serialize_nullifier_check_result() {
+        let result = NullifierCheckResult {
             earliest_height: 100,
             latest_height: 200,
-            spent_note_ids: vec![1, 3],
-            total_spent_value: 50_000,
+            spent: vec![true, false, true],
         };
         let json: serde_json::Value = serde_json::to_value(&result).unwrap();
         assert_eq!(json["earliest_height"], 100);
         assert_eq!(json["latest_height"], 200);
-        assert_eq!(json["spent_note_ids"], serde_json::json!([1, 3]));
-        assert_eq!(json["total_spent_value"], 50_000);
+        assert_eq!(json["spent"], serde_json::json!([true, false, true]));
     }
 
     #[test]
-    fn serialize_pir_pending_spends_result() {
-        let result = PIRPendingSpendsResult {
-            notes: vec![
-                PIRPendingNote { note_id: 5, value: 10_000 },
-                PIRPendingNote { note_id: 8, value: 30_000 },
-            ],
-            total_value: 40_000,
-        };
-        let json: serde_json::Value = serde_json::to_value(&result).unwrap();
-        assert_eq!(json["total_value"], 40_000);
-        let notes = json["notes"].as_array().unwrap();
-        assert_eq!(notes.len(), 2);
-        assert_eq!(notes[0]["note_id"], 5);
-        assert_eq!(notes[0]["value"], 10_000);
-        assert_eq!(notes[1]["note_id"], 8);
-        assert_eq!(notes[1]["value"], 30_000);
-    }
-
-    #[test]
-    fn serialize_empty_spendability_result() {
-        let result = SpendabilityCheckResult {
+    fn serialize_empty_nullifier_check_result() {
+        let result = NullifierCheckResult {
             earliest_height: 0,
             latest_height: 0,
-            spent_note_ids: vec![],
-            total_spent_value: 0,
+            spent: vec![],
         };
         let json: serde_json::Value = serde_json::to_value(&result).unwrap();
-        assert_eq!(json["spent_note_ids"], serde_json::json!([]));
-    }
-
-    #[test]
-    fn insert_succeeds_without_contention() {
-        // Create a test database with no contention.
-        let (conn, db_path) = create_pir_test_db_on_disk("no_contention");
-        // Insert a test note.
-        insert_test_note(&conn, 1, 10_000, Some(&[0xAA; 32]));
-        let result = insert_pir_spent_note_with_retry(&conn, 1);
-        assert!(result.is_ok());
-        // Verify the spent note was inserted.
-        let count: i64 = conn
-            .query_row("SELECT COUNT(*) FROM pir_spent_notes", [], |r| r.get(0))
-            .unwrap();
-        assert_eq!(count, 1);
-        // Clean up.
-        drop(conn);
-        let _ = std::fs::remove_file(&db_path);
-    }
-
-    #[test]
-    fn insert_propagates_non_busy_error() {
-        let db_path = std::env::temp_dir().join(format!(
-            "pir_nonbusy_test_{}.db",
-            std::process::id()
-        ));
-        // Open the wallet DB read-write.
-        let conn = rusqlite::Connection::open(&db_path).unwrap();
-        // Insert a test note.
-        let result = insert_pir_spent_note_with_retry(&conn, 999);
-        assert!(result.is_err());
-        // Verify the error is not a busy error.
-        let msg = format!("{}", result.unwrap_err());
-        assert!(
-            !msg.contains("database busy"),
-            "should not be a busy error: {msg}"
-        );
-        // Clean up.
-        drop(conn);
-        let _ = std::fs::remove_file(&db_path);
-    }
-
-    #[test]
-    fn insert_retries_on_busy() {
-        use std::sync::{Arc, Barrier};
-
-        // Create a test database with contention.
-        let (conn1, db_path) = create_pir_test_db_on_disk("busy");
-        // Insert a test note.
-        insert_test_note(&conn1, 1, 10_000, Some(&[0xAA; 32]));
-
-        // Create a barrier to synchronize the two threads.
-        let barrier = Arc::new(Barrier::new(2));
-        let barrier2 = barrier.clone();
-        let db_path2 = db_path.clone();
-
-        // Start the second thread.
-        let handle = std::thread::spawn(move || {
-            let conn2 = rusqlite::Connection::open(&db_path2).unwrap();
-            conn2.execute_batch("BEGIN EXCLUSIVE").unwrap();
-            barrier2.wait();
-            std::thread::sleep(std::time::Duration::from_millis(150));
-            conn2.execute_batch("COMMIT").unwrap();
-        });
-
-        // Wait for the second thread to start.
-        barrier.wait();
-        // Insert the test note.
-        let result = insert_pir_spent_note_with_retry(&conn1, 1);
-        handle.join().unwrap();
-
-        // Verify the spent note was inserted.
-        assert!(result.is_ok());
-        // Clean up.
-        drop(conn1);
-        let _ = std::fs::remove_file(&db_path);
+        assert_eq!(json["spent"], serde_json::json!([]));
     }
 }


### PR DESCRIPTION
## Summary

Integrates nullifier PIR (Private Information Retrieval) into the Swift wallet SDK, enabling Orchard note spendability detection without waiting for sequential shard-tree scanning. The wallet can query a PIR server for nullifier presence and show correct spendable balances before the scan catches up.

## Design

PIR spendability checking is split into three phases to avoid concurrent database writers:

1. **DB read** (`getUnspentOrchardNotesForPIR`) — fetch unspent Orchard notes with nullifiers via `wallet_db()` on `@DBActor`, serialized with the sync path.
2. **Network** (`checkNullifiersPIR`) — check nullifiers against the PIR server in a detached task. This is the slow call and holds no DB connection.
3. **DB write** (`insertPIRSpentNotes`) — record spent notes via `wallet_db()` on `@DBActor`, again serialized with sync.

This eliminates the `SQLITE_BUSY` crash caused by the original monolithic `zcashlc_check_wallet_spendability`, which opened its own `rusqlite::Connection` and bypassed `@DBActor` serialization — creating two concurrent writers on a non-WAL database.

A 5-second `busyTimeout` is also added to `SimpleConnectionProvider` as defense-in-depth against any remaining contention between the Swift-side `SQLite.swift` connection and the Rust-side `rusqlite` connection.

## Rust FFI

**`rust/src/lib.rs`** (DB operations via `wallet_db()`):
- `zcashlc_get_unspent_orchard_notes_for_pir` — returns JSON array of notes with nullifiers.
- `zcashlc_insert_pir_spent_notes` — inserts spent note IDs from JSON array.
- `zcashlc_get_pir_pending_spends_v2` — returns PIR-detected spends not yet confirmed by scanning.

**`rust/src/spendability.rs`** (network only):
- `zcashlc_check_nullifiers_pir` — takes nullifiers as JSON, queries PIR server, returns spent flags. No DB access.

## Swift SDK

- `ZcashRustBackendWelding` / `ZcashRustBackend` — three new `@DBActor` methods wrapping the DB FFI calls.
- `SpendabilityBackend` — refactored to only wrap the network FFI call (phase 2).
- `SDKSynchronizer.checkWalletSpendability` — orchestrates the three-phase flow.
- `SDKSynchronizer.getPIRPendingSpends` — now delegates to `rustBackend` (serialized via `@DBActor`).
- New types: `PIRUnspentNote`, `PIRNullifierCheckResult` in `SpendabilityTypes.swift`.

## Tests

- **Rust**: serialization tests for `NullifierCheckResult` (populated and empty).
- **Swift** (`SpendabilityTypesTests`): JSON round-trip tests for all FFI-boundary types (`PIRUnspentNote`, `PIRNullifierCheckResult`, `SpendabilityResult`, `PIRPendingNote`, `PIRPendingSpends`), snake_case key verification, and three-phase pipeline logic tests.

## Dependencies

All `[patch.crates-io]` entries pin to valargroup/librustzcash at `9861871` (`sync-pir-0.19.x` branch), which carries PIR spent-note tracking on top of the 0.19.x release line.

`spend-client` / `spend-types` pinned to valargroup/sync-nullifier-pir main (`ab81f98`).

## Related PRs

- `librustzcash` (0.19.x backport): zcash/librustzcash#2268
- `zcash-swift-wallet-sdk`: https://github.com/zcash/zcash-swift-wallet-sdk/pull/1674
- `zodl-ios`: https://github.com/zodl-inc/zodl-ios/pull/1675

## Demo

### Detect Spend During Sync

https://www.youtube.com/watch?v=TMFQUpdcnLo

Once the spend is detected, the balance decreases by the full note amount. The decreased balance remains spendable — enabled by the sync nullifier PIR — until the wallet scans the spend and discovers the output change note.

### Comparison to No PIR via Debug Settings

https://www.youtube.com/watch?v=JOKyPA1pqwI

Without PIR, the full balance appears available even though it is partially spent, which would lead to a broadcast failure. Triggering a PIR check via the debug menu shows the balance dropping to the correct spendable amount.