### PR TITLE
[#1661] Add delegation PIR precompute FFI (zcashlc_voting_precompute_delegation_pir)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2547,6 +2547,7 @@ dependencies = [
  "sapling-crypto",
  "secrecy",
  "serde",
+ "serde_json",
  "sharded-slab",
  "tonic",
  "tor-rtcompat",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ ffi_helpers = "0.3"
 uuid = "1.1"
 bitflags = "2"
 serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 
 # HTTP
 bytes = "1"

--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -15,6 +15,12 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   or secret material involved.
 - `zcashlc_voting_validate_pir_proof`: Validate a PIR-fetched IMT
   non-membership proof against an expected root.
+- `zcashlc_voting_db_open`, `zcashlc_voting_db_free`, and
+  `zcashlc_voting_set_wallet_id`: Manage the voting database handle used by
+  stateful voting FFI calls.
+- `zcashlc_voting_precompute_delegation_pir`: Precompute and cache delegation
+  PIR IMT proofs for a voting bundle using the configured voting database and
+  caller-supplied PIR endpoint.
 - Added `zcash_voting 0.5.2` (`default-features = false`, `client-pir`) as a
   Rust dependency.
 

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -4137,7 +4137,7 @@ pub unsafe extern "C" fn zcashlc_tor_lwd_conn_check_single_use_taddr(
 // Utility functions
 //
 
-fn parse_network(value: u32) -> anyhow::Result<Network> {
+pub(crate) fn parse_network(value: u32) -> anyhow::Result<Network> {
     match value {
         0 => Ok(TestNetwork),
         1 => Ok(MainNetwork),

--- a/rust/src/voting.rs
+++ b/rust/src/voting.rs
@@ -3,5 +3,8 @@
 //! Implementation is split into submodules for navigation. Exported FFI functions
 //! keep their stable C symbols with `#[unsafe(no_mangle)]`.
 
+pub mod db;
 pub mod delegation;
+pub mod helpers;
+pub mod json;
 pub mod share_tracking;

--- a/rust/src/voting/db.rs
+++ b/rust/src/voting/db.rs
@@ -1,0 +1,108 @@
+use std::panic::AssertUnwindSafe;
+use std::sync::Arc;
+
+use anyhow::anyhow;
+use ffi_helpers::panic::catch_panic;
+use zcash_voting::storage::VotingDb;
+
+use crate::{unwrap_exc_or, unwrap_exc_or_null};
+
+use super::helpers::str_from_ptr;
+
+/// Opaque handle wrapping the voting database.
+pub struct VotingDatabaseHandle {
+    pub(super) db: Arc<VotingDb>,
+}
+
+/// Open a voting database at the given path.
+///
+/// Returns an opaque `*mut VotingDatabaseHandle` on success, or null on error.
+///
+/// # Safety
+///
+/// - For the `(path, path_len)` byte argument: if `path_len > 0` then `path` must be
+///   non-null and valid for reads for `path_len` bytes; if `path_len == 0`, `path` is
+///   ignored.
+/// - Call `zcashlc_voting_db_free` to free the returned handle.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn zcashlc_voting_db_open(
+    path: *const u8,
+    path_len: usize,
+) -> *mut VotingDatabaseHandle {
+    let res = catch_panic(|| {
+        let path_str = unsafe { str_from_ptr(path, path_len) }?;
+        let db = VotingDb::open(&path_str)
+            .map_err(|e| anyhow!("Error opening voting database: {}", e))?;
+        Ok(Box::into_raw(Box::new(VotingDatabaseHandle {
+            db: Arc::new(db),
+        })))
+    });
+    unwrap_exc_or_null(res)
+}
+
+/// Free a `VotingDatabaseHandle`.
+///
+/// # Safety
+///
+/// - If `ptr` is non-null, it must be a pointer previously returned by
+///   `zcashlc_voting_db_open` that has not already been freed.
+/// - Calling this twice on the same non-null pointer, or on any pointer not obtained
+///   from `zcashlc_voting_db_open`, is undefined behavior.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn zcashlc_voting_db_free(ptr: *mut VotingDatabaseHandle) {
+    if !ptr.is_null() {
+        let s: Box<VotingDatabaseHandle> = unsafe { Box::from_raw(ptr) };
+        drop(s);
+    }
+}
+
+/// Set the wallet identifier for all subsequent voting operations.
+/// Must be called after `zcashlc_voting_db_open` and before any round operations.
+///
+/// Returns 0 on success, -1 on error.
+///
+/// # Safety
+///
+/// - `db` must be a valid, non-null `VotingDatabaseHandle` pointer.
+/// - For the `(wallet_id, wallet_id_len)` byte argument: if `wallet_id_len > 0` then
+///   `wallet_id` must be non-null and valid for reads for `wallet_id_len` bytes; if
+///   `wallet_id_len == 0`, `wallet_id` is ignored.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn zcashlc_voting_set_wallet_id(
+    db: *mut VotingDatabaseHandle,
+    wallet_id: *const u8,
+    wallet_id_len: usize,
+) -> i32 {
+    let db = AssertUnwindSafe(db);
+    let res = catch_panic(|| {
+        let handle =
+            unsafe { db.as_ref() }.ok_or_else(|| anyhow!("VotingDatabaseHandle is null"))?;
+        let wallet_id_str = unsafe { str_from_ptr(wallet_id, wallet_id_len) }?;
+        handle.db.set_wallet_id(&wallet_id_str);
+        Ok(0)
+    });
+    unwrap_exc_or(res, -1)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn db_open_rejects_invalid_utf8_path() {
+        let invalid_path = [0xff];
+        let handle = unsafe { zcashlc_voting_db_open(invalid_path.as_ptr(), invalid_path.len()) };
+        assert!(handle.is_null());
+    }
+
+    #[test]
+    fn db_free_accepts_null() {
+        unsafe { zcashlc_voting_db_free(std::ptr::null_mut()) };
+    }
+
+    #[test]
+    fn set_wallet_id_rejects_null_db() {
+        let code = unsafe { zcashlc_voting_set_wallet_id(std::ptr::null_mut(), b"x".as_ptr(), 1) };
+        assert_eq!(code, -1);
+    }
+}

--- a/rust/src/voting/delegation.rs
+++ b/rust/src/voting/delegation.rs
@@ -1,10 +1,83 @@
+use std::panic::AssertUnwindSafe;
+use std::sync::Arc;
+
 use anyhow::anyhow;
 use ff::PrimeField;
 use ffi_helpers::panic::catch_panic;
 use pasta_curves::pallas;
-use zcash_voting::zkp1;
+use zcash_voting::{self as voting, zkp1};
 
-use crate::unwrap_exc_or;
+use crate::{unwrap_exc_or, unwrap_exc_or_null};
+
+use super::db::VotingDatabaseHandle;
+use super::helpers::{bytes_from_ptr, json_to_boxed_slice, str_from_ptr};
+use super::json::{JsonDelegationPirPrecomputeResult, JsonNoteInfo};
+
+// Keep PIR client construction at the SDK boundary so zcash_voting can accept
+// an injected transport. Today we use direct Hyper/Rustls. In the future this will be the
+// single place to add a Tor-backed transport based on SDK configuration.
+fn connect_pir_client(pir_url: &str) -> anyhow::Result<voting::PirClientBlocking> {
+    voting::PirClientBlocking::with_transport(pir_url, Arc::new(voting::HyperTransport::new()))
+        .map_err(|e| anyhow!("connect to PIR server failed: {}", e))
+}
+
+/// Precompute and cache delegation PIR IMT proofs for the delegation ZKP.
+///
+/// Returns JSON-encoded `DelegationPirPrecomputeResult` as `*mut FfiBoxedSlice`,
+/// or null on error.
+///
+/// # Safety
+///
+/// - `db` must be a valid, non-null `VotingDatabaseHandle` pointer.
+/// - For every `(ptr, len)` byte argument (`round_id`, `notes_json`, `pir_server_url`):
+///   if `len > 0` then `ptr` must be non-null and valid for reads for `len` bytes; if
+///   `len == 0`, `ptr` is ignored. An empty `notes_json` is treated as the empty notes
+///   list (JSON is not parsed).
+/// - `network_id` must be `0` (testnet) or `1` (mainnet), matching other `zcashlc_*` FFI.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn zcashlc_voting_precompute_delegation_pir(
+    db: *mut VotingDatabaseHandle,
+    round_id: *const u8,
+    round_id_len: usize,
+    bundle_index: u32,
+    notes_json: *const u8,
+    notes_json_len: usize,
+    pir_server_url: *const u8,
+    pir_server_url_len: usize,
+    network_id: u32,
+) -> *mut crate::ffi::BoxedSlice {
+    let db = AssertUnwindSafe(db);
+    let res = catch_panic(|| {
+        let handle =
+            unsafe { db.as_ref() }.ok_or_else(|| anyhow!("VotingDatabaseHandle is null"))?;
+        crate::parse_network(network_id)?;
+        let round_id_str = unsafe { str_from_ptr(round_id, round_id_len) }?;
+        let notes_bytes = unsafe { bytes_from_ptr(notes_json, notes_json_len) }?;
+        let json_notes: Vec<JsonNoteInfo> = if notes_bytes.is_empty() {
+            Vec::new()
+        } else {
+            serde_json::from_slice(notes_bytes)?
+        };
+        let core_notes: Vec<voting::NoteInfo> = json_notes.into_iter().map(Into::into).collect();
+        let pir_url = unsafe { str_from_ptr(pir_server_url, pir_server_url_len) }?;
+        let pir_client = connect_pir_client(&pir_url)?;
+
+        let result = handle
+            .db
+            .precompute_delegation_pir(
+                &round_id_str,
+                bundle_index,
+                &core_notes,
+                &pir_client,
+                network_id,
+            )
+            .map_err(|e| anyhow!("precompute_delegation_pir failed: {}", e))?;
+
+        let json_result: JsonDelegationPirPrecomputeResult = result.into();
+        json_to_boxed_slice(&json_result)
+    });
+    unwrap_exc_or_null(res)
+}
 
 /// Depth of the IMT non-membership tree: number of authentication path
 /// siblings in a PIR-fetched proof. Matches `zcash_voting::ImtProofData::path`
@@ -99,6 +172,10 @@ fn parse_path(bytes: &[u8]) -> anyhow::Result<[pallas::Base; NUM_PATH_ELEMENTS]>
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    use crate::voting::db::{
+        zcashlc_voting_db_free, zcashlc_voting_db_open, zcashlc_voting_set_wallet_id,
+    };
 
     // Golden proof generated from zcash_voting's test-only TestImt helper:
     // https://github.com/valargroup/zcash_voting/blob/zcash_voting-v0.5.2/zcash_voting/src/zkp1.rs#L573-L708
@@ -224,5 +301,56 @@ mod tests {
             ),
             -1
         );
