### PR TITLE
[#1677] Extract Broadcaster protocol for multi-server broadcast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
+## Added
+- `Broadcaster` protocol — separates transaction creation from submission, enabling custom broadcast strategies (e.g. submitting to multiple lightwalletd servers in parallel).
+  - `Broadcaster.createProposedTransactions(proposal:spendingKey:)` — creates transactions locally without broadcasting, returning `[ZcashTransaction.Overview]` with raw bytes.
+  - `Broadcaster.createTransactionFromPCZT(pcztWithProofs:pcztWithSigs:)` — extracts and stores a transaction from PCZT data without submitting.
+  - `Broadcaster.submit(_:to:)` — submits raw transaction bytes to a specific `LightWalletEndpoint`. Respects Tor configuration.
+- `Synchronizer.broadcaster` property to access the `Broadcaster` from any synchronizer instance.
+
 # 2.4.9 - 2026-04-04
 
 ## Checkpoints

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `PirSnapshotResolver`, `PirSnapshotResolverError`, `PirSnapshotProbeOutcome`, `PirSnapshotProbing`, and `HTTPPirSnapshotProbe`: Select a vote-nullifier PIR endpoint whose `/root` metadata exactly matches a voting round's expected snapshot height.
 - `Voting*` Swift types: public type contract for the shielded voting FFI boundary, in `Sources/ZcashLightClientKit/Rust/Voting/VotingTypes.swift`.
 - `VotingRustBackend`: Swift wrapper for the voting `libzcashlc` surface. Exposes the static `computeShareNullifier` over `zcashlc_voting_compute_share_nullifier` and the `VotingRustBackendError` error type.
+- `Broadcaster` protocol — separates transaction creation from submission, enabling custom broadcast strategies (e.g. submitting to multiple lightwalletd servers in parallel).
+  - `Broadcaster.createProposedTransactions(proposal:spendingKey:)` — creates transactions locally without broadcasting, returning `[ZcashTransaction.Overview]` with raw bytes.
+  - `Broadcaster.createTransactionFromPCZT(pcztWithProofs:pcztWithSigs:)` — extracts and stores a transaction from PCZT data without submitting.
+  - `Broadcaster.submit(_:to:)` — submits raw transaction bytes to a specific `LightWalletEndpoint`. Respects Tor configuration.
+- `Synchronizer.broadcaster` property, also exposed through the closure and Combine synchronizer facades, to access the `Broadcaster` from SDK synchronizer instances.
 
 ## Changed
 - Bumped Rust dependencies to current crates.io releases (`zcash_address` 0.10→0.11, `zcash_client_backend` 0.21→0.22, `zcash_client_sqlite` 0.19→0.20, `zcash_primitives`/`zcash_proofs` 0.26→0.27, `zcash_protocol` 0.7→0.8, `zcash_transparent` 0.6→0.7, `sapling-crypto` 0.6→0.7, `orchard` 0.12→0.13, `pczt` 0.5→0.6) and removed the `[patch.crates-io]` git-rev overrides. No public Swift API changes.

--- a/Sources/ZcashLightClientKit/Broadcaster.swift
+++ b/Sources/ZcashLightClientKit/Broadcaster.swift
@@ -1,0 +1,79 @@
+//
+//  Broadcaster.swift
+//  ZcashLightClientKit
+//
+//  Created by Adam Tucker on 2026-04-15.
+//
+
+import Combine
+import Foundation
+
+/// Protocol for creating transactions without immediate submission,
+/// and for submitting raw transaction data to specific endpoints.
+///
+/// This separates the concerns of transaction creation and network
+/// submission from the broader synchronization lifecycle managed
+/// by ``Synchronizer``. Use this to implement custom broadcast
+/// strategies such as submitting to multiple lightwalletd servers
+/// in parallel.
+///
+/// Typical usage:
+/// ```swift
+/// // 1. Create the transaction(s)
+/// let txs = try await synchronizer.broadcaster.createProposedTransactions(
+///     proposal: proposal, spendingKey: spendingKey
+/// )
+///
+/// // 2. Submit to one or more endpoints
+/// for endpoint in endpoints {
+///     try await synchronizer.broadcaster.submit(txs[0].raw!, to: endpoint)
+/// }
+/// ```
+public protocol Broadcaster: AnyObject {
+    /// Creates the transactions in the given proposal without submitting
+    /// them to the network.
+    ///
+    /// - Parameter proposal: the proposal for which to create transactions.
+    /// - Parameter spendingKey: the `UnifiedSpendingKey` associated with the
+    ///   account for which the proposal was created.
+    /// - Returns: An array of transaction overviews. Each overview's `raw`
+    ///   property contains the serialized transaction bytes suitable for
+    ///   later submission via ``submit(_:to:)``.
+    ///
+    /// If `prepare()` hasn't already been called since creation of the
+    /// synchronizer instance or since the last wipe then this method throws
+    /// `ZcashError.synchronizerNotPrepared`.
+    func createProposedTransactions(
+        proposal: Proposal,
+        spendingKey: UnifiedSpendingKey
+    ) async throws -> [ZcashTransaction.Overview]
+
+    /// Finalizes a PCZT that has been separately proven and signed,
+    /// stores it in the wallet, and returns the resulting transactions
+    /// without submitting them to the network.
+    ///
+    /// - Parameter pcztWithProofs: the PCZT with proofs added.
+    /// - Parameter pcztWithSigs: the PCZT with signatures added.
+    /// - Returns: An array of transaction overviews with `raw` bytes.
+    ///
+    /// If `prepare()` hasn't already been called since creation of the
+    /// synchronizer instance or since the last wipe then this method throws
+    /// `ZcashError.synchronizerNotPrepared`.
+    func createTransactionFromPCZT(
+        pcztWithProofs: Pczt,
+        pcztWithSigs: Pczt
+    ) async throws -> [ZcashTransaction.Overview]
+
+    /// Submits raw transaction bytes to a specific lightwalletd endpoint.
+    ///
+    /// Creates an ephemeral connection to the given endpoint, submits the
+    /// transaction, and tears down the connection. Respects the current
+    /// Tor configuration.
+    ///
+    /// - Parameter rawTransaction: the raw serialized transaction bytes.
+    /// - Parameter endpoint: the `LightWalletEndpoint` to submit to.
+    func submit(
+        _ rawTransaction: Data,
+        to endpoint: LightWalletEndpoint
+    ) async throws
+}

--- a/Sources/ZcashLightClientKit/Broadcaster.swift
+++ b/Sources/ZcashLightClientKit/Broadcaster.swift
@@ -5,7 +5,6 @@
 //  Created by Adam Tucker on 2026-04-15.
 //
 
-import Combine
 import Foundation
 
 /// Protocol for creating transactions without immediate submission,

--- a/Sources/ZcashLightClientKit/Broadcaster.swift
+++ b/Sources/ZcashLightClientKit/Broadcaster.swift
@@ -1,0 +1,78 @@
+//
+//  Broadcaster.swift
+//  ZcashLightClientKit
+//
+//  Created by Adam Tucker on 2026-04-15.
+//
+
+import Foundation
+
+/// Protocol for creating transactions without immediate submission,
+/// and for submitting raw transaction data to specific endpoints.
+///
+/// This separates the concerns of transaction creation and network
+/// submission from the broader synchronization lifecycle managed
+/// by ``Synchronizer``. Use this to implement custom broadcast
+/// strategies such as submitting to multiple lightwalletd servers
+/// in parallel.
+///
+/// Typical usage:
+/// ```swift
+/// // 1. Create the transaction(s)
+/// let txs = try await synchronizer.broadcaster.createProposedTransactions(
+///     proposal: proposal, spendingKey: spendingKey
+/// )
+///
+/// // 2. Submit to one or more endpoints
+/// for endpoint in endpoints {
+///     try await synchronizer.broadcaster.submit(txs[0].raw!, to: endpoint)
+/// }
+/// ```
+public protocol Broadcaster: AnyObject {
+    /// Creates the transactions in the given proposal without submitting
+    /// them to the network.
+    ///
+    /// - Parameter proposal: the proposal for which to create transactions.
+    /// - Parameter spendingKey: the `UnifiedSpendingKey` associated with the
+    ///   account for which the proposal was created.
+    /// - Returns: An array of transaction overviews. Each overview's `raw`
+    ///   property contains the serialized transaction bytes suitable for
+    ///   later submission via ``submit(_:to:)``.
+    ///
+    /// If `prepare()` hasn't already been called since creation of the
+    /// synchronizer instance or since the last wipe then this method throws
+    /// `ZcashError.synchronizerNotPrepared`.
+    func createProposedTransactions(
+        proposal: Proposal,
+        spendingKey: UnifiedSpendingKey
+    ) async throws -> [ZcashTransaction.Overview]
+
+    /// Finalizes a PCZT that has been separately proven and signed,
+    /// stores it in the wallet, and returns the resulting transactions
+    /// without submitting them to the network.
+    ///
+    /// - Parameter pcztWithProofs: the PCZT with proofs added.
+    /// - Parameter pcztWithSigs: the PCZT with signatures added.
+    /// - Returns: An array of transaction overviews with `raw` bytes.
+    ///
+    /// If `prepare()` hasn't already been called since creation of the
+    /// synchronizer instance or since the last wipe then this method throws
+    /// `ZcashError.synchronizerNotPrepared`.
+    func createTransactionFromPCZT(
+        pcztWithProofs: Pczt,
+        pcztWithSigs: Pczt
+    ) async throws -> [ZcashTransaction.Overview]
+
+    /// Submits raw transaction bytes to a specific lightwalletd endpoint.
+    ///
+    /// Creates an ephemeral connection to the given endpoint, submits the
+    /// transaction, and tears down the connection. Respects the current
+    /// Tor configuration.
+    ///
+    /// - Parameter rawTransaction: the raw serialized transaction bytes.
+    /// - Parameter endpoint: the `LightWalletEndpoint` to submit to.
+    func submit(
+        _ rawTransaction: Data,
+        to endpoint: LightWalletEndpoint
+    ) async throws
+}

--- a/Sources/ZcashLightClientKit/ClosureSynchronizer.swift
+++ b/Sources/ZcashLightClientKit/ClosureSynchronizer.swift
@@ -161,7 +161,9 @@ public protocol ClosureSynchronizer {
     func estimateBirthdayHeight(for date: Date, completion: @escaping (BlockHeight) -> Void)
 
     func httpRequestOverTor(for request: URLRequest, retryLimit: UInt8, completion: @escaping (Result<(data: Data, response: HTTPURLResponse), Error>) -> Void)
-    
+
+    var broadcaster: Broadcaster { get }
+
     /*
      It can be missleading that these two methods are returning Publisher even this protocol is closure based. Reason is that Synchronizer doesn't
      provide different implementations for these two methods. So Combine it is even here.

--- a/Sources/ZcashLightClientKit/ClosureSynchronizer.swift
+++ b/Sources/ZcashLightClientKit/ClosureSynchronizer.swift
@@ -162,7 +162,9 @@ public protocol ClosureSynchronizer {
     func estimateBirthdayHeight(for date: Date, completion: @escaping (BlockHeight) -> Void)
 
     func httpRequestOverTor(for request: URLRequest, retryLimit: UInt8, completion: @escaping (Result<(data: Data, response: HTTPURLResponse), Error>) -> Void)
-    
+
+    var broadcaster: Broadcaster { get }
+
     /*
      It can be missleading that these two methods are returning Publisher even this protocol is closure based. Reason is that Synchronizer doesn't
      provide different implementations for these two methods. So Combine it is even here.

--- a/Sources/ZcashLightClientKit/CombineSynchronizer.swift
+++ b/Sources/ZcashLightClientKit/CombineSynchronizer.swift
@@ -152,7 +152,9 @@ public protocol CombineSynchronizer {
     func estimateBirthdayHeight(for date: Date) -> SinglePublisher<BlockHeight, Error>
 
     func httpRequestOverTor(for request: URLRequest, retryLimit: UInt8) -> SinglePublisher<(data: Data, response: HTTPURLResponse), Error>
-    
+
+    var broadcaster: Broadcaster { get }
+
     func rewind(_ policy: RewindPolicy) -> CompletablePublisher<Error>
     func wipe() -> CompletablePublisher<Error>
 }

--- a/Sources/ZcashLightClientKit/CombineSynchronizer.swift
+++ b/Sources/ZcashLightClientKit/CombineSynchronizer.swift
@@ -153,7 +153,9 @@ public protocol CombineSynchronizer {
     func estimateBirthdayHeight(for date: Date) -> SinglePublisher<BlockHeight, Error>
 
     func httpRequestOverTor(for request: URLRequest, retryLimit: UInt8) -> SinglePublisher<(data: Data, response: HTTPURLResponse), Error>
-    
+
+    var broadcaster: Broadcaster { get }
+
     func rewind(_ policy: RewindPolicy) -> CompletablePublisher<Error>
     func wipe() -> CompletablePublisher<Error>
     

--- a/Sources/ZcashLightClientKit/Synchronizer.swift
+++ b/Sources/ZcashLightClientKit/Synchronizer.swift
@@ -526,6 +526,13 @@ public protocol Synchronizer: AnyObject {
     ///
     /// - Throws rustDeleteAccount as a common indicator of the operation failure
     func deleteAccount(_ accountUUID: AccountUUID) async throws -> Void
+
+    /// Provides access to transaction creation and submission operations
+    /// that are decoupled from the synchronizer's built-in submission flow.
+    ///
+    /// Use this to implement custom broadcast strategies such as submitting
+    /// to multiple lightwalletd servers in parallel.
+    var broadcaster: Broadcaster { get }
 }
 
 public enum SyncStatus: Equatable {

--- a/Sources/ZcashLightClientKit/Synchronizer.swift
+++ b/Sources/ZcashLightClientKit/Synchronizer.swift
@@ -554,6 +554,13 @@ public protocol Synchronizer: AnyObject {
     ///
     /// - Throws rustDeleteAccount as a common indicator of the operation failure
     func deleteAccount(_ accountUUID: AccountUUID) async throws -> Void
+
+    /// Provides access to transaction creation and submission operations
+    /// that are decoupled from the synchronizer's built-in submission flow.
+    ///
+    /// Use this to implement custom broadcast strategies such as submitting
+    /// to multiple lightwalletd servers in parallel.
+    var broadcaster: Broadcaster { get }
 }
 
 /// Error thrown by the default `Synchronizer.getTreeState(height:)` implementation
@@ -570,6 +577,41 @@ private struct GetTreeStateUnimplemented: LocalizedError {
     }
 }
 
+/// Error thrown by the default `Synchronizer.broadcaster` implementation.
+private struct BroadcasterUnimplemented: LocalizedError {
+    var errorDescription: String? {
+        """
+        Synchronizer.broadcaster has no default implementation. \
+        Override this property in your Synchronizer conformer to provide broadcast support.
+        """
+    }
+}
+
+/// Default broadcaster used by `Synchronizer` conformers that do not override
+/// `broadcaster`.
+private final class UnimplementedBroadcaster: Broadcaster {
+    func createProposedTransactions(
+        proposal: Proposal,
+        spendingKey: UnifiedSpendingKey
+    ) async throws -> [ZcashTransaction.Overview] {
+        throw BroadcasterUnimplemented()
+    }
+
+    func createTransactionFromPCZT(
+        pcztWithProofs: Pczt,
+        pcztWithSigs: Pczt
+    ) async throws -> [ZcashTransaction.Overview] {
+        throw BroadcasterUnimplemented()
+    }
+
+    func submit(
+        _ rawTransaction: Data,
+        to endpoint: LightWalletEndpoint
+    ) async throws {
+        throw BroadcasterUnimplemented()
+    }
+}
+
 public extension Synchronizer {
     /// Default implementation so adding `getTreeState(height:)` to the protocol is
     /// not a source-breaking change for downstream conformers. Conformers that have
@@ -578,6 +620,34 @@ public extension Synchronizer {
     /// this default and report the feature as unavailable.
     func getTreeState(height: UInt64) async throws -> Data {
         throw GetTreeStateUnimplemented()
+    }
+
+    /// Default implementation so adding `broadcaster` to the protocol is not a
+    /// source-breaking change for downstream conformers. Conformers with broadcast
+    /// support override this; mocks, stubs, and alternate transports can fall
+    /// through to this default and report the feature as unavailable.
+    var broadcaster: Broadcaster {
+        UnimplementedBroadcaster()
+    }
+}
+
+public extension ClosureSynchronizer {
+    /// Default implementation so adding `broadcaster` to the protocol is not a
+    /// source-breaking change for downstream conformers. Conformers with broadcast
+    /// support override this; mocks, stubs, and alternate transports can fall
+    /// through to this default and report the feature as unavailable.
+    var broadcaster: Broadcaster {
+        UnimplementedBroadcaster()
+    }
+}
+
+public extension CombineSynchronizer {
+    /// Default implementation so adding `broadcaster` to the protocol is not a
+    /// source-breaking change for downstream conformers. Conformers with broadcast
+    /// support override this; mocks, stubs, and alternate transports can fall
+    /// through to this default and report the feature as unavailable.
+    var broadcaster: Broadcaster {
+        UnimplementedBroadcaster()
     }
 }
 

--- a/Sources/ZcashLightClientKit/Synchronizer/ClosureSDKSynchronizer.swift
+++ b/Sources/ZcashLightClientKit/Synchronizer/ClosureSDKSynchronizer.swift
@@ -273,7 +273,9 @@ extension ClosureSDKSynchronizer: ClosureSynchronizer {
             try await self.synchronizer.httpRequestOverTor(for: request, retryLimit: retryLimit)
         }
     }
-    
+
+    public var broadcaster: Broadcaster { synchronizer.broadcaster }
+
     /*
      It can be missleading that these two methods are returning Publisher even this protocol is closure based. Reason is that Synchronizer doesn't
      provide different implementations for these two methods. So Combine it is even here.

--- a/Sources/ZcashLightClientKit/Synchronizer/ClosureSDKSynchronizer.swift
+++ b/Sources/ZcashLightClientKit/Synchronizer/ClosureSDKSynchronizer.swift
@@ -275,7 +275,9 @@ extension ClosureSDKSynchronizer: ClosureSynchronizer {
             try await self.synchronizer.httpRequestOverTor(for: request, retryLimit: retryLimit)
         }
     }
-    
+
+    public var broadcaster: Broadcaster { synchronizer.broadcaster }
+
     /*
      It can be missleading that these two methods are returning Publisher even this protocol is closure based. Reason is that Synchronizer doesn't
      provide different implementations for these two methods. So Combine it is even here.

--- a/Sources/ZcashLightClientKit/Synchronizer/CombineSDKSynchronizer.swift
+++ b/Sources/ZcashLightClientKit/Synchronizer/CombineSDKSynchronizer.swift
@@ -273,7 +273,9 @@ extension CombineSDKSynchronizer: CombineSynchronizer {
             try await self.synchronizer.httpRequestOverTor(for: request, retryLimit: retryLimit)
         }
     }
-    
+
+    public var broadcaster: Broadcaster { synchronizer.broadcaster }
+
     public func rewind(_ policy: RewindPolicy) -> CompletablePublisher<Error> { synchronizer.rewind(policy) }
     public func wipe() -> CompletablePublisher<Error> { synchronizer.wipe() }
 }

--- a/Sources/ZcashLightClientKit/Synchronizer/CombineSDKSynchronizer.swift
+++ b/Sources/ZcashLightClientKit/Synchronizer/CombineSDKSynchronizer.swift
@@ -275,7 +275,9 @@ extension CombineSDKSynchronizer: CombineSynchronizer {
             try await self.synchronizer.httpRequestOverTor(for: request, retryLimit: retryLimit)
         }
     }
-    
+
+    public var broadcaster: Broadcaster { synchronizer.broadcaster }
+
     public func rewind(_ policy: RewindPolicy) -> CompletablePublisher<Error> { synchronizer.rewind(policy) }
     public func wipe() -> CompletablePublisher<Error> { synchronizer.wipe() }
     

--- a/Sources/ZcashLightClientKit/Synchronizer/SDKBroadcaster.swift
+++ b/Sources/ZcashLightClientKit/Synchronizer/SDKBroadcaster.swift
@@ -1,0 +1,109 @@
+//
+//  SDKBroadcaster.swift
+//  ZcashLightClientKit
+//
+//  Created by Adam Tucker on 2026-04-15.
+//
+
+import Combine
+import Foundation
+
+class SDKBroadcaster: Broadcaster {
+    private let transactionEncoder: TransactionEncoder
+    private let initializer: Initializer
+    private let sdkFlags: SDKFlags
+    private let logger: Logger
+    private let eventSubject: PassthroughSubject<SynchronizerEvent, Never>
+    private let statusCheck: () throws -> Void
+
+    init(
+        transactionEncoder: TransactionEncoder,
+        initializer: Initializer,
+        sdkFlags: SDKFlags,
+        logger: Logger,
+        eventSubject: PassthroughSubject<SynchronizerEvent, Never>,
+        statusCheck: @escaping () throws -> Void
+    ) {
+        self.transactionEncoder = transactionEncoder
+        self.initializer = initializer
+        self.sdkFlags = sdkFlags
+        self.logger = logger
+        self.eventSubject = eventSubject
+        self.statusCheck = statusCheck
+    }
+
+    func createProposedTransactions(
+        proposal: Proposal,
+        spendingKey: UnifiedSpendingKey
+    ) async throws -> [ZcashTransaction.Overview] {
+        try statusCheck()
+
+        try await SaplingParameterDownloader.downloadParamsIfnotPresent(
+            spendURL: initializer.spendParamsURL,
+            spendSourceURL: initializer.saplingParamsSourceURL.spendParamFileURL,
+            outputURL: initializer.outputParamsURL,
+            outputSourceURL: initializer.saplingParamsSourceURL.outputParamFileURL,
+            logger: logger
+        )
+
+        let transactions = try await transactionEncoder.createProposedTransactions(
+            proposal: proposal,
+            spendingKey: spendingKey
+        )
+
+        if !transactions.isEmpty {
+            eventSubject.send(.foundTransactions(transactions, nil))
+        }
+
+        return transactions
+    }
+
+    func createTransactionFromPCZT(
+        pcztWithProofs: Pczt,
+        pcztWithSigs: Pczt
+    ) async throws -> [ZcashTransaction.Overview] {
+        try statusCheck()
+
+        try await SaplingParameterDownloader.downloadParamsIfnotPresent(
+            spendURL: initializer.spendParamsURL,
+            spendSourceURL: initializer.saplingParamsSourceURL.spendParamFileURL,
+            outputURL: initializer.outputParamsURL,
+            outputSourceURL: initializer.saplingParamsSourceURL.outputParamFileURL,
+            logger: logger
+        )
+
+        let txId = try await initializer.rustBackend.extractAndStoreTxFromPCZT(
+            pcztWithProofs: pcztWithProofs,
+            pcztWithSigs: pcztWithSigs
+        )
+
+        let transactions = try await transactionEncoder.fetchTransactionsForTxIds([txId])
+
+        if !transactions.isEmpty {
+            eventSubject.send(.foundTransactions(transactions, nil))
+        }
+
+        return transactions
+    }
+
+    func submit(
+        _ rawTransaction: Data,
+        to endpoint: LightWalletEndpoint
+    ) async throws {
+        try statusCheck()
+
+        let torClient = initializer.container.resolve(TorClient.self)
+        let service = LightWalletGRPCServiceOverTor(endpoint: endpoint, tor: torClient)
+        defer { Task { await service.closeConnections() } }
+
+        let mode: ServiceMode = await sdkFlags.torEnabled ? .uniqueTor : .direct
+        let response = try await service.submit(spendTransaction: rawTransaction, mode: mode)
+
+        guard response.errorCode >= 0 else {
+            throw TransactionEncoderError.submitError(
+                code: Int(response.errorCode),
+                message: response.errorMessage
+            )
+        }
+    }
+}

--- a/Sources/ZcashLightClientKit/Synchronizer/SDKBroadcaster.swift
+++ b/Sources/ZcashLightClientKit/Synchronizer/SDKBroadcaster.swift
@@ -1,0 +1,107 @@
+//
+//  SDKBroadcaster.swift
+//  ZcashLightClientKit
+//
+//  Created by Adam Tucker on 2026-04-15.
+//
+
+import Combine
+import Foundation
+
+class SDKBroadcaster: Broadcaster {
+    private let transactionEncoder: TransactionEncoder
+    private let initializer: Initializer
+    private let sdkFlags: SDKFlags
+    private let logger: Logger
+    private let eventSubject: PassthroughSubject<SynchronizerEvent, Never>
+    private let statusCheck: () throws -> Void
+
+    init(
+        transactionEncoder: TransactionEncoder,
+        initializer: Initializer,
+        sdkFlags: SDKFlags,
+        logger: Logger,
+        eventSubject: PassthroughSubject<SynchronizerEvent, Never>,
+        statusCheck: @escaping () throws -> Void
+    ) {
+        self.transactionEncoder = transactionEncoder
+        self.initializer = initializer
+        self.sdkFlags = sdkFlags
+        self.logger = logger
+        self.eventSubject = eventSubject
+        self.statusCheck = statusCheck
+    }
+
+    func createProposedTransactions(
+        proposal: Proposal,
+        spendingKey: UnifiedSpendingKey
+    ) async throws -> [ZcashTransaction.Overview] {
+        try statusCheck()
+
+        try await SaplingParameterDownloader.downloadParamsIfnotPresent(
+            spendURL: initializer.spendParamsURL,
+            spendSourceURL: initializer.saplingParamsSourceURL.spendParamFileURL,
+            outputURL: initializer.outputParamsURL,
+            outputSourceURL: initializer.saplingParamsSourceURL.outputParamFileURL,
+            logger: logger
+        )
+
+        let transactions = try await transactionEncoder.createProposedTransactions(
+            proposal: proposal,
+            spendingKey: spendingKey
+        )
+
+        if !transactions.isEmpty {
+            eventSubject.send(.foundTransactions(transactions, nil))
+        }
+
+        return transactions
+    }
+
+    func createTransactionFromPCZT(
+        pcztWithProofs: Pczt,
+        pcztWithSigs: Pczt
+    ) async throws -> [ZcashTransaction.Overview] {
+        try statusCheck()
+
+        try await SaplingParameterDownloader.downloadParamsIfnotPresent(
+            spendURL: initializer.spendParamsURL,
+            spendSourceURL: initializer.saplingParamsSourceURL.spendParamFileURL,
+            outputURL: initializer.outputParamsURL,
+            outputSourceURL: initializer.saplingParamsSourceURL.outputParamFileURL,
+            logger: logger
+        )
+
+        let txId = try await initializer.rustBackend.extractAndStoreTxFromPCZT(
+            pcztWithProofs: pcztWithProofs,
+            pcztWithSigs: pcztWithSigs
+        )
+
+        let transactions = try await transactionEncoder.fetchTransactionsForTxIds([txId])
+
+        if !transactions.isEmpty {
+            eventSubject.send(.foundTransactions(transactions, nil))
+        }
+
+        return transactions
+    }
+
+    func submit(
+        _ rawTransaction: Data,
+        to endpoint: LightWalletEndpoint
+    ) async throws {
+        let torClient = initializer.container.resolve(TorClient.self)
+        let service = LightWalletGRPCServiceOverTor(endpoint: endpoint, tor: torClient)
+        defer { Task { await service.closeConnections() } }
+
+        let mode: ServiceMode = await sdkFlags.torEnabled ? .uniqueTor : .direct
+        let response = try await service.submit(spendTransaction: rawTransaction, mode: mode)
+
+        guard response.errorCode >= 0 else {
+            throw TransactionEncoderError.submitError(
+                code: Int(response.errorCode),
+                message: response.errorMessage
+            )
+        }
+    }
+}

--- a/Sources/ZcashLightClientKit/Synchronizer/SDKSynchronizer.swift
+++ b/Sources/ZcashLightClientKit/Synchronizer/SDKSynchronizer.swift
@@ -55,6 +55,18 @@ public class SDKSynchronizer: Synchronizer {
     private let syncSessionTicker: SessionTicker
     var latestBlocksDataProvider: LatestBlocksDataProvider
 
+    public private(set) lazy var broadcaster: Broadcaster = SDKBroadcaster(
+        transactionEncoder: transactionEncoder,
+        initializer: initializer,
+        sdkFlags: sdkFlags,
+        logger: logger,
+        eventSubject: eventSubject,
+        statusCheck: { [weak self] in
+            guard let self else { return }
+            try self.throwIfUnprepared()
+        }
+    )
+
     /// Creates an SDKSynchronizer instance
     /// - Parameter initializer: a wallet Initializer object
     public convenience init(initializer: Initializer) {

--- a/Sources/ZcashLightClientKit/Synchronizer/SDKSynchronizer.swift
+++ b/Sources/ZcashLightClientKit/Synchronizer/SDKSynchronizer.swift
@@ -55,6 +55,14 @@ public class SDKSynchronizer: Synchronizer {
     private let syncSessionTicker: SessionTicker
     var latestBlocksDataProvider: LatestBlocksDataProvider
 
+    private var broadcasterStorage: Broadcaster?
+    public var broadcaster: Broadcaster {
+        guard let broadcaster = broadcasterStorage else {
+            preconditionFailure("Broadcaster accessed before initialization")
+        }
+        return broadcaster
+    }
+
     /// Creates an SDKSynchronizer instance
     /// - Parameter initializer: a wallet Initializer object
     public convenience init(initializer: Initializer) {
@@ -93,6 +101,20 @@ public class SDKSynchronizer: Synchronizer {
         self.syncSessionTicker = syncSessionTicker
         self.latestBlocksDataProvider = initializer.container.resolve(LatestBlocksDataProvider.self)
         self.sdkFlags = initializer.container.resolve(SDKFlags.self)
+
+        self.broadcasterStorage = SDKBroadcaster(
+            transactionEncoder: transactionEncoder,
+            initializer: initializer,
+            sdkFlags: sdkFlags,
+            logger: logger,
+            eventSubject: eventSubject,
+            statusCheck: { [weak self] in
+                guard let self else {
+                    throw ZcashError.synchronizerNotPrepared
+                }
+                try self.throwIfUnprepared()
+            }
+        )
 
         initializer.lightWalletService.connectionStateChange = { [weak self] oldState, newState in
             self?.connectivityStateChanged(oldState: oldState, newState: newState)
@@ -425,17 +447,7 @@ public class SDKSynchronizer: Synchronizer {
         proposal: Proposal,
         spendingKey: UnifiedSpendingKey
     ) async throws -> AsyncThrowingStream<TransactionSubmitResult, Error> {
-        try throwIfUnprepared()
-
-        try await SaplingParameterDownloader.downloadParamsIfnotPresent(
-            spendURL: initializer.spendParamsURL,
-            spendSourceURL: initializer.saplingParamsSourceURL.spendParamFileURL,
-            outputURL: initializer.outputParamsURL,
-            outputSourceURL: initializer.saplingParamsSourceURL.outputParamFileURL,
-            logger: logger
-        )
-
-        let transactions = try await transactionEncoder.createProposedTransactions(
+        let transactions = try await broadcaster.createProposedTransactions(
             proposal: proposal,
             spendingKey: spendingKey
         )
@@ -446,11 +458,6 @@ public class SDKSynchronizer: Synchronizer {
     func submitTransactions(_ transactions: [ZcashTransaction.Overview]) -> AsyncThrowingStream<TransactionSubmitResult, Error> {
         var iterator = transactions.makeIterator()
         var submitFailed = false
-
-        // let clients know the transaction repository changed
-        if !transactions.isEmpty {
-            eventSubject.send(.foundTransactions(transactions, nil))
-        }
         
         return AsyncThrowingStream() {
             guard let transaction = iterator.next() else { return nil }
@@ -512,22 +519,10 @@ public class SDKSynchronizer: Synchronizer {
     }
     
     public func createTransactionFromPCZT(pcztWithProofs: Pczt, pcztWithSigs: Pczt) async throws -> AsyncThrowingStream<TransactionSubmitResult, Error> {
-        try throwIfUnprepared()
-
-        try await SaplingParameterDownloader.downloadParamsIfnotPresent(
-            spendURL: initializer.spendParamsURL,
-            spendSourceURL: initializer.saplingParamsSourceURL.spendParamFileURL,
-            outputURL: initializer.outputParamsURL,
-            outputSourceURL: initializer.saplingParamsSourceURL.outputParamFileURL,
-            logger: logger
-        )
-
-        let txId = try await initializer.rustBackend.extractAndStoreTxFromPCZT(
+        let transactions = try await broadcaster.createTransactionFromPCZT(
             pcztWithProofs: pcztWithProofs,
             pcztWithSigs: pcztWithSigs
         )
-
-        let transactions = try await transactionEncoder.fetchTransactionsForTxIds([txId])
         
         return submitTransactions(transactions)
     }

--- a/Tests/OfflineTests/BroadcasterTests.swift
+++ b/Tests/OfflineTests/BroadcasterTests.swift
@@ -1,0 +1,413 @@
+//
+//  BroadcasterTests.swift
+//  ZcashLightClientKitTests
+//
+
+import Combine
+import XCTest
+import GRPC
+import NIO
+import NIOTransportServices
+@testable import TestUtils
+@testable import ZcashLightClientKit
+
+final class BroadcasterTests: ZcashTestCase {
+    private var cancellables: [AnyCancellable] = []
+
+    override func setUp() async throws {
+        try await super.setUp()
+        cancellables = []
+    }
+
+    override func tearDown() async throws {
+        cancellables = []
+        try await super.tearDown()
+    }
+
+    // MARK: - createProposedTransactions
+
+    func testCreateProposedTransactionsReturnsRawBytesAndEmitsEvent() async throws {
+        let rawTransaction = Data([0x01, 0x02, 0x03, 0x04])
+        let createdTransactions = [makeTransaction(raw: rawTransaction, rawID: Data(repeating: 0xAB, count: 32))]
+        let transactionEncoder = StubTransactionEncoder(createdTransactions: createdTransactions)
+        let synchronizer = try makeSynchronizer(transactionEncoder: transactionEncoder)
+
+        let foundTransactionsExpectation = XCTestExpectation(description: "found transactions event")
+
+        synchronizer.eventStream
+            .sink { event in
+                guard case let .foundTransactions(transactions, range) = event else { return }
+                XCTAssertNil(range)
+                XCTAssertEqual(transactions.map(\.rawID), createdTransactions.map(\.rawID))
+                foundTransactionsExpectation.fulfill()
+            }
+            .store(in: &cancellables)
+
+        await synchronizer.updateStatus(.stopped)
+
+        let proposal = Proposal.testOnlyFakeProposal(totalFee: 10)
+        let spendingKey = TestsData(networkType: .testnet).spendingKey
+
+        let transactions = try await synchronizer.broadcaster.createProposedTransactions(
+            proposal: proposal,
+            spendingKey: spendingKey
+        )
+
+        XCTAssertEqual(transactionEncoder.receivedCreateArguments?.proposal, proposal)
+        XCTAssertEqual(transactionEncoder.receivedCreateArguments?.spendingKey, spendingKey)
+        XCTAssertEqual(transactions.map(\.rawID), createdTransactions.map(\.rawID))
+        XCTAssertEqual(try transactions.map { try XCTUnwrap($0.raw) }, [rawTransaction])
+
+        await fulfillment(of: [foundTransactionsExpectation], timeout: 1.0)
+    }
+
+    // MARK: - submit
+
+    func testSubmitSendsRawBytesToProvidedEndpoint() async throws {
+        let rawTransaction = Data([0x01, 0x02, 0x03, 0x04])
+        let createdTransactions = [makeTransaction(raw: rawTransaction, rawID: Data(repeating: 0xAB, count: 32))]
+        let transactionEncoder = StubTransactionEncoder(createdTransactions: createdTransactions)
+        let service = try RecordingCompactTxStreamerService(sendResponse: makeSendResponse(errorCode: 0, errorMessage: ""))
+        defer { try? service.stop() }
+        let synchronizer = try makeSynchronizer(transactionEncoder: transactionEncoder)
+
+        await synchronizer.updateStatus(.stopped)
+
+        try await synchronizer.broadcaster.submit(rawTransaction, to: service.endpoint)
+
+        XCTAssertEqual(service.recordedTransactions(), [rawTransaction])
+    }
+
+    func testSubmitThrowsWhenEndpointRejectsTransaction() async throws {
+        try await assertSubmitThrows(errorCode: -25, errorMessage: "rejected")
+    }
+
+    // MARK: - Full round-trip: create then submit
+
+    func testCreateThenSubmitRoundTrip() async throws {
+        let rawTransaction = Data([0x01, 0x02, 0x03, 0x04])
+        let createdTransactions = [makeTransaction(raw: rawTransaction, rawID: Data(repeating: 0xAB, count: 32))]
+        let transactionEncoder = StubTransactionEncoder(createdTransactions: createdTransactions)
+        let service = try RecordingCompactTxStreamerService(sendResponse: makeSendResponse(errorCode: 0, errorMessage: ""))
+        defer { try? service.stop() }
+        let synchronizer = try makeSynchronizer(transactionEncoder: transactionEncoder)
+
+        await synchronizer.updateStatus(.stopped)
+
+        let proposal = Proposal.testOnlyFakeProposal(totalFee: 10)
+        let spendingKey = TestsData(networkType: .testnet).spendingKey
+
+        // Step 1: Create without submitting
+        let transactions = try await synchronizer.broadcaster.createProposedTransactions(
+            proposal: proposal,
+            spendingKey: spendingKey
+        )
+
+        XCTAssertEqual(service.recordedTransactions(), [], "No transactions should be submitted yet")
+
+        // Step 2: Submit to the endpoint
+        let raw = try XCTUnwrap(transactions.first?.raw)
+        try await synchronizer.broadcaster.submit(raw, to: service.endpoint)
+
+        XCTAssertEqual(service.recordedTransactions(), [rawTransaction])
+    }
+
+    func testBroadcasterThrowsWhenNotPrepared() async throws {
+        let transactionEncoder = StubTransactionEncoder(createdTransactions: [])
+        let synchronizer = try makeSynchronizer(transactionEncoder: transactionEncoder)
+
+        // Status is .unprepared by default — broadcaster should throw
+
+        let proposal = Proposal.testOnlyFakeProposal(totalFee: 10)
+        let spendingKey = TestsData(networkType: .testnet).spendingKey
+
+        do {
+            _ = try await synchronizer.broadcaster.createProposedTransactions(
+                proposal: proposal,
+                spendingKey: spendingKey
+            )
+            XCTFail("Should throw when synchronizer is not prepared")
+        } catch {
+            XCTAssertTrue(error is ZcashError, "Expected ZcashError but got \(error)")
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func makeSynchronizer(transactionEncoder: TransactionEncoder) throws -> SDKSynchronizer {
+        let serviceMock = LightWalletServiceMock()
+        let transactionRepository = TransactionRepositoryMock()
+
+        mockContainer.mock(type: LightWalletService.self, isSingleton: true) { _ in serviceMock }
+        mockContainer.mock(type: TransactionRepository.self, isSingleton: true) { _ in transactionRepository }
+
+        let initializer = Initializer(
+            container: mockContainer,
+            cacheDbURL: nil,
+            fsBlockDbRoot: testTempDirectory,
+            generalStorageURL: testGeneralStorageDirectory,
+            dataDbURL: try __dataDbURL(),
+            torDirURL: try __torDirURL(),
+            endpoint: LightWalletEndpointBuilder.default,
+            network: ZcashNetworkBuilder.network(for: .testnet),
+            spendParamsURL: try __spendParamsURL(),
+            outputParamsURL: try __outputParamsURL(),
+            saplingParamsSourceURL: SaplingParamsSourceURL.tests,
+            isTorEnabled: false,
+            isExchangeRateEnabled: false
+        )
+
+        let blockProcessor = CompactBlockProcessor(
+            initializer: initializer,
+            walletBirthdayProvider: { initializer.walletBirthday }
+        )
+
+        return SDKSynchronizer(
+            status: .unprepared,
+            initializer: initializer,
+            transactionEncoder: transactionEncoder,
+            transactionRepository: transactionRepository,
+            blockProcessor: blockProcessor,
+            syncSessionTicker: .live
+        )
+    }
+
+    private func makeTransaction(raw: Data, rawID: Data) -> ZcashTransaction.Overview {
+        ZcashTransaction.Overview(
+            accountUUID: TestsData.mockedAccountUUID,
+            blockTime: nil,
+            expiryHeight: 123_456,
+            fee: Zatoshi(10_000),
+            index: 0,
+            isShielding: false,
+            hasChange: false,
+            memoCount: 0,
+            minedHeight: nil,
+            raw: raw,
+            rawID: rawID,
+            receivedNoteCount: 0,
+            sentNoteCount: 1,
+            value: Zatoshi(-1_000),
+            isExpiredUmined: false,
+            totalSpent: nil,
+            totalReceived: nil
+        )
+    }
+
+    private func makeSendResponse(errorCode: Int32, errorMessage: String) -> SendResponse {
+        var response = SendResponse()
+        response.errorCode = errorCode
+        response.errorMessage = errorMessage
+        return response
+    }
+
+    private func assertSubmitThrows(errorCode: Int32, errorMessage: String) async throws {
+        let rawTransaction = Data([0x0A, 0x0B, 0x0C])
+        let transactionEncoder = StubTransactionEncoder(createdTransactions: [])
+        let service = try RecordingCompactTxStreamerService(
+            sendResponse: makeSendResponse(errorCode: errorCode, errorMessage: errorMessage)
+        )
+        defer { try? service.stop() }
+
+        let synchronizer = try makeSynchronizer(transactionEncoder: transactionEncoder)
+
+        await synchronizer.updateStatus(.stopped)
+
+        do {
+            try await synchronizer.broadcaster.submit(rawTransaction, to: service.endpoint)
+            XCTFail("submit should throw when the server rejects the transaction.")
+        } catch let error as TransactionEncoderError {
+            guard case let .submitError(code, message) = error else {
+                XCTFail("Expected submitError but got \(error)")
+                return
+            }
+            XCTAssertEqual(code, Int(errorCode))
+            XCTAssertEqual(message, errorMessage)
+        } catch {
+            XCTFail("Expected TransactionEncoderError.submitError but got \(error)")
+        }
+
+        XCTAssertEqual(service.recordedTransactions(), [rawTransaction])
+    }
+}
+
+// MARK: - Test Doubles
+
+private final class StubTransactionEncoder: TransactionEncoder {
+    private let createdTransactions: [ZcashTransaction.Overview]
+    private(set) var receivedCreateArguments: (proposal: Proposal, spendingKey: UnifiedSpendingKey)?
+
+    init(createdTransactions: [ZcashTransaction.Overview]) {
+        self.createdTransactions = createdTransactions
+    }
+
+    func proposeTransfer(
+        accountUUID: AccountUUID,
+        recipient: String,
+        amount: Zatoshi,
+        memoBytes: MemoBytes?
+    ) async throws -> Proposal {
+        fatalError("Unused in test")
+    }
+
+    func proposeShielding(
+        accountUUID: AccountUUID,
+        shieldingThreshold: Zatoshi,
+        memoBytes: MemoBytes?,
+        transparentReceiver: String?
+    ) async throws -> Proposal? {
+        fatalError("Unused in test")
+    }
+
+    func createProposedTransactions(
+        proposal: Proposal,
+        spendingKey: UnifiedSpendingKey
+    ) async throws -> [ZcashTransaction.Overview] {
+        receivedCreateArguments = (proposal, spendingKey)
+        return createdTransactions
+    }
+
+    func proposeFulfillingPaymentFromURI(
+        _ uri: String,
+        accountUUID: AccountUUID
+    ) async throws -> Proposal {
+        fatalError("Unused in test")
+    }
+
+    func submit(transaction: EncodedTransaction) async throws {
+        fatalError("Unused in test")
+    }
+
+    func fetchTransactionsForTxIds(_ txIds: [Data]) async throws -> [ZcashTransaction.Overview] {
+        fatalError("Unused in test")
+    }
+
+    func closeDBConnection() { }
+}
+
+private final class RecordingCompactTxStreamerService: CompactTxStreamerProvider {
+    var interceptors: CompactTxStreamerServerInterceptorFactoryProtocol? { nil }
+
+    private(set) var endpoint: LightWalletEndpoint!
+
+    private let sendResponse: SendResponse
+    private let eventLoopGroup = NIOTSEventLoopGroup(loopCount: 1, defaultQoS: .default)
+    private let queue = DispatchQueue(label: "RecordingCompactTxStreamerService.queue")
+    private var submittedTransactions: [Data] = []
+    private var server: Server?
+
+    init(sendResponse: SendResponse) throws {
+        self.sendResponse = sendResponse
+        self.endpoint = LightWalletEndpoint(address: "127.0.0.1", port: 0, secure: false)
+
+        let server = try Server.insecure(group: eventLoopGroup)
+            .withServiceProviders([self])
+            .bind(host: "127.0.0.1", port: 0)
+            .wait()
+
+        self.server = server
+        self.endpoint = LightWalletEndpoint(
+            address: "127.0.0.1",
+            port: server.channel.localAddress?.port ?? 0,
+            secure: false,
+            singleCallTimeoutInMillis: 5_000,
+            streamingCallTimeoutInMillis: 5_000
+        )
+    }
+
+    func stop() throws {
+        try server?.close().wait()
+        try eventLoopGroup.syncShutdownGracefully()
+    }
+
+    func recordedTransactions() -> [Data] {
+        queue.sync { submittedTransactions }
+    }
+
+    func getLatestBlock(request: ChainSpec, context: StatusOnlyCallContext) -> EventLoopFuture<BlockID> {
+        unimplementedUnary(on: context.eventLoop)
+    }
+
+    func getBlock(request: BlockID, context: StatusOnlyCallContext) -> EventLoopFuture<CompactBlock> {
+        unimplementedUnary(on: context.eventLoop)
+    }
+
+    func getBlockNullifiers(request: BlockID, context: StatusOnlyCallContext) -> EventLoopFuture<CompactBlock> {
+        unimplementedUnary(on: context.eventLoop)
+    }
+
+    func getBlockRange(request: BlockRange, context: StreamingResponseCallContext<CompactBlock>) -> EventLoopFuture<GRPCStatus> {
+        unimplementedStreaming(on: context.eventLoop)
+    }
+
+    func getBlockRangeNullifiers(request: BlockRange, context: StreamingResponseCallContext<CompactBlock>) -> EventLoopFuture<GRPCStatus> {
+        unimplementedStreaming(on: context.eventLoop)
+    }
+
+    func getTransaction(request: TxFilter, context: StatusOnlyCallContext) -> EventLoopFuture<RawTransaction> {
+        unimplementedUnary(on: context.eventLoop)
+    }
+
+    func sendTransaction(request: RawTransaction, context: StatusOnlyCallContext) -> EventLoopFuture<SendResponse> {
+        queue.sync {
+            submittedTransactions.append(request.data)
+        }
+        return context.eventLoop.makeSucceededFuture(sendResponse)
+    }
+
+    func getTaddressTxids(request: TransparentAddressBlockFilter, context: StreamingResponseCallContext<RawTransaction>) -> EventLoopFuture<GRPCStatus> {
+        unimplementedStreaming(on: context.eventLoop)
+    }
+
+    func getTaddressBalance(request: AddressList, context: StatusOnlyCallContext) -> EventLoopFuture<Balance> {
+        unimplementedUnary(on: context.eventLoop)
+    }
+
+    func getTaddressBalanceStream(context: UnaryResponseCallContext<Balance>) -> EventLoopFuture<(StreamEvent<Address>) -> Void> {
+        unimplementedUnary(on: context.eventLoop)
+    }
+
+    func getMempoolTx(request: Exclude, context: StreamingResponseCallContext<CompactTx>) -> EventLoopFuture<GRPCStatus> {
+        unimplementedStreaming(on: context.eventLoop)
+    }
+
+    func getMempoolStream(request: ZcashLightClientKit.Empty, context: StreamingResponseCallContext<RawTransaction>) -> EventLoopFuture<GRPCStatus> {
+        unimplementedStreaming(on: context.eventLoop)
+    }
+
+    func getTreeState(request: BlockID, context: StatusOnlyCallContext) -> EventLoopFuture<TreeState> {
+        unimplementedUnary(on: context.eventLoop)
+    }
+
+    func getLatestTreeState(request: ZcashLightClientKit.Empty, context: StatusOnlyCallContext) -> EventLoopFuture<TreeState> {
+        unimplementedUnary(on: context.eventLoop)
+    }
+
+    func getSubtreeRoots(request: GetSubtreeRootsArg, context: StreamingResponseCallContext<SubtreeRoot>) -> EventLoopFuture<GRPCStatus> {
+        unimplementedStreaming(on: context.eventLoop)
+    }
+
+    func getAddressUtxos(request: GetAddressUtxosArg, context: StatusOnlyCallContext) -> EventLoopFuture<GetAddressUtxosReplyList> {
+        unimplementedUnary(on: context.eventLoop)
+    }
+
+    func getAddressUtxosStream(request: GetAddressUtxosArg, context: StreamingResponseCallContext<GetAddressUtxosReply>) -> EventLoopFuture<GRPCStatus> {
+        unimplementedStreaming(on: context.eventLoop)
+    }
+
+    func getLightdInfo(request: ZcashLightClientKit.Empty, context: StatusOnlyCallContext) -> EventLoopFuture<LightdInfo> {
+        unimplementedUnary(on: context.eventLoop)
+    }
+
+    func ping(request: ZcashLightClientKit.Duration, context: StatusOnlyCallContext) -> EventLoopFuture<PingResponse> {
+        unimplementedUnary(on: context.eventLoop)
+    }
+
+    private func unimplementedUnary<T>(on eventLoop: EventLoop) -> EventLoopFuture<T> {
+        eventLoop.makeFailedFuture(GRPCStatus(code: .unimplemented, message: "Unused in test"))
+    }
+
+    private func unimplementedStreaming(on eventLoop: EventLoop) -> EventLoopFuture<GRPCStatus> {
+        eventLoop.makeSucceededFuture(GRPCStatus(code: .unimplemented, message: "Unused in test"))
+    }
+}

--- a/Tests/OfflineTests/BroadcasterTests.swift
+++ b/Tests/OfflineTests/BroadcasterTests.swift
@@ -1,0 +1,550 @@
+//
+//  BroadcasterTests.swift
+//  ZcashLightClientKitTests
+//
+
+import Combine
+import XCTest
+import GRPC
+import NIO
+import NIOTransportServices
+@testable import TestUtils
+@testable import ZcashLightClientKit
+
+final class BroadcasterTests: ZcashTestCase {
+    private var cancellables: [AnyCancellable] = []
+
+    override func setUp() async throws {
+        try await super.setUp()
+        cancellables = []
+    }
+
+    override func tearDown() async throws {
+        cancellables = []
+        try await super.tearDown()
+    }
+
+    // MARK: - createProposedTransactions
+
+    func testCreateProposedTransactionsReturnsRawBytesAndEmitsEvent() async throws {
+        let rawTransaction = Data([0x01, 0x02, 0x03, 0x04])
+        let createdTransactions = [makeTransaction(raw: rawTransaction, rawID: Data(repeating: 0xAB, count: 32))]
+        let transactionEncoder = StubTransactionEncoder(createdTransactions: createdTransactions)
+        let synchronizer = try makeSynchronizer(transactionEncoder: transactionEncoder)
+
+        let foundTransactionsExpectation = XCTestExpectation(description: "found transactions event")
+
+        synchronizer.eventStream
+            .sink { event in
+                guard case let .foundTransactions(transactions, range) = event else { return }
+                XCTAssertNil(range)
+                XCTAssertEqual(transactions.map(\.rawID), createdTransactions.map(\.rawID))
+                foundTransactionsExpectation.fulfill()
+            }
+            .store(in: &cancellables)
+
+        await synchronizer.updateStatus(.stopped)
+
+        let proposal = Proposal.testOnlyFakeProposal(totalFee: 10)
+        let spendingKey = TestsData(networkType: .testnet).spendingKey
+
+        let transactions = try await synchronizer.broadcaster.createProposedTransactions(
+            proposal: proposal,
+            spendingKey: spendingKey
+        )
+
+        XCTAssertEqual(transactionEncoder.receivedCreateArguments?.proposal, proposal)
+        XCTAssertEqual(transactionEncoder.receivedCreateArguments?.spendingKey, spendingKey)
+        XCTAssertEqual(transactions.map(\.rawID), createdTransactions.map(\.rawID))
+        XCTAssertEqual(try transactions.map { try XCTUnwrap($0.raw) }, [rawTransaction])
+
+        await fulfillment(of: [foundTransactionsExpectation], timeout: 1.0)
+    }
+
+    // MARK: - submit
+
+    func testSubmitSendsRawBytesToProvidedEndpoint() async throws {
+        let rawTransaction = Data([0x01, 0x02, 0x03, 0x04])
+        let createdTransactions = [makeTransaction(raw: rawTransaction, rawID: Data(repeating: 0xAB, count: 32))]
+        let transactionEncoder = StubTransactionEncoder(createdTransactions: createdTransactions)
+        let service = try RecordingCompactTxStreamerService(sendResponse: makeSendResponse(errorCode: 0, errorMessage: ""))
+        defer { try? service.stop() }
+        let synchronizer = try makeSynchronizer(transactionEncoder: transactionEncoder)
+
+        try await synchronizer.broadcaster.submit(rawTransaction, to: service.endpoint)
+
+        XCTAssertEqual(service.recordedTransactions(), [rawTransaction])
+    }
+
+    func testSubmitThrowsWhenEndpointRejectsTransaction() async throws {
+        try await assertSubmitThrows(errorCode: -25, errorMessage: "rejected")
+    }
+
+    // MARK: - Full round-trip: create then submit
+
+    func testCreateThenSubmitRoundTrip() async throws {
+        let rawTransaction = Data([0x01, 0x02, 0x03, 0x04])
+        let createdTransactions = [makeTransaction(raw: rawTransaction, rawID: Data(repeating: 0xAB, count: 32))]
+        let transactionEncoder = StubTransactionEncoder(createdTransactions: createdTransactions)
+        let service = try RecordingCompactTxStreamerService(sendResponse: makeSendResponse(errorCode: 0, errorMessage: ""))
+        defer { try? service.stop() }
+        let synchronizer = try makeSynchronizer(transactionEncoder: transactionEncoder)
+
+        await synchronizer.updateStatus(.stopped)
+
+        let proposal = Proposal.testOnlyFakeProposal(totalFee: 10)
+        let spendingKey = TestsData(networkType: .testnet).spendingKey
+
+        // Step 1: Create without submitting
+        let transactions = try await synchronizer.broadcaster.createProposedTransactions(
+            proposal: proposal,
+            spendingKey: spendingKey
+        )
+
+        XCTAssertEqual(service.recordedTransactions(), [], "No transactions should be submitted yet")
+
+        // Step 2: Submit to the endpoint
+        let raw = try XCTUnwrap(transactions.first?.raw)
+        try await synchronizer.broadcaster.submit(raw, to: service.endpoint)
+
+        XCTAssertEqual(service.recordedTransactions(), [rawTransaction])
+    }
+
+    func testBroadcasterThrowsWhenNotPrepared() async throws {
+        let transactionEncoder = StubTransactionEncoder(createdTransactions: [])
+        let synchronizer = try makeSynchronizer(transactionEncoder: transactionEncoder)
+
+        // Status is .unprepared by default — broadcaster should throw
+
+        let proposal = Proposal.testOnlyFakeProposal(totalFee: 10)
+        let spendingKey = TestsData(networkType: .testnet).spendingKey
+
+        do {
+            _ = try await synchronizer.broadcaster.createProposedTransactions(
+                proposal: proposal,
+                spendingKey: spendingKey
+            )
+            XCTFail("Should throw when synchronizer is not prepared")
+        } catch {
+            XCTAssertTrue(error is ZcashError, "Expected ZcashError but got \(error)")
+        }
+    }
+
+    func testBroadcasterThrowsWhenSynchronizerIsReleased() async throws {
+        let transactionEncoder = StubTransactionEncoder(createdTransactions: [])
+        var synchronizer: SDKSynchronizer? = try makeSynchronizer(transactionEncoder: transactionEncoder)
+        await synchronizer?.updateStatus(.stopped)
+
+        let broadcaster = try XCTUnwrap(synchronizer?.broadcaster)
+        synchronizer = nil
+        await Task.yield()
+
+        do {
+            _ = try await broadcaster.createProposedTransactions(
+                proposal: Proposal.testOnlyFakeProposal(totalFee: 10),
+                spendingKey: TestsData(networkType: .testnet).spendingKey
+            )
+            XCTFail("Should throw when the owning synchronizer has been released")
+        } catch ZcashError.synchronizerNotPrepared {
+            XCTAssertNil(transactionEncoder.receivedCreateArguments)
+        } catch {
+            XCTFail("Expected synchronizerNotPrepared but got \(error)")
+        }
+    }
+
+    // MARK: - Legacy Synchronizer APIs
+
+    func testLegacyCreateProposedTransactionsReusesBroadcasterCreationAndSubmitsOnce() async throws {
+        let rawID = Data(repeating: 0xAB, count: 32)
+        let rawTransaction = Data([0x01, 0x02, 0x03, 0x04])
+        let createdTransactions = [makeTransaction(raw: rawTransaction, rawID: rawID)]
+        let transactionEncoder = StubTransactionEncoder(createdTransactions: createdTransactions)
+        let synchronizer = try makeSynchronizer(transactionEncoder: transactionEncoder)
+        let foundTransactionsExpectation = XCTestExpectation(description: "found transactions event")
+        foundTransactionsExpectation.expectedFulfillmentCount = 1
+        foundTransactionsExpectation.assertForOverFulfill = true
+        var foundTransactionsEventCount = 0
+
+        synchronizer.eventStream
+            .sink { event in
+                guard case let .foundTransactions(transactions, range) = event else { return }
+                foundTransactionsEventCount += 1
+                XCTAssertNil(range)
+                XCTAssertEqual(transactions.map(\.rawID), [rawID])
+                foundTransactionsExpectation.fulfill()
+            }
+            .store(in: &cancellables)
+
+        await synchronizer.updateStatus(.stopped)
+
+        let proposal = Proposal.testOnlyFakeProposal(totalFee: 10)
+        let spendingKey = TestsData(networkType: .testnet).spendingKey
+        let stream = try await synchronizer.createProposedTransactions(
+            proposal: proposal,
+            spendingKey: spendingKey
+        )
+        var iterator = stream.makeAsyncIterator()
+
+        let maybeSubmitResult = try await iterator.next()
+        let submitResult = try XCTUnwrap(maybeSubmitResult)
+        XCTAssertEqual(submitResult, .success(txId: rawID))
+        let nextSubmitResult = try await iterator.next()
+        XCTAssertNil(nextSubmitResult)
+        XCTAssertEqual(transactionEncoder.receivedCreateArguments?.proposal, proposal)
+        XCTAssertEqual(transactionEncoder.receivedCreateArguments?.spendingKey, spendingKey)
+        XCTAssertEqual(
+            transactionEncoder.submittedTransactions,
+            [EncodedTransaction(transactionId: rawID, raw: rawTransaction)]
+        )
+
+        await fulfillment(of: [foundTransactionsExpectation], timeout: 1.0)
+        XCTAssertEqual(foundTransactionsEventCount, 1)
+    }
+
+    func testLegacyCreateTransactionFromPCZTReusesBroadcasterCreationAndSubmitsOnce() async throws {
+        let rawID = Data(repeating: 0xCD, count: 32)
+        let rawTransaction = Data([0x05, 0x06, 0x07, 0x08])
+        let pcztWithProofs = Pczt([0x10, 0x11])
+        let pcztWithSigs = Pczt([0x12, 0x13])
+        let createdTransactions = [makeTransaction(raw: rawTransaction, rawID: rawID)]
+        let transactionEncoder = StubTransactionEncoder(createdTransactions: createdTransactions)
+        let rustBackend = ZcashRustBackendWeldingMock()
+        rustBackend.extractAndStoreTxFromPCZTPcztWithProofsPcztWithSigsReturnValue = rawID
+        let synchronizer = try makeSynchronizer(
+            transactionEncoder: transactionEncoder,
+            rustBackend: rustBackend
+        )
+        let foundTransactionsExpectation = XCTestExpectation(description: "found transactions event")
+        foundTransactionsExpectation.expectedFulfillmentCount = 1
+        foundTransactionsExpectation.assertForOverFulfill = true
+        var foundTransactionsEventCount = 0
+
+        synchronizer.eventStream
+            .sink { event in
+                guard case let .foundTransactions(transactions, range) = event else { return }
+                foundTransactionsEventCount += 1
+                XCTAssertNil(range)
+                XCTAssertEqual(transactions.map(\.rawID), [rawID])
+                foundTransactionsExpectation.fulfill()
+            }
+            .store(in: &cancellables)
+
+        await synchronizer.updateStatus(.stopped)
+
+        let stream = try await synchronizer.createTransactionFromPCZT(
+            pcztWithProofs: pcztWithProofs,
+            pcztWithSigs: pcztWithSigs
+        )
+        var iterator = stream.makeAsyncIterator()
+
+        let maybeSubmitResult = try await iterator.next()
+        let submitResult = try XCTUnwrap(maybeSubmitResult)
+        XCTAssertEqual(submitResult, .success(txId: rawID))
+        let nextSubmitResult = try await iterator.next()
+        XCTAssertNil(nextSubmitResult)
+        XCTAssertEqual(
+            rustBackend.extractAndStoreTxFromPCZTPcztWithProofsPcztWithSigsReceivedArguments?.pcztWithProofs,
+            pcztWithProofs
+        )
+        XCTAssertEqual(
+            rustBackend.extractAndStoreTxFromPCZTPcztWithProofsPcztWithSigsReceivedArguments?.pcztWithSigs,
+            pcztWithSigs
+        )
+        XCTAssertEqual(transactionEncoder.receivedFetchTxIds, [rawID])
+        XCTAssertEqual(
+            transactionEncoder.submittedTransactions,
+            [EncodedTransaction(transactionId: rawID, raw: rawTransaction)]
+        )
+
+        await fulfillment(of: [foundTransactionsExpectation], timeout: 1.0)
+        XCTAssertEqual(foundTransactionsEventCount, 1)
+    }
+
+    // MARK: - Helpers
+
+    private func makeSynchronizer(
+        transactionEncoder: TransactionEncoder,
+        rustBackend: ZcashRustBackendWelding? = nil
+    ) throws -> SDKSynchronizer {
+        let serviceMock = LightWalletServiceMock()
+        let transactionRepository = TransactionRepositoryMock()
+
+        if let rustBackend {
+            mockContainer.mock(type: ZcashRustBackendWelding.self, isSingleton: true) { _ in rustBackend }
+        }
+        mockContainer.mock(type: LightWalletService.self, isSingleton: true) { _ in serviceMock }
+        mockContainer.mock(type: TransactionRepository.self, isSingleton: true) { _ in transactionRepository }
+
+        let initializer = Initializer(
+            container: mockContainer,
+            cacheDbURL: nil,
+            fsBlockDbRoot: testTempDirectory,
+            generalStorageURL: testGeneralStorageDirectory,
+            dataDbURL: try __dataDbURL(),
+            torDirURL: try __torDirURL(),
+            endpoint: LightWalletEndpointBuilder.default,
+            network: ZcashNetworkBuilder.network(for: .testnet),
+            spendParamsURL: try __spendParamsURL(),
+            outputParamsURL: try __outputParamsURL(),
+            saplingParamsSourceURL: SaplingParamsSourceURL.tests,
+            isTorEnabled: false,
+            isExchangeRateEnabled: false
+        )
+
+        let blockProcessor = CompactBlockProcessor(
+            initializer: initializer,
+            walletBirthdayProvider: { initializer.walletBirthday }
+        )
+
+        return SDKSynchronizer(
+            status: .unprepared,
+            initializer: initializer,
+            transactionEncoder: transactionEncoder,
+            transactionRepository: transactionRepository,
+            blockProcessor: blockProcessor,
+            syncSessionTicker: .live
+        )
+    }
+
+    private func makeTransaction(raw: Data, rawID: Data) -> ZcashTransaction.Overview {
+        ZcashTransaction.Overview(
+            accountUUID: TestsData.mockedAccountUUID,
+            blockTime: nil,
+            expiryHeight: 123_456,
+            fee: Zatoshi(10_000),
+            index: 0,
+            isShielding: false,
+            hasChange: false,
+            memoCount: 0,
+            minedHeight: nil,
+            raw: raw,
+            rawID: rawID,
+            receivedNoteCount: 0,
+            sentNoteCount: 1,
+            value: Zatoshi(-1_000),
+            isExpiredUmined: false,
+            totalSpent: nil,
+            totalReceived: nil
+        )
+    }
+
+    private func makeSendResponse(errorCode: Int32, errorMessage: String) -> SendResponse {
+        var response = SendResponse()
+        response.errorCode = errorCode
+        response.errorMessage = errorMessage
+        return response
+    }
+
+    private func assertSubmitThrows(errorCode: Int32, errorMessage: String) async throws {
+        let rawTransaction = Data([0x0A, 0x0B, 0x0C])
+        let transactionEncoder = StubTransactionEncoder(createdTransactions: [])
+        let service = try RecordingCompactTxStreamerService(
+            sendResponse: makeSendResponse(errorCode: errorCode, errorMessage: errorMessage)
+        )
+        defer { try? service.stop() }
+
+        let synchronizer = try makeSynchronizer(transactionEncoder: transactionEncoder)
+
+        do {
+            try await synchronizer.broadcaster.submit(rawTransaction, to: service.endpoint)
+            XCTFail("submit should throw when the server rejects the transaction.")
+        } catch let error as TransactionEncoderError {
+            guard case let .submitError(code, message) = error else {
+                XCTFail("Expected submitError but got \(error)")
+                return
+            }
+            XCTAssertEqual(code, Int(errorCode))
+            XCTAssertEqual(message, errorMessage)
+        } catch {
+            XCTFail("Expected TransactionEncoderError.submitError but got \(error)")
+        }
+
+        XCTAssertEqual(service.recordedTransactions(), [rawTransaction])
+    }
+}
+
+// MARK: - Test Doubles
+
+private final class StubTransactionEncoder: TransactionEncoder {
+    private let createdTransactions: [ZcashTransaction.Overview]
+    private(set) var receivedCreateArguments: (proposal: Proposal, spendingKey: UnifiedSpendingKey)?
+    private(set) var receivedFetchTxIds: [Data]?
+    private(set) var submittedTransactions: [EncodedTransaction] = []
+
+    init(createdTransactions: [ZcashTransaction.Overview]) {
+        self.createdTransactions = createdTransactions
+    }
+
+    func proposeTransfer(
+        accountUUID: AccountUUID,
+        recipient: String,
+        amount: Zatoshi,
+        memoBytes: MemoBytes?
+    ) async throws -> Proposal {
+        fatalError("Unused in test")
+    }
+
+    func proposeShielding(
+        accountUUID: AccountUUID,
+        shieldingThreshold: Zatoshi,
+        memoBytes: MemoBytes?,
+        transparentReceiver: String?
+    ) async throws -> Proposal? {
+        fatalError("Unused in test")
+    }
+
+    func createProposedTransactions(
+        proposal: Proposal,
+        spendingKey: UnifiedSpendingKey
+    ) async throws -> [ZcashTransaction.Overview] {
+        receivedCreateArguments = (proposal, spendingKey)
+        return createdTransactions
+    }
+
+    func proposeFulfillingPaymentFromURI(
+        _ uri: String,
+        accountUUID: AccountUUID
+    ) async throws -> Proposal {
+        fatalError("Unused in test")
+    }
+
+    func submit(transaction: EncodedTransaction) async throws {
+        submittedTransactions.append(transaction)
+    }
+
+    func fetchTransactionsForTxIds(_ txIds: [Data]) async throws -> [ZcashTransaction.Overview] {
+        receivedFetchTxIds = txIds
+        return txIds.compactMap { txId in
+            createdTransactions.first { $0.rawID == txId }
+        }
+    }
+
+    func closeDBConnection() { }
+}
+
+private final class RecordingCompactTxStreamerService: CompactTxStreamerProvider {
+    var interceptors: CompactTxStreamerServerInterceptorFactoryProtocol? { nil }
+
+    private(set) var endpoint: LightWalletEndpoint!
+
+    private let sendResponse: SendResponse
+    private let eventLoopGroup = NIOTSEventLoopGroup(loopCount: 1, defaultQoS: .default)
+    private let queue = DispatchQueue(label: "RecordingCompactTxStreamerService.queue")
+    private var submittedTransactions: [Data] = []
+    private var server: Server?
+
+    init(sendResponse: SendResponse) throws {
+        self.sendResponse = sendResponse
+        self.endpoint = LightWalletEndpoint(address: "127.0.0.1", port: 0, secure: false)
+
+        let server = try Server.insecure(group: eventLoopGroup)
+            .withServiceProviders([self])
+            .bind(host: "127.0.0.1", port: 0)
+            .wait()
+
+        self.server = server
+        self.endpoint = LightWalletEndpoint(
+            address: "127.0.0.1",
+            port: server.channel.localAddress?.port ?? 0,
+            secure: false,
+            singleCallTimeoutInMillis: 5_000,
+            streamingCallTimeoutInMillis: 5_000
+        )
+    }
+
+    func stop() throws {
+        try server?.close().wait()
+        try eventLoopGroup.syncShutdownGracefully()
+    }
+
+    func recordedTransactions() -> [Data] {
+        queue.sync { submittedTransactions }
+    }
+
+    func getLatestBlock(request: ChainSpec, context: StatusOnlyCallContext) -> EventLoopFuture<BlockID> {
+        unimplementedUnary(on: context.eventLoop)
+    }
+
+    func getBlock(request: BlockID, context: StatusOnlyCallContext) -> EventLoopFuture<CompactBlock> {
+        unimplementedUnary(on: context.eventLoop)
+    }
+
+    func getBlockNullifiers(request: BlockID, context: StatusOnlyCallContext) -> EventLoopFuture<CompactBlock> {
+        unimplementedUnary(on: context.eventLoop)
+    }
+
+    func getBlockRange(request: BlockRange, context: StreamingResponseCallContext<CompactBlock>) -> EventLoopFuture<GRPCStatus> {
+        unimplementedStreaming(on: context.eventLoop)
+    }
+
+    func getBlockRangeNullifiers(request: BlockRange, context: StreamingResponseCallContext<CompactBlock>) -> EventLoopFuture<GRPCStatus> {
+        unimplementedStreaming(on: context.eventLoop)
+    }
+
+    func getTransaction(request: TxFilter, context: StatusOnlyCallContext) -> EventLoopFuture<RawTransaction> {
+        unimplementedUnary(on: context.eventLoop)
+    }
+
+    func sendTransaction(request: RawTransaction, context: StatusOnlyCallContext) -> EventLoopFuture<SendResponse> {
+        queue.sync {
+            submittedTransactions.append(request.data)
+        }
+        return context.eventLoop.makeSucceededFuture(sendResponse)
+    }
+
+    func getTaddressTxids(request: TransparentAddressBlockFilter, context: StreamingResponseCallContext<RawTransaction>) -> EventLoopFuture<GRPCStatus> {
+        unimplementedStreaming(on: context.eventLoop)
+    }
+
+    func getTaddressBalance(request: AddressList, context: StatusOnlyCallContext) -> EventLoopFuture<Balance> {
+        unimplementedUnary(on: context.eventLoop)
+    }
+
+    func getTaddressBalanceStream(context: UnaryResponseCallContext<Balance>) -> EventLoopFuture<(StreamEvent<Address>) -> Void> {
+        unimplementedUnary(on: context.eventLoop)
+    }
+
+    func getMempoolTx(request: Exclude, context: StreamingResponseCallContext<CompactTx>) -> EventLoopFuture<GRPCStatus> {
+        unimplementedStreaming(on: context.eventLoop)
+    }
+
+    func getMempoolStream(request: ZcashLightClientKit.Empty, context: StreamingResponseCallContext<RawTransaction>) -> EventLoopFuture<GRPCStatus> {
+        unimplementedStreaming(on: context.eventLoop)
+    }
+
+    func getTreeState(request: BlockID, context: StatusOnlyCallContext) -> EventLoopFuture<TreeState> {
+        unimplementedUnary(on: context.eventLoop)
+    }
+
+    func getLatestTreeState(request: ZcashLightClientKit.Empty, context: StatusOnlyCallContext) -> EventLoopFuture<TreeState> {
+        unimplementedUnary(on: context.eventLoop)
+    }
+
+    func getSubtreeRoots(request: GetSubtreeRootsArg, context: StreamingResponseCallContext<SubtreeRoot>) -> EventLoopFuture<GRPCStatus> {
+        unimplementedStreaming(on: context.eventLoop)
+    }
+
+    func getAddressUtxos(request: GetAddressUtxosArg, context: StatusOnlyCallContext) -> EventLoopFuture<GetAddressUtxosReplyList> {
+        unimplementedUnary(on: context.eventLoop)
+    }
+
+    func getAddressUtxosStream(request: GetAddressUtxosArg, context: StreamingResponseCallContext<GetAddressUtxosReply>) -> EventLoopFuture<GRPCStatus> {
+        unimplementedStreaming(on: context.eventLoop)
+    }
+
+    func getLightdInfo(request: ZcashLightClientKit.Empty, context: StatusOnlyCallContext) -> EventLoopFuture<LightdInfo> {
+        unimplementedUnary(on: context.eventLoop)
+    }
+
+    func ping(request: ZcashLightClientKit.Duration, context: StatusOnlyCallContext) -> EventLoopFuture<PingResponse> {
+        unimplementedUnary(on: context.eventLoop)
+    }
+
+    private func unimplementedUnary<T>(on eventLoop: EventLoop) -> EventLoopFuture<T> {
+        eventLoop.makeFailedFuture(GRPCStatus(code: .unimplemented, message: "Unused in test"))
+    }
+
+    private func unimplementedStreaming(on eventLoop: EventLoop) -> EventLoopFuture<GRPCStatus> {
+        eventLoop.makeSucceededFuture(GRPCStatus(code: .unimplemented, message: "Unused in test"))
+    }
+}

--- a/Tests/TestUtils/Sourcery/AutoMockable.swift
+++ b/Tests/TestUtils/Sourcery/AutoMockable.swift
@@ -23,6 +23,7 @@ extension LightWalletdInfo { }
 extension LightWalletService { }
 extension Logger { }
 extension SaplingParametersHandler { }
+extension Broadcaster { }
 extension Synchronizer { }
 extension TransactionRepository { }
 extension UTXOFetcher { }

--- a/Tests/TestUtils/Sourcery/GeneratedMocks/AutoMockable.generated.swift
+++ b/Tests/TestUtils/Sourcery/GeneratedMocks/AutoMockable.generated.swift
@@ -1439,6 +1439,75 @@ class SaplingParametersHandlerMock: SaplingParametersHandler {
     }
 
 }
+class BroadcasterMock: Broadcaster {
+
+
+    init(
+    ) {
+    }
+
+    // MARK: - createProposedTransactions
+
+    var createProposedTransactionsProposalSpendingKeyThrowableError: Error?
+    var createProposedTransactionsProposalSpendingKeyCallsCount = 0
+    var createProposedTransactionsProposalSpendingKeyCalled: Bool {
+        return createProposedTransactionsProposalSpendingKeyCallsCount > 0
+    }
+    var createProposedTransactionsProposalSpendingKeyReturnValue: [ZcashTransaction.Overview]!
+    var createProposedTransactionsProposalSpendingKeyClosure: ((Proposal, UnifiedSpendingKey) async throws -> [ZcashTransaction.Overview])?
+
+    func createProposedTransactions(proposal: Proposal, spendingKey: UnifiedSpendingKey) async throws -> [ZcashTransaction.Overview] {
+        if let error = createProposedTransactionsProposalSpendingKeyThrowableError {
+            throw error
+        }
+        createProposedTransactionsProposalSpendingKeyCallsCount += 1
+        if let closure = createProposedTransactionsProposalSpendingKeyClosure {
+            return try await closure(proposal, spendingKey)
+        } else {
+            return createProposedTransactionsProposalSpendingKeyReturnValue
+        }
+    }
+
+    // MARK: - createTransactionFromPCZT
+
+    var createTransactionFromPCZTPcztWithProofsPcztWithSigsThrowableError: Error?
+    var createTransactionFromPCZTPcztWithProofsPcztWithSigsCallsCount = 0
+    var createTransactionFromPCZTPcztWithProofsPcztWithSigsCalled: Bool {
+        return createTransactionFromPCZTPcztWithProofsPcztWithSigsCallsCount > 0
+    }
+    var createTransactionFromPCZTPcztWithProofsPcztWithSigsReturnValue: [ZcashTransaction.Overview]!
+    var createTransactionFromPCZTPcztWithProofsPcztWithSigsClosure: ((Pczt, Pczt) async throws -> [ZcashTransaction.Overview])?
+
+    func createTransactionFromPCZT(pcztWithProofs: Pczt, pcztWithSigs: Pczt) async throws -> [ZcashTransaction.Overview] {
+        if let error = createTransactionFromPCZTPcztWithProofsPcztWithSigsThrowableError {
+            throw error
+        }
+        createTransactionFromPCZTPcztWithProofsPcztWithSigsCallsCount += 1
+        if let closure = createTransactionFromPCZTPcztWithProofsPcztWithSigsClosure {
+            return try await closure(pcztWithProofs, pcztWithSigs)
+        } else {
+            return createTransactionFromPCZTPcztWithProofsPcztWithSigsReturnValue
+        }
+    }
+
+    // MARK: - submit
+
+    var submitToThrowableError: Error?
+    var submitToCallsCount = 0
+    var submitToCalled: Bool {
+        return submitToCallsCount > 0
+    }
+    var submitToClosure: ((Data, LightWalletEndpoint) async throws -> Void)?
+
+    func submit(_ rawTransaction: Data, to endpoint: LightWalletEndpoint) async throws {
+        if let error = submitToThrowableError {
+            throw error
+        }
+        submitToCallsCount += 1
+        try await submitToClosure?(rawTransaction, endpoint)
+    }
+
+}
 class SynchronizerMock: Synchronizer {
 
 
@@ -1481,6 +1550,10 @@ class SynchronizerMock: Synchronizer {
         get async { return underlyingReceivedTransactions }
     }
     var underlyingReceivedTransactions: [ZcashTransaction.Overview] = []
+    var broadcaster: Broadcaster {
+        get { return underlyingBroadcaster }
+    }
+    var underlyingBroadcaster: Broadcaster!
 
     // MARK: - prepare
 


### PR DESCRIPTION
Closes: https://github.com/zcash/zcash-swift-wallet-sdk/issues/1677 
Resolves MOB-1038

## Summary

Introduces a standalone `Broadcaster` protocol that separates transaction creation from submission, enabling custom broadcast strategies such as submitting to multiple lightwalletd servers in parallel.

New public API:
- `Broadcaster.createProposedTransactions(proposal:spendingKey:)` — creates transactions locally without broadcasting, returning `[ZcashTransaction.Overview]` with raw bytes.
- `Broadcaster.createTransactionFromPCZT(pcztWithProofs:pcztWithSigs:)` — extracts and stores a transaction from PCZT data without submitting, for use with multi-server broadcast of Keystone/PCZT transactions.
- `Broadcaster.submit(_:to:)` — submits raw transaction bytes to a specific `LightWalletEndpoint`. Respects Tor configuration.
- `Synchronizer.broadcaster` property, also exposed through the closure and Combine synchronizer facades, to access the `Broadcaster` from SDK synchronizer instances.

## Motivation

The existing `createProposedTransactions` and `createTransactionFromPCZT` APIs couple transaction creation with submission to the SDK's configured endpoint. For multi-server broadcast strategies (e.g. submitting to several lightwalletd instances in parallel for reliability), callers need the ability to separate these concerns.

Rather than adding more methods to the already large `Synchronizer` protocol (~45 methods), this extracts the decoupled create/submit concern into a focused `Broadcaster` interface.

## Testing

- Wired the new APIs into zodl.
- Tested both regular and Keystone send paths with multi-server broadcast.
- Verified automatic mode (9 servers) and manual mode (1 server) on physical device.
- Integration tests with a local gRPC server verify bytes are delivered to the target endpoint.

Video from testing:

https://screen.studio/share/1mgC0NYH

If you check the logs in the video, we can see a perfect example of why this feature is good, as one of the endpoints was faulty with an Orchard anchor error, but the other endpoints successfully submitted it.

---

# Author
- [x] Self-review: Did you review your own code in GitHub's web interface?
- [x] Automated tests: Did you add appropriate automated tests for any code changes?
- [ ] Code coverage: Did you check the code coverage report for the automated tests?
- [x] Documentation: Did you update Docs as appropriate?
- [x] Run the app: Did you run the app and try the changes?
- [x] Did you provide Screenshots of what the App looks like before and after your changes as part of the description of this PR?
- [x] Rebase and squash: Did you pull in the latest changes from the main branch and squash your commits before assigning a reviewer?

# Reviewer
- [ ] Checklist review: Did you go through the code with the [Code Review Guidelines](../blob/main/CODE_REVIEW_GUIDELINES.md) checklist?
- [ ] Ad hoc review: Did you perform an ad hoc review?
- [ ] Automated tests: Did you review the automated tests?
- [ ] Manual tests: Did you review the manual tests?
- [ ] How is Code Coverage affected by this PR?
- [ ] Documentation: Did you review Docs, [README.md](../blob/master/README.md), [LICENSE.md](../blob/master/LICENSE.md), and [Architecture.md](../blob/master/docs/Architecture.md) as appropriate?
- [ ] Run the app: Did you run the app and try the changes?
