### PR TITLE
Run CodeQL on merge to main and weekly, not on every PR

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -11,11 +11,28 @@
 #
 name: "CodeQL Advanced"
 
+# CodeQL runs on merges to main and on a weekly schedule, not on every PR.
+#
+# Rationale:
+# - The Swift matrix entry requires `build-mode: manual` (CodeQL's Swift extractor
+#   hooks the compiler), so it has to run a full Rust FFI + Swift build on a
+#   macos-15 runner. On Cargo.lock-changing PRs this is a 30-50 min cold build,
+#   per push, with no concurrency cancellation.
+# - The build-integration signal that matters at PR time (does Rust still link
+#   with Swift? do offline tests pass?) is already covered by `swift.yml` on
+#   every PR. CodeQL Swift adds static-analysis findings, not build verification.
+# - Moving CodeQL to push-to-main + weekly cadence keeps the security signal
+#   while removing a major source of PR-time CI cost.
 on:
   push:
     branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
+  schedule:
+    # Weekly Monday 06:00 UTC: catches new query-pack rules and dependency
+    # drift even when nobody has pushed to main.
+    - cron: '0 6 * * 1'
+  # Manual trigger: re-run between scheduled scans, e.g. after a security-
+  # relevant dependency lands and waiting until the next Monday is too long.
+  workflow_dispatch: {}
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

Move `codeql.yml` from `pull_request:` triggers to `push: branches: [main]` + weekly `schedule:` + `workflow_dispatch:`. No other changes.

## Why

CodeQL's Swift matrix entry uses `build-mode: manual` — the extractor hooks the Swift compiler, so it has to run a full Rust FFI + Swift build on `macos-15`. On `Cargo.lock`-changing PRs this is a 30-50 minute cold build per push.

Concrete recent example on a Rust-only PR: [`Analyze (swift)`](https://github.com/zcash/zcash-swift-wallet-sdk/actions/runs/25386244403/job/74454517572?pr=1699) ran for 54m35s on PR #1699 ([#1661] Add zcash_voting dependency foundation), which touches zero Swift files.

The build-integration signal that matters at PR time (does Rust still link with Swift, do offline tests pass) is already covered by `swift.yml` on every PR — see, e.g., the [19m21s `build` run on PR #1831](https://github.com/zcash/zcash-swift-wallet-sdk/actions/runs/25333209983/job/74274503393). CodeQL Swift adds static-analysis findings, not build verification, so dropping it from the PR-time gate does not regress integration coverage.

## What changes

```yaml
on:
  push:
    branches: [ "main" ]
  schedule:
    - cron: '0 6 * * 1'   # weekly Monday 06:00 UTC
  workflow_dispatch: {}
```

- `push: branches: [main]` — analyze every commit landing on `main` (PRs use the `merge` strategy per the repo ruleset, so each PR produces one merge commit on `main` that gets fully scanned).
- `schedule:` — weekly safety net, picks up new query-pack rules and dependency drift.
- `workflow_dispatch:` — manual re-run for cases like a security-relevant dep landing mid-week, where waiting until Monday is too long.

The four-language matrix (`actions`, `c-cpp`, `rust`, `swift`) and all build/analyze steps are **unchanged**. Only the trigger block is touched, plus a rationale comment above `on:`.

## Scope note

This moves all four matrix languages off PR, not only `swift`. The Linux entries are cheap (~3-8 min each), but uniformly running CodeQL on push and schedule keeps the trigger configuration simple and the mental model uniform. Splitting the matrix to keep the cheap languages on PR is possible (would require either two workflow files or matrix-conditional triggers) and can be revisited if the team wants more PR-time security signal back.

## Branch protection

None of the CodeQL matrix entries (`Analyze (swift)`, `Analyze (rust)`, `Analyze (actions)`, `Analyze (c-cpp)`) appear in the repo's required status checks per ruleset 15170778 — only `build` (from `swift.yml`) and `Run zizmor 🌈` are required. So no ruleset / branch-protection edits are needed; merges will not block waiting for a CodeQL check that no longer reports on PRs.
