### PR TITLE
ci: Replace CodeQL default setup with advanced setup for Swift FFI builds

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -134,9 +134,13 @@ jobs:
         cp -R BuildSupport/products/libzcashlc.xcframework LocalPackages/
         cp BuildSupport/LocalPackages-Package.swift LocalPackages/Package.swift
 
+    - name: Resolve Swift dependencies
+      if: matrix.language == 'swift'
+      run: swift package resolve
+
     - name: Build Swift package
       if: matrix.language == 'swift'
-      timeout-minutes: 15
+      timeout-minutes: 30
       run: swift build
 
     # --- End Swift manual build steps ---

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -16,18 +16,14 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
-  schedule:
-    - cron: '44 7 * * 1'
+
+permissions:
+  contents: read
 
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})
-    # Runner size impacts CodeQL analysis time. To learn more, please see:
-    #   - https://gh.io/recommended-hardware-resources-for-running-codeql
-    #   - https://gh.io/supported-runners-and-hardware-resources
-    #   - https://gh.io/using-larger-runners (GitHub.com only)
-    # Consider using larger runners or machines with greater resources for possible analysis time improvements.
-    runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
+    runs-on: ${{ matrix.runner }}
     permissions:
       # required for all workflows
       security-events: write
@@ -45,12 +41,16 @@ jobs:
         include:
         - language: actions
           build-mode: none
+          runner: ubuntu-latest
         - language: c-cpp
-          build-mode: autobuild
+          build-mode: none
+          runner: ubuntu-latest
         - language: rust
           build-mode: none
+          runner: ubuntu-latest
         - language: swift
-          build-mode: autobuild
+          build-mode: manual
+          runner: macos-15
         # CodeQL supports the following values keywords for 'language': 'actions', 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'rust', 'swift'
         # Use `c-cpp` to analyze code written in C, C++ or both
         # Use 'java-kotlin' to analyze code written in Java, Kotlin or both
@@ -61,17 +61,13 @@ jobs:
         # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
-
-    # Add any setup steps before running the `github/codeql-action/init` action.
-    # This includes steps like installing compilers or runtimes (`actions/setup-node`
-    # or others). This is typically only required for manual builds.
-    # - name: Setup runtime (example)
-    #   uses: actions/setup-example@v1
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4
+      uses: github/codeql-action/init@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
@@ -82,24 +78,70 @@ jobs:
         # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
         # queries: security-extended,security-and-quality
 
-    # If the analyze step fails for one of the languages you are analyzing with
-    # "We were unable to automatically build your code", modify the matrix above
-    # to set the build mode to "manual" for that language. Then modify this step
-    # to build your code.
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
-    - name: Run manual build steps
-      if: matrix.build-mode == 'manual'
-      shell: bash
+    # --- Swift manual build steps (mirrors swift.yml) ---
+    #
+    # Swift does not support build-mode: none, and autobuild fails because
+    # Package.swift falls back to a pre-built xcframework that may lack new
+    # FFI symbols. We build the Rust FFI from source and configure LocalPackages
+    # so swift build resolves against the freshly-built xcframework.
+
+    - name: Select Xcode version
+      if: matrix.language == 'swift'
+      run: sudo xcode-select -s '/Applications/Xcode_16.0.app/Contents/Developer'
+
+    - name: Generate FFI source hash
+      if: matrix.language == 'swift'
+      id: ffi-hash
       run: |