+    }
+
+    #[test]
+    fn precompute_delegation_pir_rejects_null_db() {
+        let result = unsafe {
+            zcashlc_voting_precompute_delegation_pir(
+                std::ptr::null_mut(),
+                std::ptr::null(),
+                0,
+                0,
+                std::ptr::null(),
+                0,
+                std::ptr::null(),
+                0,
+                0,
+            )
+        };
+
+        assert!(result.is_null());
+    }
+
+    #[test]
+    fn precompute_delegation_pir_rejects_invalid_network_id() {
+        let mut path = std::env::temp_dir();
+        path.push(format!(
+            "zcashlc_voting_precompute_network_test_{}.sqlite",
+            std::process::id()
+        ));
+        let path_bytes = path.to_string_lossy().as_bytes().to_vec();
+        let db = unsafe { zcashlc_voting_db_open(path_bytes.as_ptr(), path_bytes.len()) };
+        assert!(!db.is_null(), "open voting db");
+        let wallet = b"wallet-id";
+        assert_eq!(0, unsafe {
+            zcashlc_voting_set_wallet_id(db, wallet.as_ptr(), wallet.len())
+        });
+        let result = unsafe {
+            zcashlc_voting_precompute_delegation_pir(
+                db,
+                b"round1".as_ptr(),
+                6,
+                0,
+                b"[]".as_ptr(),
+                2,
+                b"https://example.com/".as_ptr(),
+                20,
+                99,
+            )
+        };
+        assert!(result.is_null());
+        unsafe { zcashlc_voting_db_free(db) };
+        let _ = std::fs::remove_file(&path);
     }
 }

