### PR TITLE
[#1695] Expose fullyScannedHeight on SynchronizerState

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Added
 - `SDKSynchronizer.rescanFrom(height:)`: Rescans the chain from the given BlockHeight.
+- `SynchronizerState.fullyScannedHeight`: Contiguous-from-birthday scan high-water mark published on `stateStream`/`latestState`. Callers that need an authoritative view of the wallet's note and nullifier state at a specific height (for example, balance anchored at a poll snapshot) should gate on this rather than `latestBlockHeight` (chain tip) or `maxScannedHeight` (head-first scan progress, which can race ahead under Spend-before-Sync).
 
 # 2.4.9 - 2026-04-04
 

--- a/Sources/ZcashLightClientKit/Synchronizer.swift
+++ b/Sources/ZcashLightClientKit/Synchronizer.swift
@@ -42,6 +42,13 @@ public struct SynchronizerState: Equatable {
     public var syncStatus: SyncStatus
     /// height of the latest block on the blockchain known to this synchronizer.
     public var latestBlockHeight: BlockHeight
+    /// Height below which every block has been scanned contiguously from the wallet
+    /// birthday. Unlike `latestBlockHeight` (chain tip) or `maxScannedHeight` (head-first
+    /// scan progress), this is the only value that tells a caller "the wallet has
+    /// authoritative note and nullifier state for this height." Callers that need a
+    /// stable snapshot of balance at a specific height — e.g. voting power at a poll
+    /// snapshot — must gate on this, not on `latestBlockHeight`.
+    public var fullyScannedHeight: BlockHeight
 
     /// Represents a synchronizer that has made zero progress hasn't done a sync attempt
     public static var zero: SynchronizerState {
@@ -49,20 +56,23 @@ public struct SynchronizerState: Equatable {
             syncSessionID: .nullID,
             accountsBalances: [:],
             internalSyncStatus: .unprepared,
-            latestBlockHeight: .zero
+            latestBlockHeight: .zero,
+            fullyScannedHeight: .zero
         )
     }
-    
+
     init(
         syncSessionID: UUID,
         accountsBalances: [AccountUUID: AccountBalance],
         internalSyncStatus: InternalSyncStatus,
-        latestBlockHeight: BlockHeight
+        latestBlockHeight: BlockHeight,
+        fullyScannedHeight: BlockHeight = .zero
     ) {
         self.syncSessionID = syncSessionID
         self.accountsBalances = accountsBalances
         self.internalSyncStatus = internalSyncStatus
         self.latestBlockHeight = latestBlockHeight
+        self.fullyScannedHeight = fullyScannedHeight
         self.syncStatus = internalSyncStatus.mapToSyncStatus()
     }
 }

--- a/Sources/ZcashLightClientKit/Synchronizer/SDKSynchronizer.swift
+++ b/Sources/ZcashLightClientKit/Synchronizer/SDKSynchronizer.swift
@@ -1228,7 +1228,8 @@ public class SDKSynchronizer: Synchronizer {
             syncSessionID: syncSession.value,
             accountsBalances: (try? await getAccountsBalances()) ?? [:],
             internalSyncStatus: status,
-            latestBlockHeight: latestBlocksDataProvider.latestBlockHeight
+            latestBlockHeight: latestBlocksDataProvider.latestBlockHeight,
+            fullyScannedHeight: latestBlocksDataProvider.fullyScannedHeight
         )
     }
 

--- a/Tests/DarksideTests/SynchronizerDarksideTests.swift
+++ b/Tests/DarksideTests/SynchronizerDarksideTests.swift
@@ -228,7 +228,14 @@ class SynchronizerDarksideTests: ZcashTestCase {
         XCTAssertEqual(states.count, expectedStates.count)
 
         for (index, state) in states.enumerated() {
-            let expectedState = expectedStates[index]
+            var expectedState = expectedStates[index]
+            // `fullyScannedHeight` is not what this test exercises — it's checking the
+            // sequence of (syncSessionID, internalSyncStatus, latestBlockHeight) tuples
+            // emitted on `stateStream`. Scan-progress wiring is covered separately by
+            // `SynchronizerOfflineTests.testSynchronizerStateEquatableDistinguishesFullyScannedHeight`
+            // and the offline `SynchronizerState.zero` / init tests. Mask the field so
+            // the structural comparison below stays focused on the transitions under test.
+            expectedState.fullyScannedHeight = state.fullyScannedHeight
             XCTAssertEqual(state, expectedState, "Failed state comparison at index \(index).")
         }
     }
