### PR TITLE
[#1661] Add VotingTypes.swift for shielded voting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Synchronizer.getTreeState(height:)`: Fetches the commitment tree state at the given block height from lightwalletd and returns the protobuf-serialized `TreeState` bytes, for app-layer consumers that need to hand tree state to an external component (for example, witness generation via FFI). A throwing default implementation keeps the addition source-compatible for downstream `Synchronizer` conformers.
 - `zcash_voting` dependency foundation: SDK Rust crate now depends on `zcash_voting 0.5.2` (`default-features = false`, `client-pir`) and exposes pure-function FFI symbols for share-nullifier computation and PIR proof validation. No Swift API surface is added in this step.
 - `PirSnapshotResolver`, `PirSnapshotResolverError`, `PirSnapshotProbeOutcome`, `PirSnapshotProbing`, and `HTTPPirSnapshotProbe`: Select a vote-nullifier PIR endpoint whose `/root` metadata exactly matches a voting round's expected snapshot height.
+- `Voting*` Swift types: public type contract for the shielded voting FFI boundary, in `Sources/ZcashLightClientKit/Rust/Voting/VotingTypes.swift`.
 
 ## Changed
 - Bumped Rust dependencies to current crates.io releases (`zcash_address` 0.10→0.11, `zcash_client_backend` 0.21→0.22, `zcash_client_sqlite` 0.19→0.20, `zcash_primitives`/`zcash_proofs` 0.26→0.27, `zcash_protocol` 0.7→0.8, `zcash_transparent` 0.6→0.7, `sapling-crypto` 0.6→0.7, `orchard` 0.12→0.13, `pczt` 0.5→0.6) and removed the `[patch.crates-io]` git-rev overrides. No public Swift API changes.

--- a/Sources/ZcashLightClientKit/Rust/Voting/VotingTypes.swift
+++ b/Sources/ZcashLightClientKit/Rust/Voting/VotingTypes.swift
@@ -1,0 +1,442 @@
+//
+//  VotingTypes.swift
+//  ZcashLightClientKit
+//
+
+import Foundation
+
+// MARK: - Round State
+
+/// Phase of a voting round.
+public enum VotingRoundPhase: UInt32, Codable, Sendable {
+    case initialized = 0
+    case hotkeyGenerated = 1
+    case delegationConstructed = 2
+    case delegationProved = 3
+    case voteReady = 4
+}
+
+/// State of a voting round.
+public struct VotingRoundState: Sendable {
+    public let roundId: String
+    public let phase: VotingRoundPhase
+    public let snapshotHeight: UInt64
+    public let hotkeyAddress: String?
+    public let delegatedWeight: UInt64?
+    public let proofGenerated: Bool
+}
+
+/// Summary of a voting round for list display.
+public struct VotingRoundSummary: Sendable {
+    public let roundId: String
+    public let phase: VotingRoundPhase
+    public let snapshotHeight: UInt64
+    public let createdAt: UInt64
+}
+
+// MARK: - Hotkey
+
+/// Voting hotkey (secret key, public key, address).
+public struct VotingHotkey: Sendable {
+    public let secretKey: [UInt8]
+    public let publicKey: [UInt8]
+    public let address: String
+}
+
+// MARK: - Bundle Setup
+
+/// Result of setting up vote bundles.
+public struct VotingBundleSetupResult: Sendable {
+    public let bundleCount: UInt32
+    public let eligibleWeight: UInt64
+}
+
+// MARK: - Vote Record
+
+/// Record of a vote for a specific proposal/bundle.
+public struct VotingVoteRecord: Sendable {
+    public let proposalId: UInt32
+    public let bundleIndex: UInt32
+    public let choice: UInt32
+    public let submitted: Bool
+}
+
+// MARK: - Note Info (JSON)
+
+/// Note information for voting eligibility.
+public struct VotingNoteInfo: Codable, Sendable {
+    public let commitment: [UInt8]
+    public let nullifier: [UInt8]
+    public let value: UInt64
+    public let position: UInt64
+    public let diversifier: [UInt8]
+    public let rho: [UInt8]
+    public let rseed: [UInt8]
+    public let scope: UInt32
+    public let ufvkStr: String
+
+    enum CodingKeys: String, CodingKey {
+        case commitment, nullifier, value, position, diversifier, rho, rseed, scope
+        case ufvkStr = "ufvk_str"
+    }
+
+    public init(
+        commitment: [UInt8],
+        nullifier: [UInt8],
+        value: UInt64,
+        position: UInt64,
+        diversifier: [UInt8],
+        rho: [UInt8],
+        rseed: [UInt8],
+        scope: UInt32,
+        ufvkStr: String
+    ) {
+        self.commitment = commitment
+        self.nullifier = nullifier
+        self.value = value
+        self.position = position
+        self.diversifier = diversifier
+        self.rho = rho
+        self.rseed = rseed
+        self.scope = scope
+        self.ufvkStr = ufvkStr
+    }
+}
+
+// MARK: - Voting PCZT (JSON)
+
+/// Result of building a voting PCZT.
+public struct VotingPczt: Codable, Sendable {
+    public let pcztBytes: [UInt8]
+    /// Randomized verification key (`rk` on the wire).
+    public let randomizedKey: [UInt8]
+    public let alpha: [UInt8]
+    public let nfSigned: [UInt8]
+    public let cmxNew: [UInt8]
+    public let govNullifiers: [[UInt8]]
+    public let van: [UInt8]
+    public let vanCommRand: [UInt8]
+    public let dummyNullifiers: [[UInt8]]
+    public let rhoSigned: [UInt8]
+    public let paddedCmx: [[UInt8]]
+    public let rseedSigned: [UInt8]
+    public let rseedOutput: [UInt8]
+    public let actionBytes: [UInt8]
+    public let actionIndex: UInt32
+    /// Each element is [rho, rseed].
+    public let paddedNoteSecrets: [[[UInt8]]]
+    public let pcztSighash: [UInt8]
+
+    enum CodingKeys: String, CodingKey {
+        case pcztBytes = "pczt_bytes"
+        case randomizedKey = "rk"
+        case alpha
+        case nfSigned = "nf_signed"
+        case cmxNew = "cmx_new"
+        case govNullifiers = "gov_nullifiers"
+        case van
+        case vanCommRand = "van_comm_rand"
+        case dummyNullifiers = "dummy_nullifiers"
+        case rhoSigned = "rho_signed"
+        case paddedCmx = "padded_cmx"
+        case rseedSigned = "rseed_signed"
+        case rseedOutput = "rseed_output"
+        case actionBytes = "action_bytes"
+        case actionIndex = "action_index"
+        case paddedNoteSecrets = "padded_note_secrets"
+        case pcztSighash = "pczt_sighash"
+    }
+}
+
+// MARK: - Witness Data (JSON)
+
+/// Merkle witness data for a note.
+public struct VotingWitnessData: Codable, Sendable {
+    public let noteCommitment: [UInt8]
+    public let position: UInt64
+    public let root: [UInt8]
+    public let authPath: [[UInt8]]
+
+    enum CodingKeys: String, CodingKey {
+        case noteCommitment = "note_commitment"
+        case position, root
+        case authPath = "auth_path"
+    }
+
+    public init(
+        noteCommitment: [UInt8],
+        position: UInt64,
+        root: [UInt8],
+        authPath: [[UInt8]]
+    ) {
+        self.noteCommitment = noteCommitment
+        self.position = position
+        self.root = root
+        self.authPath = authPath
+    }
+}
+
+// MARK: - Share Delegation (JSON)
+
+/// Record of a share delegation sent to helper servers.
+public struct VotingShareDelegation: Codable, Equatable, Sendable {
+    public let roundId: String
+    public let bundleIndex: UInt32
+    public let proposalId: UInt32
+    public let shareIndex: UInt32
+    public let sentToURLs: [String]
+    public let nullifier: [UInt8]
+    public let confirmed: Bool
+    public let submitAt: UInt64
+    public let createdAt: UInt64
+
+    enum CodingKeys: String, CodingKey {
+        case roundId = "round_id"
+        case bundleIndex = "bundle_index"
+        case proposalId = "proposal_id"
+        case shareIndex = "share_index"
+        case sentToURLs = "sent_to_urls"
+        case nullifier
+        case confirmed
+        case submitAt = "submit_at"
+        case createdAt = "created_at"
+    }
+}
+
+// MARK: - Delegation Proof Result (JSON)
+
+/// Result of building and proving a delegation.
+public struct VotingDelegationProofResult: Codable, Sendable {
+    public let proof: [UInt8]
+    public let publicInputs: [[UInt8]]
+    public let nfSigned: [UInt8]
+    public let cmxNew: [UInt8]
+    public let govNullifiers: [[UInt8]]
+    public let vanComm: [UInt8]
+    /// Randomized verification key (`rk` on the wire).
+    public let randomizedKey: [UInt8]
+
+    enum CodingKeys: String, CodingKey {
+        case proof
+        case publicInputs = "public_inputs"
+        case nfSigned = "nf_signed"
+        case cmxNew = "cmx_new"
+        case govNullifiers = "gov_nullifiers"
+        case vanComm = "van_comm"
+        case randomizedKey = "rk"
+    }
+}
+
+// MARK: - Delegation PIR Precompute Result (JSON)
+
+/// Result of precomputing and caching PIR proofs needed by delegation proving.
+public struct VotingDelegationPirPrecomputeResult: Codable, Sendable {
+    public let cachedCount: UInt32
+    public let fetchedCount: UInt32
+
+    enum CodingKeys: String, CodingKey {
+        case cachedCount = "cached_count"
+        case fetchedCount = "fetched_count"
+    }
+}
+
+// MARK: - Delegation Submission (JSON)
+
+/// Delegation submission payload.
+public struct VotingDelegationSubmission: Codable, Sendable {
+    /// Randomized verification key (`rk` on the wire).
+    public let randomizedKey: [UInt8]
+    public let spendAuthSig: [UInt8]
+    public let sighash: [UInt8]
+    public let nfSigned: [UInt8]
+    public let cmxNew: [UInt8]
+    public let govComm: [UInt8]
+    public let govNullifiers: [[UInt8]]
+    public let proof: [UInt8]
+    public let voteRoundId: String
+
+    enum CodingKeys: String, CodingKey {
+        case randomizedKey = "rk"
+        case spendAuthSig = "spend_auth_sig"
+        case sighash
+        case nfSigned = "nf_signed"
+        case cmxNew = "cmx_new"
+        case govComm = "gov_comm"
+        case govNullifiers = "gov_nullifiers"
+        case proof
+        case voteRoundId = "vote_round_id"
+    }
+}
+
+// MARK: - Vote Commitment Bundle (JSON)
+
+/// A vote commitment bundle produced by Voting ZKP.
+public struct VotingVoteCommitmentBundle: Codable, Sendable {
+    public let vanNullifier: [UInt8]
+    public let voteAuthorityNoteNew: [UInt8]
+    public let voteCommitment: [UInt8]
+    public let proposalId: UInt32
+    public let proof: [UInt8]
+    public let encShares: [VotingWireEncryptedShare]
+    public let anchorHeight: UInt32
+    public let voteRoundId: String
+    public let sharesHash: [UInt8]
+    public let shareBlinds: [[UInt8]]
+    public let shareComms: [[UInt8]]
+    public let rVpkBytes: [UInt8]
+    public let alphaV: [UInt8]
+
+    enum CodingKeys: String, CodingKey {
+        case vanNullifier = "van_nullifier"
+        case voteAuthorityNoteNew = "vote_authority_note_new"
+        case voteCommitment = "vote_commitment"
+        case proposalId = "proposal_id"
+        case proof
+        case encShares = "enc_shares"
+        case anchorHeight = "anchor_height"
+        case voteRoundId = "vote_round_id"
+        case sharesHash = "shares_hash"
+        case shareBlinds = "share_blinds"
+        case shareComms = "share_comms"
+        case rVpkBytes = "r_vpk_bytes"
+        case alphaV = "alpha_v"
+    }
+
+    public init(
+        vanNullifier: [UInt8],
+        voteAuthorityNoteNew: [UInt8],
+        voteCommitment: [UInt8],
+        proposalId: UInt32,
+        proof: [UInt8],
+        encShares: [VotingWireEncryptedShare],
+        anchorHeight: UInt32,
+        voteRoundId: String,
+        sharesHash: [UInt8],
+        shareBlinds: [[UInt8]],
+        shareComms: [[UInt8]],
+        rVpkBytes: [UInt8],
+        alphaV: [UInt8]
+    ) {
+        self.vanNullifier = vanNullifier
+        self.voteAuthorityNoteNew = voteAuthorityNoteNew
+        self.voteCommitment = voteCommitment
+        self.proposalId = proposalId
+        self.proof = proof
+        self.encShares = encShares
+        self.anchorHeight = anchorHeight
+        self.voteRoundId = voteRoundId
+        self.sharesHash = sharesHash
+        self.shareBlinds = shareBlinds
+        self.shareComms = shareComms
+        self.rVpkBytes = rVpkBytes
+        self.alphaV = alphaV
+    }
+}
+
+// MARK: - Wire Encrypted Share (JSON)
+
+/// Wire-safe encrypted share — contains only the public ciphertext components.
+/// Secrets (plaintextValue, randomness) stay inside Rust and never cross the FFI boundary.
+public struct VotingWireEncryptedShare: Codable, Sendable {
+    /// First ciphertext component (`c1` on the wire).
+    public let ciphertext1: [UInt8]
+    /// Second ciphertext component (`c2` on the wire).
+    public let ciphertext2: [UInt8]
+    public let shareIndex: UInt32
+
+    enum CodingKeys: String, CodingKey {
+        case ciphertext1 = "c1"
+        case ciphertext2 = "c2"
+        case shareIndex = "share_index"
+    }
+
+    public init(ciphertext1: [UInt8], ciphertext2: [UInt8], shareIndex: UInt32) {
+        self.ciphertext1 = ciphertext1
+        self.ciphertext2 = ciphertext2
+        self.shareIndex = shareIndex
+    }
+}
+
+// MARK: - Share Payload (JSON)
+
+/// Share payload for delegated share submission.
+public struct VotingSharePayload: Codable, Sendable {
+    public let sharesHash: [UInt8]
+    public let proposalId: UInt32
+    public let voteDecision: UInt32
+    public let encShare: VotingWireEncryptedShare
+    public let treePosition: UInt64
+    public let allEncShares: [VotingWireEncryptedShare]
+    public let shareComms: [[UInt8]]
+    public let primaryBlind: [UInt8]
+
+    enum CodingKeys: String, CodingKey {
+        case sharesHash = "shares_hash"
+        case proposalId = "proposal_id"
+        case voteDecision = "vote_decision"
+        case encShare = "enc_share"
+        case treePosition = "tree_position"
+        case allEncShares = "all_enc_shares"
+        case shareComms = "share_comms"
+        case primaryBlind = "primary_blind"
+    }
+}
+
+// MARK: - Cast Vote Signature (JSON)
+
+/// Signature for a cast vote transaction.
+public struct VotingCastVoteSignature: Codable, Sendable {
+    public let voteAuthSig: [UInt8]
+
+    enum CodingKeys: String, CodingKey {
+        case voteAuthSig = "vote_auth_sig"
+    }
+}
+
+// MARK: - Delegation Inputs (JSON)
+
+/// Inputs needed for delegation construction.
+public struct VotingDelegationInputs: Codable, Sendable {
+    public let fvkBytes: [UInt8]
+    public let gDNewX: [UInt8]
+    public let pkDNewX: [UInt8]
+    public let hotkeyRawAddress: [UInt8]
+    public let hotkeyPublicKey: [UInt8]
+    public let hotkeyAddress: String
+    public let seedFingerprint: [UInt8]
+
+    enum CodingKeys: String, CodingKey {
+        case fvkBytes = "fvk_bytes"
+        case gDNewX = "g_d_new_x"
+        case pkDNewX = "pk_d_new_x"
+        case hotkeyRawAddress = "hotkey_raw_address"
+        case hotkeyPublicKey = "hotkey_public_key"
+        case hotkeyAddress = "hotkey_address"
+        case seedFingerprint = "seed_fingerprint"
+    }
+}
+
+// MARK: - VAN Witness (JSON)
+
+/// VAN Merkle witness for voting ZKP.
+public struct VotingVanWitness: Codable, Sendable {
+    public let authPath: [[UInt8]]
+    public let position: UInt32
+    public let anchorHeight: UInt32
+
+    enum CodingKeys: String, CodingKey {
+        case authPath = "auth_path"
+        case position
+        case anchorHeight = "anchor_height"
+    }
+}
+
+// MARK: - TX hash lookup
+
+/// Result of a stored-tx-hash lookup for a delegation or vote bundle.
+public enum VotingTxHashLookup: Equatable, Sendable {
+    /// No record exists for the given key (round/bundle or round/bundle/proposal).
+    case notFound
+    /// A record exists and contains the given tx hash.
+    case present(String)
+}


### PR DESCRIPTION
Tracks zcash/zcash-swift-wallet-sdk#1661.

This PR is part of the Shielded Voting merge sequence (zcash/zcash-swift-wallet-sdk#1687), split for ease of review. It adds a Swift-only public type contract over the JSON shapes that `zcash_voting` will return across the FFI boundary.

## What this PR does

`Sources/ZcashLightClientKit/Rust/Voting/VotingTypes.swift` adds 20 public types, all pure-Swift `Sendable`, most also `Codable`:

- Round / lifecycle: `VotingRoundPhase`, `VotingRoundState`, `VotingRoundSummary`, `VotingHotkey`, `VotingBundleSetupResult`, `VotingVoteRecord`
- Notes and witnesses: `VotingNoteInfo`, `VotingWitnessData`, `VotingVanWitness`
- Delegation: `VotingShareDelegation`, `VotingDelegationProofResult`, `VotingDelegationPirPrecomputeResult`, `VotingDelegationSubmission`, `VotingDelegationInputs`
- Vote bundle: `VotingPczt`, `VotingVoteCommitmentBundle`, `VotingWireEncryptedShare`, `VotingSharePayload`, `VotingCastVoteSignature`
- Lookup: `VotingTxHashLookup`

## Verification

- `swiftlint lint Sources/ZcashLightClientKit/Rust/Voting/VotingTypes.swift` (SwiftLint 0.63.2, repo `.swiftlint.yml`): **0 findings**, **0 `swiftlint:disable` annotations** in the file.
- `swiftc -typecheck Sources/ZcashLightClientKit/Rust/Voting/VotingTypes.swift`: clean (zero output, exit 0).
- `swift build` against this branch: 38 errors, **identical** to the `upstream/main` baseline (`Package.swift` points at the released `libzcashlc` 2.4.6 XCFramework, which lacks newer `zcashlc_eip681_*` symbols already called from `Sources/`). None of the 38 errors reference `VotingTypes.swift`.

## Source compatibility

Strictly additive. No existing public API is changed, no protocol requirements are added, no conformances on existing types are added, and no mock generator output needs to change. The new public types are isolated in their own Swift file in a new `Voting/` subdirectory and are not wired into existing SDK flows in this PR.