--- a/rust/src/voting/helpers.rs
+++ b/rust/src/voting/helpers.rs
@@ -1,0 +1,74 @@
+use anyhow::anyhow;
+use serde::Serialize;
+
+/// Borrow a byte slice from a raw `(ptr, len)` pair.
+///
+/// When `len == 0`, returns an empty slice without reading `ptr`, so `ptr` may be null.
+///
+/// Centralizing the null + length check here lets every voting FFI byte input — strings,
+/// JSON payloads, anything else — share one boundary contract instead of open-coding it
+/// per call site. `str_from_ptr` now delegates to this helper.
+///
+/// # Safety
+///
+/// When `len > 0`, `ptr` must be non-null and valid for reads for `len` bytes, and the
+/// memory must not be mutated for the duration of the call. The returned slice must not
+/// outlive the underlying allocation.
+pub(super) unsafe fn bytes_from_ptr<'a>(ptr: *const u8, len: usize) -> anyhow::Result<&'a [u8]> {
+    if len == 0 {
+        return Ok(&[]);
+    }
+    if ptr.is_null() {
+        return Err(anyhow!("FFI pointer is null but length is non-zero"));
+    }
+    Ok(unsafe { std::slice::from_raw_parts(ptr, len) })
+}
+
+/// Parse a UTF-8 string from a raw pointer and length.
+///
+/// When `len == 0`, returns the empty string without reading `ptr`, so `ptr` may be null.
+///
+/// # Safety
+///
+/// Same contract as `bytes_from_ptr`.
+pub(super) unsafe fn str_from_ptr(ptr: *const u8, len: usize) -> anyhow::Result<String> {
+    let bytes = unsafe { bytes_from_ptr(ptr, len) }?;
+    Ok(std::str::from_utf8(bytes)?.to_string())
+}
+
+/// Return JSON-serialized bytes as `*mut ffi::BoxedSlice`.
+pub(super) fn json_to_boxed_slice<T: Serialize>(
+    value: &T,
+) -> anyhow::Result<*mut crate::ffi::BoxedSlice> {
+    let json = serde_json::to_vec(value)?;
+    Ok(crate::ffi::BoxedSlice::some(json))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bytes_from_ptr_zero_len_accepts_null() {
+        let bytes = unsafe { bytes_from_ptr(std::ptr::null(), 0) }.expect("empty");
+        assert!(bytes.is_empty());
+    }
+
+    #[test]
+    fn bytes_from_ptr_rejects_null_when_nonzero_len() {
+        let err = unsafe { bytes_from_ptr(std::ptr::null(), 3) }.expect_err("null");
+        assert!(err.to_string().contains("null"));
+    }
+
+    #[test]
+    fn str_from_ptr_zero_len_accepts_null() {
+        let s = unsafe { str_from_ptr(std::ptr::null(), 0) }.expect("empty");
+        assert!(s.is_empty());
+    }
+
+    #[test]
+    fn str_from_ptr_rejects_null_when_nonzero_len() {
+        let err = unsafe { str_from_ptr(std::ptr::null(), 3) }.expect_err("null");
+        assert!(err.to_string().contains("null"));
+    }
+}

