### PR TITLE
[#1661] Add zcash_voting dependency foundation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,11 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `SDKSynchronizer.rescanFrom(height:)`: Rescans the chain from the given BlockHeight.
 - `SynchronizerState.fullyScannedHeight`: Contiguous-from-birthday scan high-water mark published on `stateStream`/`latestState`. Callers that need an authoritative view of the wallet's note and nullifier state at a specific height (for example, balance anchored at a poll snapshot) should gate on this rather than `latestBlockHeight` (chain tip) or `maxScannedHeight` (head-first scan progress, which can race ahead under Spend-before-Sync).
 - `Synchronizer.getTreeState(height:)`: Fetches the commitment tree state at the given block height from lightwalletd and returns the protobuf-serialized `TreeState` bytes, for app-layer consumers that need to hand tree state to an external component (for example, witness generation via FFI). A throwing default implementation keeps the addition source-compatible for downstream `Synchronizer` conformers.
+- `zcash_voting` dependency foundation: SDK Rust crate now depends on `zcash_voting 0.4` (`default-features = false`) and exposes a single pure-function FFI symbol, `zcashlc_voting_compute_share_nullifier`, used to prove end-to-end linkage against the voting crate. No Swift API surface is added in this step.
 
 ## Changed
 - Bumped Rust dependencies to current crates.io releases (`zcash_address` 0.10→0.11, `zcash_client_backend` 0.21→0.22, `zcash_client_sqlite` 0.19→0.20, `zcash_primitives`/`zcash_proofs` 0.26→0.27, `zcash_protocol` 0.7→0.8, `zcash_transparent` 0.6→0.7, `sapling-crypto` 0.6→0.7, `orchard` 0.12→0.13, `pczt` 0.5→0.6) and removed the `[patch.crates-io]` git-rev overrides. No public Swift API changes.
+- Pinned `orchard` to `=0.13.1` and enabled its `unstable-voting-circuits` feature, required transitively by `zcash_voting`. No public Swift API changes.
 
 # 2.4.9 - 2026-04-04
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1201,7 +1201,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd5f2b7218a51c827a11d22d1439b598121fac94bf9b99452e4afffe512d78c9"
 dependencies = [
  "heck",
- "indexmap 2.14.0",
+ "indexmap 1.9.3",
  "itertools 0.14.0",
  "proc-macro-crate",
  "proc-macro2",
@@ -2228,7 +2228,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -2530,6 +2530,7 @@ dependencies = [
  "zcash_protocol",
  "zcash_script",
  "zcash_transparent",
+ "zcash_voting",
  "zip32",
 ]
 
@@ -6049,6 +6050,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
+name = "voting-circuits"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ba6635f8e207689c290634f6e34f7eddaf1b254aa0f9b0ef65418d89d1d1ae7"
+dependencies = [
+ "blake2b_simd",
+ "ff",
+ "group",
+ "halo2_gadgets",
+ "halo2_poseidon",
+ "halo2_proofs",
+ "incrementalmerkletree",
+ "lazy_static",
+ "orchard",
+ "pasta_curves",
+ "rand 0.8.6",
+ "sinsemilla",
+]
+
+[[package]]
 name = "walkdir"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6252,7 +6273,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
 dependencies = [
  "windows-collections",
- "windows-core 0.61.2",
+ "windows-core",
  "windows-future",
  "windows-link 0.1.3",
  "windows-numerics",
@@ -6264,7 +6285,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
 dependencies = [
- "windows-core 0.61.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -6276,21 +6297,8 @@ dependencies = [
  "windows-implement",
  "windows-interface",
  "windows-link 0.1.3",
- "windows-result 0.3.4",
- "windows-strings 0.4.2",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.62.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
-dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
- "windows-strings 0.5.1",
+ "windows-result",
+ "windows-strings",
 ]
 
 [[package]]
@@ -6299,7 +6307,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
- "windows-core 0.61.2",
+ "windows-core",
  "windows-link 0.1.3",
  "windows-threading",
 ]
@@ -6344,7 +6352,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
- "windows-core 0.61.2",
+ "windows-core",
  "windows-link 0.1.3",
 ]
 
@@ -6358,30 +6366,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-result"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
-dependencies = [
- "windows-link 0.2.1",
-]
-
-[[package]]
 name = "windows-strings"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
  "windows-link 0.1.3",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
-dependencies = [
- "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -6995,6 +6985,36 @@ dependencies = [
  "zcash_protocol",
  "zcash_script",
  "zcash_spec",
+ "zip32",
+]
+
+[[package]]
+name = "zcash_voting"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72bede6ecb43d7626988c09b2001fd95317f2a510ce168e1e8384612261061ea"
+dependencies = [
+ "blake2b_simd",
+ "ff",
+ "group",
+ "halo2_gadgets",
+ "halo2_proofs",
+ "hex",
+ "incrementalmerkletree",
+ "nonempty",
+ "orchard",
+ "pasta_curves",
+ "pczt",
+ "rand 0.8.6",
+ "rusqlite",
+ "serde",
+ "serde_json",
+ "subtle",
+ "thiserror 2.0.18",
+ "voting-circuits",
+ "zcash_keys",
+ "zcash_primitives",
+ "zcash_protocol",
  "zip32",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ build = "rust/build.rs"
 [dependencies]
 
 # Zcash
-orchard = "0.13"
+orchard = { version = "=0.13.1", features = ["unstable-voting-circuits"] }
 sapling = { package = "sapling-crypto", version = "0.7", default-features = false }
 transparent = { package = "zcash_transparent", version = "0.7", default-features = false }
 zcash_address = { version = "0.11" }
@@ -77,6 +77,9 @@ tor-rtcompat = "0.35"
 rust_decimal = { version = "1", default-features = false, features = ["c-repr"] }
 # - The "static" feature is required for the "compression" default feature of arti-client.
 xz2 = { version = "0.1", features = ["static"] }
+
+# Voting
+zcash_voting = { version = "0.4", default-features = false }
 
 [build-dependencies]
 bindgen = "0.72"

--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -6,6 +6,19 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+- `zcashlc_voting_compute_share_nullifier`: Compute the 32-byte share-reveal
+  nullifier from a vote commitment, primary blind, and share index. Returns
+  the nullifier as a 64-character hex C-string; the caller must free the
+  returned pointer via `zcashlc_string_free`. Returns `NULL` on error or
+  panic. Pure-function FFI: no wallet DB, voting DB, network, randomness,
+  or secret material involved.
+- Added `zcash_voting 0.4` (`default-features = false`) as a Rust dependency.
+
+### Changed
+- Pinned `orchard` to `=0.13.1` and enabled its `unstable-voting-circuits`
+  feature (required transitively by `zcash_voting`).
+
 ## 2.4.6 - 2026-03-12
 
 ### Changed

--- a/rust/build.rs
+++ b/rust/build.rs
@@ -4,6 +4,8 @@ use std::{env, path::PathBuf};
 
 fn main() {
     println!("cargo:rerun-if-changed=rust/src/lib.rs");
+    println!("cargo:rerun-if-changed=rust/src/voting.rs");
+    println!("cargo:rerun-if-changed=rust/src/voting");
     println!("cargo:rerun-if-changed=rust/wrapper.c");
     println!("cargo:rerun-if-changed=rust/wrapper.h");
 

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -96,6 +96,7 @@ mod derivation;
 mod eip681;
 mod ffi;
 mod tor;
+mod voting;
 
 #[cfg(target_vendor = "apple")]
 mod os_log;

--- a/rust/src/voting.rs
+++ b/rust/src/voting.rs
@@ -1,0 +1,6 @@
+//! C FFI for the voting functionality.
+//!
+//! Implementation is split into submodules for navigation. Exported FFI functions
+//! keep their stable C symbols with `#[unsafe(no_mangle)]`.
+
+pub mod share_tracking;

--- a/rust/src/voting/share_tracking.rs
+++ b/rust/src/voting/share_tracking.rs
@@ -1,0 +1,41 @@
+use std::ffi::CString;
+use std::fmt::Write as _;
+use std::os::raw::c_char;
+
+use anyhow::anyhow;
+use ffi_helpers::panic::catch_panic;
+use zcash_voting as voting;
+
+use crate::unwrap_exc_or_null;
+
+/// Compute the share reveal nullifier from client-known inputs.
+///
+/// Returns the 32-byte nullifier as a hex string (64 chars), or null on error.
+///
+/// # Safety
+///
+/// - `vote_commitment` must point to exactly 32 bytes.
+/// - `primary_blind` must point to exactly 32 bytes.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn zcashlc_voting_compute_share_nullifier(
+    vote_commitment: *const u8,
+    primary_blind: *const u8,
+    share_index: u32,
+) -> *mut c_char {
+    let res = catch_panic(|| {
+        let vc = unsafe { std::slice::from_raw_parts(vote_commitment, 32) };
+        let blind = unsafe { std::slice::from_raw_parts(primary_blind, 32) };
+
+        let nullifier = voting::share_tracking::compute_share_nullifier(vc, share_index, blind)
+            .map_err(|e| anyhow!("compute_share_nullifier failed: {}", e))?;
+
+        // Fixed-width hex: one 64-char allocation instead of per-byte `format!` temporaries.
+        let mut hex_str = String::with_capacity(64);
+        for b in nullifier {
+            write!(&mut hex_str, "{b:02x}").expect("writing to a String cannot fail");
+        }
+        let c_str = CString::new(hex_str).map_err(|e| anyhow!("null byte in hex string: {}", e))?;
+        Ok(c_str.into_raw())
+    });
+    unwrap_exc_or_null(res)
+}


### PR DESCRIPTION
Tracks #1661.

This PR is part of the Shielded Voting merge sequence (#1687), split for ease of review.

Brings the SDK Rust crate onto the released `zcash_voting 0.4` dependency line and the matching pinned `orchard 0.13.1` (with the `unstable-voting-circuits` feature), and lands a single pure-function FFI symbol that proves end-to-end linkage. The follow-up PRs in this sequence will then layer wallet-to-voting plumbing, the broader FFI surface, and the Swift wrappers on top of this foundation.

## Why this rather than landing more of the FFI now

Reviewing #1687 as a single 1571-line Swift wrapper plus a 3000-line `voting.rs` is hard. The FFI surface there mixes four concerns that a reviewer needs to evaluate independently:

| Concern | What a reviewer has to verify | Lands in |
|---|---|---|
| Does the SDK build against released `zcash_voting` and `orchard 0.13.1`? | Cargo graph resolves to single versions, FFI links | **this PR** |
| Wallet-to-voting plumbing (note snapshot, witness generation) | Wallet DB queries at historical heights are correct | follow-up |
| Voting DB lifecycle, JSON serde across FFI, ProgressContext lifetimes | Memory ownership and FFI safety | follow-up |
| Swift `VotingRustBackend` API surface | Public Swift contract, locking, error mapping | follow-up |

This PR isolates the first row. The diff is intentionally narrow and the new symbol is provably outside the wallet path.

## Version changes

| Crate          | Before | After                                                  |
| -------------- | ------ | ------------------------------------------------------ |
| orchard        | 0.13   | `=0.13.1`, `features = ["unstable-voting-circuits"]`   |
| zcash_voting   | new    | `0.4`, `default-features = false`                      |

Both are released on crates.io; no `[patch.crates-io]` entries are introduced and no fork URLs are pinned. The `orchard` `unstable-voting-circuits` feature is required transitively by `zcash_voting`.

## What the new FFI does — and what it deliberately does not do

`rust/src/voting/share_tracking.rs` exposes one symbol:

```rust
#[unsafe(no_mangle)]
pub unsafe extern "C" fn zcashlc_voting_compute_share_nullifier(
    vote_commitment: *const u8, // 32 bytes
    primary_blind:   *const u8, // 32 bytes
    share_index:     u32,
) -> *mut c_char // 64-char hex nullifier; caller frees via zcashlc_string_free
```

It forwards to `zcash_voting::share_tracking::compute_share_nullifier` and returns the 32-byte share-reveal nullifier as a 64-character hex C-string. On error or panic it returns `NULL`. The returned pointer must be freed by the caller via the SDK's existing `zcashlc_string_free`.

It intentionally stays outside the wallet-to-voting data path:

- No wallet DB open / read
- No voting DB open / read
- No network I/O (no PIR, no lightwalletd)
- No proving-key cache warm-up or other process-lifetime side effects
- No randomness
- No secret material in or out

The function is a deterministic computation over caller-supplied bytes. Its only purpose in this PR is to prove that the SDK Rust crate links and dispatches against `zcash_voting`.

## Source compatibility

No public Swift API changes. No new Swift wrapper. No `Synchronizer` protocol additions or default implementations. Existing constructor call sites and downstream conformers continue to compile unchanged.

## Out of scope (intentionally deferred to follow-ups)

- Swift `VotingRustBackend` and `VotingTypes` (the 1571 + 456 line files in #1687)
- Wallet note snapshot lookup, witness generation, voting DB lifecycle, PIR snapshot resolver
- Any `Package.swift` linker or binary target changes
- Any FFI symbol that takes a `wallet_db_path` or opens `WalletDb`

These will land as separate, individually reviewable PRs once this foundation is in.
