### PR TITLE
[#1694] Add Synchronizer.getTreeState(height:) for app-layer consumers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Added
 - `SDKSynchronizer.rescanFrom(height:)`: Rescans the chain from the given BlockHeight.
 - `SynchronizerState.fullyScannedHeight`: Contiguous-from-birthday scan high-water mark published on `stateStream`/`latestState`. Callers that need an authoritative view of the wallet's note and nullifier state at a specific height (for example, balance anchored at a poll snapshot) should gate on this rather than `latestBlockHeight` (chain tip) or `maxScannedHeight` (head-first scan progress, which can race ahead under Spend-before-Sync).
+- `Synchronizer.getTreeState(height:)`: Fetches the commitment tree state at the given block height from lightwalletd and returns the protobuf-serialized `TreeState` bytes, for app-layer consumers that need to hand tree state to an external component (for example, witness generation via FFI). A throwing default implementation keeps the addition source-compatible for downstream `Synchronizer` conformers.
 
 ## Changed
 - Bumped Rust dependencies to current crates.io releases (`zcash_address` 0.10→0.11, `zcash_client_backend` 0.21→0.22, `zcash_client_sqlite` 0.19→0.20, `zcash_primitives`/`zcash_proofs` 0.26→0.27, `zcash_protocol` 0.7→0.8, `zcash_transparent` 0.6→0.7, `sapling-crypto` 0.6→0.7, `orchard` 0.12→0.13, `pczt` 0.5→0.6) and removed the `[patch.crates-io]` git-rev overrides. No public Swift API changes.

--- a/Sources/ZcashLightClientKit/Synchronizer.swift
+++ b/Sources/ZcashLightClientKit/Synchronizer.swift
@@ -494,6 +494,19 @@ public protocol Synchronizer: AnyObject {
     ///   hex-encoded bytes otherwise.
     func debugDatabase(sql: String) -> String
 
+    /// Fetch the commitment tree state at the given block height from lightwalletd,
+    /// returned as protobuf-serialized bytes suitable for witness generation.
+    ///
+    /// Tor posture: when Tor is enabled on the Synchronizer, this uses a unique,
+    /// one-shot Tor circuit per call (`.uniqueTor`), matching the policy of
+    /// other public transport calls on this protocol (`fetchUTXOsBy`,
+    /// `checkSingleUseTransparentAddresses`, `updateTransparentAddressTransactions`).
+    /// A fresh circuit keeps each fetch unlinkable from other SDK traffic — in
+    /// particular from later `.txIdGroup`-scoped submission of a transaction
+    /// anchored at the same height. When Tor is disabled, this uses a direct
+    /// gRPC connection.
+    func getTreeState(height: UInt64) async throws -> Data
+
     /// Get an ephemeral single use transparent address
     /// - Parameter accountUUID: The account for which the single use transparent address is going to be created.
     /// - Returns The struct with an ephemeral transparent address and gap limit info
@@ -541,6 +554,31 @@ public protocol Synchronizer: AnyObject {
     ///
     /// - Throws rustDeleteAccount as a common indicator of the operation failure
     func deleteAccount(_ accountUUID: AccountUUID) async throws -> Void
+}
+
+/// Error thrown by the default `Synchronizer.getTreeState(height:)` implementation
+/// when a conformer without a lightwalletd source doesn't override it. Hoisted to
+/// file scope because Swift forbids nesting concrete types with synthesized members
+/// inside a generic function — protocol-extension methods carry an implicit `Self`
+/// and so count as generic.
+private struct GetTreeStateUnimplemented: LocalizedError {
+    var errorDescription: String? {
+        """
+        Synchronizer.getTreeState(height:) has no default implementation. \
+        Override this method in your Synchronizer conformer to provide a tree-state source.
+        """
+    }
+}
+
+public extension Synchronizer {
+    /// Default implementation so adding `getTreeState(height:)` to the protocol is
+    /// not a source-breaking change for downstream conformers. Conformers that have
+    /// a lightwalletd connection (such as `SDKSynchronizer`) override this;
+    /// conformers that don't — mocks, stubs, alternate transports — fall through to
+    /// this default and report the feature as unavailable.
+    func getTreeState(height: UInt64) async throws -> Data {
+        throw GetTreeStateUnimplemented()
+    }
 }
 
 public enum SyncStatus: Equatable {

--- a/Sources/ZcashLightClientKit/Synchronizer/SDKSynchronizer.swift
+++ b/Sources/ZcashLightClientKit/Synchronizer/SDKSynchronizer.swift
@@ -1052,7 +1052,15 @@ public class SDKSynchronizer: Synchronizer {
     public func debugDatabase(sql: String) -> String {
         transactionRepository.debugDatabase(sql: sql)
     }
-    
+
+    public func getTreeState(height: UInt64) async throws -> Data {
+        let treeState = try await initializer.lightWalletService.getTreeState(
+            BlockID(height: height),
+            mode: await sdkFlags.ifTor(.uniqueTor)
+        )
+        return try treeState.serializedData()
+    }
+
     public func getSingleUseTransparentAddress(accountUUID: AccountUUID) async throws -> SingleUseTransparentAddress {
         try await initializer.rustBackend.getSingleUseTransparentAddress(accountUUID: accountUUID)
     }

--- a/Tests/OfflineTests/SynchronizerOfflineTests.swift
+++ b/Tests/OfflineTests/SynchronizerOfflineTests.swift
@@ -476,6 +476,39 @@ class SynchronizerOfflineTests: ZcashTestCase {
         XCTAssertNotEqual(lhs, rhs)
     }
 
+    // The public `Synchronizer.getTreeState(height:)` accessor is the whole point
+    // of exposing tree-state retrieval to app-layer code. These tests pin down the
+    // shape of the protocol requirement by exercising the Sourcery-generated
+    // `SynchronizerMock`: a regression in the requirement's signature, or in the
+    // mock generator's handling of it, would break out-of-repo consumers that
+    // mock the synchronizer in their own tests.
+    func testSynchronizerGetTreeStatePassesHeightAndReturnsConfiguredData() async throws {
+        let mock = SynchronizerMock()
+        let expectedBytes = Data([0x01, 0x02, 0x03, 0x04])
+        mock.getTreeStateHeightReturnValue = expectedBytes
+
+        let result = try await mock.getTreeState(height: 2_400_000)
+
+        XCTAssertEqual(result, expectedBytes)
+        XCTAssertEqual(mock.getTreeStateHeightCallsCount, 1)
+        XCTAssertEqual(mock.getTreeStateHeightReceivedHeight, 2_400_000)
+    }
+
+    func testSynchronizerGetTreeStatePropagatesError() async {
+        struct BoomError: Error, Equatable {}
+        let mock = SynchronizerMock()
+        mock.getTreeStateHeightThrowableError = BoomError()
+
+        do {
+            _ = try await mock.getTreeState(height: 1_234_567)
+            XCTFail("getTreeState was expected to throw")
+        } catch let error as BoomError {
+            XCTAssertEqual(error, BoomError())
+        } catch {
+            XCTFail("Unexpected error type \(error)")
+        }
+    }
+
     func synchronizerState(for internalSyncStatus: InternalSyncStatus) -> SynchronizerState {
         SynchronizerState(
             syncSessionID: .nullID,

--- a/Tests/TestUtils/Sourcery/GeneratedMocks/AutoMockable.generated.swift
+++ b/Tests/TestUtils/Sourcery/GeneratedMocks/AutoMockable.generated.swift
@@ -2523,6 +2523,30 @@ class SynchronizerMock: Synchronizer {
         try await rescanFromHeightClosure?(height)
     }
 
+    // MARK: - getTreeState
+
+    var getTreeStateHeightThrowableError: Error?
+    var getTreeStateHeightCallsCount = 0
+    var getTreeStateHeightCalled: Bool {
+        return getTreeStateHeightCallsCount > 0
+    }
+    var getTreeStateHeightReceivedHeight: UInt64?
+    var getTreeStateHeightReturnValue: Data!
+    var getTreeStateHeightClosure: ((UInt64) async throws -> Data)?
+
+    func getTreeState(height: UInt64) async throws -> Data {
+        if let error = getTreeStateHeightThrowableError {
+            throw error
+        }
+        getTreeStateHeightCallsCount += 1
+        getTreeStateHeightReceivedHeight = height
+        if let closure = getTreeStateHeightClosure {
+            return try await closure(height)
+        } else {
+            return getTreeStateHeightReturnValue
+        }
+    }
+
 }
 class TransactionRepositoryMock: TransactionRepository {
 


### PR DESCRIPTION
Closes #1694

This PR is part of the Shielded Voting merge sequence, split for ease of review. Please view [this document](https://hackmd.io/@TJGUVkqNQYieiMqJQQBDeA/B1nzBrBA-g/edit) for details.

Adds a single typed accessor on the `Synchronizer` protocol so app-layer code that links `ZcashLightClientKit` can fetch a commitment tree state for a given height without reaching into the SDK's internal `LightWalletService`. Returns the protobuf-serialized `TreeState` bytes (`Data`), suitable for direct consumption by an external FFI (e.g. witness generation in the Rust voting stack).

```swift
public protocol Synchronizer: AnyObject {
    /// Fetch the commitment tree state at the given block height from lightwalletd,
    /// returned as protobuf-serialized bytes suitable for witness generation.
    ///
    /// Tor posture: when Tor is enabled on the Synchronizer, this uses a unique,
    /// one-shot Tor circuit per call (`.uniqueTor`), matching the policy of
    /// other public transport calls on this protocol. When Tor is disabled,
    /// this uses a direct gRPC connection.
    func getTreeState(height: UInt64) async throws -> Data
}
```

## Why this rather than wrap the underlying call at the call site

The full motivation lives in the commit message; the short version is that the SDK's transport (`LightWalletService`) is `internal` by design, and the call sites that need a tree state are app-layer (outside the SDK module). Without a public entry point, the only options were "reach into private SDK plumbing" or "promote the entire transport protocol to public." Both are bigger architectural changes than this need justifies. See _Alternatives considered_ below.

## ServiceMode: Tor posture

The `ServiceMode` argument to the underlying `LightWalletService.getTreeState` call is `await sdkFlags.ifTor(.uniqueTor)`, matching the policy of every other public `Synchronizer` → `lightWalletService` call (`fetchUTXOsBy`, `checkSingleUseTransparentAddresses`, `updateTransparentAddressTransactions`, the `importAccount` latest-height probe).

When Tor is disabled (the default), `ifTor(...)` collapses to `.direct` — so this costs exactly the same as a plain gRPC call for users who haven't opted into Tor.

When Tor is enabled, a fresh one-shot circuit per call keeps the tree-state fetch unlinkable from other SDK traffic — in particular, unlinkable from the subsequent `.txIdGroup`-scoped submission of any transaction anchored at the same height. For the primary consumer of this API (shielded-vote witness generation anchored at a poll snapshot), that decorrelation is the whole point: a `.direct` tree-state fetch followed by a Tor'd vote-tx submission would leak a "wallet at IP X interested in height H" signal right before lightwalletd sees "Tor'd tx anchored at H", linking the wallet to the vote.

## Source compatibility

The new requirement on the `Synchronizer` protocol ships with a throwing default in a `public extension`, so out-of-repo conformers (downstream test doubles, alternate transports, apps that implement the protocol directly) keep compiling on upgrade. `SDKSynchronizer` overrides the default with the real lightwalletd call.

## Tests

Two offline tests added in `SynchronizerOfflineTests`:
- `testSynchronizerGetTreeStatePassesHeightAndReturnsConfiguredData` — verifies the height argument flows through and the returned `Data` is propagated.
- `testSynchronizerGetTreeStatePropagatesError` — verifies thrown errors propagate to the caller.

`Tests/TestUtils/Sourcery/GeneratedMocks/AutoMockable.generated.swift` is updated with the new mock entry for `getTreeState(height:)`.

## Alternatives considered

### 1. Expose `LightWalletService` (or an `Initializer.lightWalletService` getter) publicly

That's a huge public-API expansion for a one-method need.

The pattern in the existing protocol points the other way: `submitRawTransaction`, `proposeTransfer`, `getUnifiedAddress`, the resubmission machinery — every transport-backed capability on `Synchronizer` is already wrapped this way. This change follows that established pattern.

### 2. Have the consumer reach into `initializer.lightWalletService` directly

- The `Initializer` API is not a supported public surface — its `lightWalletService` is a `var`, re-assigned on endpoint changes (e.g. server switch), so any cached reference goes stale.
- It bypasses the SDK's encapsulation by design — a future change that, say, makes `LightWalletService` non-stored, lazily-resolved, or pool-managed would silently break the consumer.
- It requires the consumer to import / depend on protobuf-generated types (`BlockID`, `TreeState`).

### 3. Introduce a smaller, voting-specific protocol (e.g. `VotingDataSource`) instead of growing `Synchronizer`

```swift
public protocol VotingDataSource {
    func getTreeState(height: UInt64) async throws -> Data
}
extension SDKSynchronizer: VotingDataSource { /* same impl */ }
```

This keeps the public surface narrow and makes the dependency from the consumer explicit ("this needs a `VotingDataSource`, not a whole `Synchronizer`"). It's worth doing once there are 2–3 such transport-layer needs, but it's overkill for one method, and naming it now ("`VotingDataSource`?") would prematurely couple a public protocol name to a specific feature that the SDK shouldn't otherwise be aware of. Easy to refactor into later if the surface grows.

### 4. Keep the protocol requirement, drop the throwing default

Without the default, every out-of-repo `Synchronizer` conformer (downstream test doubles, alternate transports, apps that implement the protocol directly) would fail to compile on upgrade. That converts a strictly additive change into a source-breaking one. The default is a 6-line cost for full source compatibility.
