### PR TITLE
Expose fullyScannedHeight on SynchronizerState

### DIFF
--- a/Sources/ZcashLightClientKit/Synchronizer.swift
+++ b/Sources/ZcashLightClientKit/Synchronizer.swift
@@ -42,6 +42,13 @@ public struct SynchronizerState: Equatable {
     public var syncStatus: SyncStatus
     /// height of the latest block on the blockchain known to this synchronizer.
     public var latestBlockHeight: BlockHeight
+    /// Height below which every block has been scanned contiguously from the wallet
+    /// birthday. Unlike `latestBlockHeight` (chain tip) or `maxScannedHeight` (head-first
+    /// scan progress), this is the only value that tells a caller "the wallet has
+    /// authoritative note and nullifier state for this height." Callers that need a
+    /// stable snapshot of balance at a specific height — e.g. voting power at a poll
+    /// snapshot — must gate on this, not on `latestBlockHeight`.
+    public var fullyScannedHeight: BlockHeight
 
     /// Represents a synchronizer that has made zero progress hasn't done a sync attempt
     public static var zero: SynchronizerState {
@@ -49,20 +56,23 @@ public struct SynchronizerState: Equatable {
             syncSessionID: .nullID,
             accountsBalances: [:],
             internalSyncStatus: .unprepared,
-            latestBlockHeight: .zero
+            latestBlockHeight: .zero,
+            fullyScannedHeight: .zero
         )
     }
-    
+
     init(
         syncSessionID: UUID,
         accountsBalances: [AccountUUID: AccountBalance],
         internalSyncStatus: InternalSyncStatus,
-        latestBlockHeight: BlockHeight
+        latestBlockHeight: BlockHeight,
+        fullyScannedHeight: BlockHeight = .zero
     ) {
         self.syncSessionID = syncSessionID
         self.accountsBalances = accountsBalances
         self.internalSyncStatus = internalSyncStatus
         self.latestBlockHeight = latestBlockHeight
+        self.fullyScannedHeight = fullyScannedHeight
         self.syncStatus = internalSyncStatus.mapToSyncStatus()
     }
 }

--- a/Sources/ZcashLightClientKit/Synchronizer/SDKSynchronizer.swift
+++ b/Sources/ZcashLightClientKit/Synchronizer/SDKSynchronizer.swift
@@ -1228,7 +1228,8 @@ public class SDKSynchronizer: Synchronizer {
             syncSessionID: syncSession.value,
             accountsBalances: (try? await getAccountsBalances()) ?? [:],
             internalSyncStatus: status,
-            latestBlockHeight: latestBlocksDataProvider.latestBlockHeight
+            latestBlockHeight: latestBlocksDataProvider.latestBlockHeight,
+            fullyScannedHeight: latestBlocksDataProvider.fullyScannedHeight
         )
     }
 

--- a/Tests/OfflineTests/SynchronizerOfflineTests.swift
+++ b/Tests/OfflineTests/SynchronizerOfflineTests.swift
@@ -439,7 +439,8 @@ class SynchronizerOfflineTests: ZcashTestCase {
             syncSessionID: .nullID,
             accountsBalances: [:],
             internalSyncStatus: internalSyncStatus,
-            latestBlockHeight: .zero
+            latestBlockHeight: .zero,
+            fullyScannedHeight: .zero
         )
     }
 }

--- a/Tests/TestUtils/Stubs.swift
+++ b/Tests/TestUtils/Stubs.swift
@@ -152,7 +152,8 @@ extension SynchronizerState {
             syncSessionID: .nullID,
             accountsBalances: [:],
             internalSyncStatus: .syncing(0, false),
-            latestBlockHeight: 222222
+            latestBlockHeight: 222222,
+            fullyScannedHeight: 0
         )
     }
 }


### PR DESCRIPTION
## Summary

Adds `fullyScannedHeight` to `SynchronizerState` so callers can gate on contiguous-from-birthday scan progress, not chain tip or head-first scan progress.

## Why

Callers that need to read authoritative wallet state at a specific height — for example, a snapshot height for voting power lookup, or any anchor-height balance read — currently have no good signal:

- `latestBlockHeight` comes from lightwalletd and reflects the chain tip, not local state.
- `maxScannedHeight` reflects head-first scan progress, which can skip ahead of birthday-first scanning under Spend-before-Sync.

Only `fullyScannedHeight` — already tracked in `LatestBlocksDataProvider` — is safe to compare against a fixed target height. This PR just surfaces it on `SynchronizerState` so downstream consumers get it through the existing `stateStream`/`latestState` plumbing without any new API surface.

## Source compatibility

The new initializer parameter has a default of `.zero`, so existing construction call sites (darkside tests etc.) keep compiling.

## Test plan

- [ ] CI green
- [ ] Existing offline/darkside tests pass (no behavior change for callers that don't read the new field)