--- a/rust/src/voting/json.rs
+++ b/rust/src/voting/json.rs
@@ -1,0 +1,48 @@
+use serde::{Deserialize, Serialize};
+use zcash_voting as voting;
+
+/// JSON-serializable `NoteInfo`.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct JsonNoteInfo {
+    pub commitment: Vec<u8>,
+    pub nullifier: Vec<u8>,
+    pub value: u64,
+    pub position: u64,
+    pub diversifier: Vec<u8>,
+    pub rho: Vec<u8>,
+    pub rseed: Vec<u8>,
+    pub scope: u32,
+    pub ufvk_str: String,
+}
+
+impl From<JsonNoteInfo> for voting::NoteInfo {
+    fn from(n: JsonNoteInfo) -> Self {
+        Self {
+            commitment: n.commitment,
+            nullifier: n.nullifier,
+            value: n.value,
+            position: n.position,
+            diversifier: n.diversifier,
+            rho: n.rho,
+            rseed: n.rseed,
+            scope: n.scope,
+            ufvk_str: n.ufvk_str,
+        }
+    }
+}
+
+/// JSON-serializable `DelegationPirPrecomputeResult`.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct JsonDelegationPirPrecomputeResult {
+    pub cached_count: u32,
+    pub fetched_count: u32,
+}
+
+impl From<voting::DelegationPirPrecomputeResult> for JsonDelegationPirPrecomputeResult {
+    fn from(r: voting::DelegationPirPrecomputeResult) -> Self {
+        Self {
+            cached_count: r.cached_count,
+            fetched_count: r.fetched_count,
+        }
+    }
+}