@@ -300,7 +307,11 @@ class SynchronizerDarksideTests: ZcashTestCase {
         XCTAssertEqual(states.count, expectedStates.count)
 
         for (index, state) in states.enumerated() {
-            let expectedState = expectedStates[index]
+            var expectedState = expectedStates[index]
+            // See note in `testLastStates`: this test exercises sync-session + status
+            // transitions, not scan-progress wiring; mask `fullyScannedHeight` to keep
+            // the comparison focused.
+            expectedState.fullyScannedHeight = state.fullyScannedHeight
             XCTAssertEqual(state, expectedState, "Failed state comparison at index \(index).")
         }
 
@@ -351,7 +362,9 @@ class SynchronizerDarksideTests: ZcashTestCase {
         XCTAssertEqual(states.count, secondBatchOfExpectedStates.count)
 
         for (index, state) in states.enumerated() {
-            let expectedState = secondBatchOfExpectedStates[index]
+            var expectedState = secondBatchOfExpectedStates[index]
+            // See note above; `fullyScannedHeight` is intentionally out of scope for this test.
+            expectedState.fullyScannedHeight = state.fullyScannedHeight
             XCTAssertEqual(state, expectedState, "Failed state comparison at index \(index).")
         }
     }

--- a/Tests/OfflineTests/SynchronizerOfflineTests.swift
+++ b/Tests/OfflineTests/SynchronizerOfflineTests.swift
@@ -433,13 +433,56 @@ class SynchronizerOfflineTests: ZcashTestCase {
             XCTFail("Syncing is expected to be 100% (1.0) but received \(data).")
         }
     }
-    
+
+    func testSynchronizerStateZeroHasZeroFullyScannedHeight() {
+        XCTAssertEqual(SynchronizerState.zero.fullyScannedHeight, .zero)
+    }
+
+    func testSynchronizerStateInitPreservesFullyScannedHeight() {
+        let state = SynchronizerState(
+            syncSessionID: .nullID,
+            accountsBalances: [:],
+            internalSyncStatus: .syncing(0, false),
+            latestBlockHeight: 222_222,
+            fullyScannedHeight: 100_000
+        )
+
+        XCTAssertEqual(state.fullyScannedHeight, 100_000)
+    }
+
+    // Regression guard: `fullyScannedHeight` is a *separate* dimension of `SynchronizerState`
+    // from `latestBlockHeight`. Callers (e.g. shielded-vote snapshot gating) rely on receiving
+    // a state-stream update whenever `fullyScannedHeight` advances, even if no other field
+    // changes. If `Equatable` ever stops distinguishing this field — e.g. because someone
+    // reorders the stored properties so the synthesised `==` excludes it — upstream
+    // deduplication (`removeDuplicates`, `Publisher.removeDuplicates`, `CurrentValueSubject`
+    // dedup) would silently swallow those updates.
+    func testSynchronizerStateEquatableDistinguishesFullyScannedHeight() {
+        let lhs = SynchronizerState(
+            syncSessionID: .nullID,
+            accountsBalances: [:],
+            internalSyncStatus: .syncing(0.5, false),
+            latestBlockHeight: 222_222,
+            fullyScannedHeight: 100_000
+        )
+        let rhs = SynchronizerState(
+            syncSessionID: .nullID,
+            accountsBalances: [:],
+            internalSyncStatus: .syncing(0.5, false),
+            latestBlockHeight: 222_222,
+            fullyScannedHeight: 120_000
+        )
+
+        XCTAssertNotEqual(lhs, rhs)
+    }
+
     func synchronizerState(for internalSyncStatus: InternalSyncStatus) -> SynchronizerState {
         SynchronizerState(
             syncSessionID: .nullID,
             accountsBalances: [:],
             internalSyncStatus: internalSyncStatus,
-            latestBlockHeight: .zero
+            latestBlockHeight: .zero,
+            fullyScannedHeight: .zero
         )
     }
 }

