### PR TITLE
[#1691] Expose static bundled checkpoint birthday estimation

### DIFF
--- a/Sources/ZcashLightClientKit/Synchronizer/SDKSynchronizer.swift
+++ b/Sources/ZcashLightClientKit/Synchronizer/SDKSynchronizer.swift
@@ -1274,6 +1274,22 @@ public class SDKSynchronizer: Synchronizer {
     }
 }
 
+public extension SDKSynchronizer {
+    static func estimateBirthdayHeight(
+        for date: Date,
+        network: NetworkType = .mainnet
+    ) -> BlockHeight {
+        CheckpointSourceFactory.fromBundle(for: network).estimateBirthdayHeight(for: date)
+    }
+
+    static func estimateTimestamp(
+        for height: BlockHeight,
+        network: NetworkType = .mainnet
+    ) -> TimeInterval? {
+        CheckpointSourceFactory.fromBundle(for: network).estimateTimestamp(for: height)
+    }
+}
+
 extension SDKSynchronizer {
     public var transactions: [ZcashTransaction.Overview] {
         get async {


### PR DESCRIPTION
## Summary
- Adds static SDKSynchronizer helpers for estimating wallet birthday height and checkpoint timestamp from bundled checkpoints.
- Mirrors the existing instance API while allowing callers to use the helpers before constructing an Initializer or prepared synchronizer.
- Supports mainnet and testnet through NetworkType.

Closes #1691

## Testing
- Not run; change is a thin delegation to the existing bundled CheckpointSource implementation.