### PR DESCRIPTION
Tracks zcash#1661.

Next incremental step in the Shielded Voting merge sequence (zcash#1687). zcash#1702 brought `zcash_voting`'s `client-pir` graph into the SDK and proved end-to-end FFI linkage with one pure-function symbol (`zcashlc_voting_validate_pir_proof`).

This PR is the first user of `client-pir`'s **stateful** path: it adds `zcashlc_voting_precompute_delegation_pir`, which precomputes and caches delegation IMT proofs in the voting database for a given round/bundle. It also lands the minimum DB-handle and serde scaffolding that every later voting FFI in this sequence will reuse unchanged.

## Version changes

`serde_json` is already in the resolved graph through `zcash_client_backend`; declaring it directly only grants `libzcashlc` visibility for `serde_json::from_slice` / `to_vec` to round-trip `Vec<NoteInfo>` and `DelegationPirPrecomputeResult` across the C boundary. No new resolved version, no new transitive crates.

## What the new FFI does — and what it deliberately does not do

`rust/src/voting/delegation.rs` exposes one new symbol on top of zcash#1702:

```rust
#[unsafe(no_mangle)]
pub unsafe extern "C" fn zcashlc_voting_precompute_delegation_pir(
    db: *mut VotingDatabaseHandle,
    round_id:        *const u8, round_id_len:        usize,
    bundle_index:    u32,
    notes_json:      *const u8, notes_json_len:      usize,
    pir_server_url:  *const u8, pir_server_url_len:  usize,
    network_id:      u32,
) -> *mut crate::ffi::BoxedSlice
```

It deserializes a caller-supplied `Vec<NoteInfo>` from JSON, constructs a `PirClientBlocking` against `pir_server_url` via `voting::HyperTransport`, calls `VotingDb::precompute_delegation_pir`, and returns a JSON-encoded `DelegationPirPrecomputeResult { cached_count, fetched_count }`. Returns null on error.

PIR client construction is intentionally kept at the SDK boundary (`connect_pir_client` in `delegation.rs`) so that `zcash_voting` accepts an injected transport. Today this uses direct Hyper/Rustls; this is the single place a future Tor-backed transport will be plugged in based on SDK configuration.

## Source compatibility

No public Swift API changes. No new Swift wrapper. No `Synchronizer` protocol additions or default implementations. Existing call sites and downstream conformers compile unchanged.