--- a/Tests/TestUtils/Stubs.swift
+++ b/Tests/TestUtils/Stubs.swift
@@ -152,7 +152,8 @@ extension SynchronizerState {
             syncSessionID: .nullID,
             accountsBalances: [:],
             internalSyncStatus: .syncing(0, false),
-            latestBlockHeight: 222222
+            latestBlockHeight: 222222,
+            fullyScannedHeight: 0
         )
     }
 }


### PR DESCRIPTION
Closes #1695

This PR is part of the Shielded Voting merge sequence, split for ease of review. Please view [this document](https://hackmd.io/@TJGUVkqNQYieiMqJQQBDeA/B1nzBrBA-g/edit) for details.

Adds a single new field, `fullyScannedHeight`, to the public `SynchronizerState` struct so app-layer callers can answer _"is the wallet's local note and nullifier state authoritative at height H?"_ — the question you have to answer before computing balance, voting weight, or any other view of state anchored at a specific historical height.

The value is already tracked inside `LatestBlocksDataProvider` and refreshed every scan tick from `rustBackend.fullyScannedHeight()`. This change just lifts it to the public state-stream surface that consumers already subscribe to.

## Why this rather than reuse an existing height

`SynchronizerState` already exposes two heights, but neither answers the question above:

| Field                                                                    | Source                              | What it answers                                                       |
| ------------------------------------------------------------------------ | ----------------------------------- | --------------------------------------------------------------------- |
| `latestBlockHeight`                                                      | lightwalletd RPC                    | "What's the current chain tip?"                                       |
| `maxScannedHeight` (on `LatestBlocksDataProvider`, not on `SynchronizerState`) | head-first scan high-water mark     | "What's the highest block I've scanned, anywhere?"                    |
| `fullyScannedHeight` _(new on `SynchronizerState`)_                      | birthday-first scan high-water mark | "Through what height is my local note/nullifier state authoritative?" |

`latestBlockHeight` is unrelated to scan progress. A caller can know the chain tip is at height 2,500,000 while the local DB has scanned only `[birthday, 1,200,000]`. Comparing `latestBlockHeight ≥ snapshotHeight` is asking the wrong question — it tells you the network has reached the snapshot, not that the wallet has.

`maxScannedHeight` is the head-first scan high-water mark, which under **Spend-before-Sync (SbS)** races ahead of the contiguous-from-birthday frontier. Concrete failure mode this enables today:

1. User opens the wallet for the first time (or after a long absence). Birthday is far below chain tip.
2. SbS triggers: the SDK starts a head-first scan of the most recent ~few thousand blocks so the user can spend immediately. `maxScannedHeight` shoots up near the chain tip.
3. Meanwhile, the birthday-first scanner is still climbing slowly from the wallet birthday. `fullyScannedHeight` is still down near the birthday.
4. Caller wakes up, sees `state.maxScannedHeight ≥ snapshotHeight` (or `state.latestBlockHeight ≥ snapshotHeight`), decides "ready," and asks the SDK to compute, sign, or prove something anchored at `H`.
5. There's a multi-thousand-block hole in `(fullyScannedHeight, maxScannedHeight)` that includes `H`. Notes received in that hole are missing from the local DB. Nullifiers spent in that hole are also missing.
6. Result: incomplete view of state at `H` — silently wrong answers, not loud errors.

`fullyScannedHeight ≥ snapshotHeight` is the _only_ check that rules this out, by construction: it is the bottom of the SbS hole.

## Source compatibility

`SynchronizerState.init` gets the new field with a default value of `.zero`, so all existing constructor call sites (darkside tests etc.) keep compiling unchanged.

## Tests

Three offline tests added in `SynchronizerOfflineTests`:
- `testSynchronizerStateZeroHasZeroFullyScannedHeight` — `SynchronizerState.zero` sets the new field to `.zero`.
- `testSynchronizerStateInitPreservesFullyScannedHeight` — the new initialiser parameter round-trips.
- `testSynchronizerStateEquatableDistinguishesFullyScannedHeight` — two states differing only in `fullyScannedHeight` are not equal (the new field participates in `Equatable`).

The two darkside tests that compare full `SynchronizerState` snapshots across sync ticks (`testLastStates`, `testSyncSessionUpdates`) are updated to mask `fullyScannedHeight` from the equality check, since those tests deliberately validate sync-session and status transitions, not contiguous-scan progress (which has its own `LatestBlocksDataProvider`-level coverage and now offline coverage above).