-        echo 'If you are using a "manual" build mode for one or more of the' \
-          'languages you are analyzing, replace this with the commands to build' \
-          'your code, for example:'
-        echo '  make bootstrap'
-        echo '  make release'
-        exit 1
+        FFI_HASH=$(find rust Cargo.toml Cargo.lock BuildSupport -type f \( -name "*.rs" -o -name "*.toml" -o -name "*.lock" -o -name "Makefile" -o -name "*.h" -o -name "*.c" -o -name "*.plist" -o -name "*.modulemap" \) -exec shasum {} \; | sort | shasum | cut -d' ' -f1)
+        echo "hash=$FFI_HASH" >> $GITHUB_OUTPUT
+        echo "FFI source hash: $FFI_HASH"
+
+    - name: Cache FFI XCFramework
+      if: matrix.language == 'swift'
+      id: cache-ffi
+      uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+      with:
+        path: BuildSupport/products/libzcashlc.xcframework
+        key: ffi-xcframework-macos-only-${{ runner.os }}-${{ steps.ffi-hash.outputs.hash }}
+
+    - name: Setup Rust
+      if: matrix.language == 'swift' && steps.cache-ffi.outputs.cache-hit != 'true'
+      uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+      with:
+        toolchain: stable
+        targets: aarch64-apple-darwin, x86_64-apple-darwin
+
+    - name: Cache Cargo
+      if: matrix.language == 'swift' && steps.cache-ffi.outputs.cache-hit != 'true'
+      uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
+
+    - name: Build FFI for macOS
+      if: matrix.language == 'swift' && steps.cache-ffi.outputs.cache-hit != 'true'
+      timeout-minutes: 30
+      working-directory: ./BuildSupport
+      run: |
+        echo "Building FFI for macOS..."
+        make macos
+        mkdir -p products/libzcashlc.xcframework
+        cp -R products/macos/frameworks products/libzcashlc.xcframework/macos-arm64_x86_64
+        cp Info.plist products/libzcashlc.xcframework
+
+    - name: Configure local FFI
+      if: matrix.language == 'swift'
+      run: |
+        mkdir -p LocalPackages
+        cp -R BuildSupport/products/libzcashlc.xcframework LocalPackages/
+        cp BuildSupport/LocalPackages-Package.swift LocalPackages/Package.swift
+
+    - name: Build Swift package
+      if: matrix.language == 'swift'
+      timeout-minutes: 15
+      run: swift build
+
+    # --- End Swift manual build steps ---
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4
+      uses: github/codeql-action/analyze@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1
       with:
         category: "/language:${{matrix.language}}"


### PR DESCRIPTION
## Summary

- Replace CodeQL default setup with a custom advanced setup workflow that builds the Rust FFI before Swift analysis
- Uses `build-mode: manual` for Swift, replicating the Rust FFI build and `LocalPackages` setup from `swift.yml`
- Uses `build-mode: none` for `actions`, `c-cpp`, and `rust` (matching current default setup behavior)

## Motivation

CodeQL's default setup uses `autobuild` for Swift, which runs `swift build` without first compiling the Rust FFI layer. When `swift build` runs, `Package.swift` detects no `LocalPackages/` directory and falls back to the remote binary target — a pre-built xcframework from the latest GitHub Release. If any new `#[no_mangle] extern "C"` functions have been added to the Rust code since that release, the downloaded xcframework's header won't declare them, and `swift build` fails with "cannot find in scope" errors.

This is currently blocking Swift CodeQL analysis on [#1639](https://github.com/zcash/zcash-swift-wallet-sdk/pull/1639) (EIP-681 support), which adds new FFI functions that don't exist in the 2.4.6 release binary. The regular build check (`swift.yml`) passes because it builds the Rust FFI from source.

Swift does not support `build-mode: none` — only `autobuild` or `manual` — so the only way to inject the Rust build step is via a custom workflow with `build-mode: manual`.

## Admin action required after merge

After this PR lands on `main`, a repository admin needs to **disable CodeQL default setup** in:

> Settings > Code Security > Code scanning

Otherwise both the default setup and this custom workflow will run simultaneously, producing duplicate results. The custom workflow will handle all the same languages (`actions`, `c-cpp`, `rust`, `swift`).

## After disabling default setup

Once default setup is disabled and this workflow is active, [#1639](https://github.com/zcash/zcash-swift-wallet-sdk/pull/1639) should be rebased onto `main` so the new CodeQL workflow runs for it. The Swift analysis will then succeed because the workflow builds the FFI from source before running `swift build`.