### PR TITLE
[#1661] Add VotingRustBackend Swift wrapper for compute_share_nullifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `zcash_voting` dependency foundation: SDK Rust crate now depends on `zcash_voting 0.5.2` (`default-features = false`, `client-pir`) and exposes pure-function FFI symbols for share-nullifier computation and PIR proof validation. No Swift API surface is added in this step.
 - `PirSnapshotResolver`, `PirSnapshotResolverError`, `PirSnapshotProbeOutcome`, `PirSnapshotProbing`, and `HTTPPirSnapshotProbe`: Select a vote-nullifier PIR endpoint whose `/root` metadata exactly matches a voting round's expected snapshot height.
 - `Voting*` Swift types: public type contract for the shielded voting FFI boundary, in `Sources/ZcashLightClientKit/Rust/Voting/VotingTypes.swift`.
+- `VotingRustBackend`: Swift wrapper for the voting `libzcashlc` surface. Exposes the static `computeShareNullifier` over `zcashlc_voting_compute_share_nullifier` and the `VotingRustBackendError` error type.
 
 ## Changed
 - Bumped Rust dependencies to current crates.io releases (`zcash_address` 0.10→0.11, `zcash_client_backend` 0.21→0.22, `zcash_client_sqlite` 0.19→0.20, `zcash_primitives`/`zcash_proofs` 0.26→0.27, `zcash_protocol` 0.7→0.8, `zcash_transparent` 0.6→0.7, `sapling-crypto` 0.6→0.7, `orchard` 0.12→0.13, `pczt` 0.5→0.6) and removed the `[patch.crates-io]` git-rev overrides. No public Swift API changes.

--- a/Sources/ZcashLightClientKit/Rust/Voting/VotingRustBackend.swift
+++ b/Sources/ZcashLightClientKit/Rust/Voting/VotingRustBackend.swift
@@ -1,0 +1,110 @@
+//
+//  VotingRustBackend.swift
+//  ZcashLightClientKit
+//
+
+import Foundation
+import libzcashlc
+
+// MARK: - Error
+
+/// Error type for voting Rust backend operations.
+public enum VotingRustBackendError: LocalizedError, Equatable {
+    /// The voting database is already open.
+    case databaseAlreadyOpen
+    /// The voting database is not open.
+    case databaseNotOpen
+    /// A Rust error occurred.
+    case rustError(String)
+    /// Invalid data was received.
+    case invalidData(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .databaseAlreadyOpen:
+            return "Voting database is already open."
+        case .databaseNotOpen:
+            return "Voting database is not open."
+        case .rustError(let message):
+            return "Voting backend error: \(message)"
+        case .invalidData(let message):
+            return "Invalid data: \(message)"
+        }
+    }
+}
+
+// MARK: - VotingRustBackend
+
+/// Swift wrapper for the voting `libzcashlc` surface.
+public enum VotingRustBackend {}
+
+// MARK: - Share tracking
+
+extension VotingRustBackend {
+    /// Byte width of a Pallas base-field element as expected by the voting FFI.
+    private static let fieldElementByteCount = 32
+
+    /// Compute the nullifier for a vote share.
+    ///
+    /// - Parameters:
+    ///   - voteCommitment: 32-byte canonical Pallas-base-field encoding.
+    ///   - shareIndex: Position of the share within its vote.
+    ///   - primaryBlind: 32-byte canonical Pallas-base-field encoding.
+    /// - Returns: 32-byte nullifier as 64 lowercase hex characters.
+    /// - Throws: `VotingRustBackendError.invalidData` if either byte array is not
+    ///   exactly 32 bytes; `VotingRustBackendError.rustError` if the underlying
+    ///   Rust computation fails (for example, non-canonical field encoding).
+    public static func computeShareNullifier(
+        voteCommitment: [UInt8],
+        shareIndex: UInt32,
+        primaryBlind: [UInt8]
+    ) throws -> String {
+        guard
+            voteCommitment.count == fieldElementByteCount,
+            primaryBlind.count == fieldElementByteCount
+        else {
+            throw VotingRustBackendError.invalidData(
+                "voteCommitment and primaryBlind must each be exactly \(fieldElementByteCount) bytes"
+            )
+        }
+
+        let ptr = voteCommitment.withUnsafeBufferPointer { vcBuf in
+            primaryBlind.withUnsafeBufferPointer { blindBuf in
+                zcashlc_voting_compute_share_nullifier(
+                    vcBuf.baseAddress,
+                    blindBuf.baseAddress,
+                    shareIndex
+                )
+            }
+        }
+
+        guard let ptr else {
+            throw VotingRustBackendError.rustError(
+                staticLastErrorMessage(fallback: "`compute_share_nullifier` failed")
+            )
+        }
+        defer { zcashlc_string_free(ptr) }
+        return String(cString: ptr)
+    }
+}
+
+// MARK: - Private helpers
+
+private extension VotingRustBackend {
+    /// Reads the last error recorded by `libzcashlc` and clears it as a side
+    /// effect, so subsequent failures do not surface a stale message.
+    static func staticLastErrorMessage(fallback: String) -> String {
+        let errorLen = zcashlc_last_error_length()
+        defer { zcashlc_clear_last_error() }
+
+        if errorLen > 0 {
+            let error = UnsafeMutablePointer<Int8>.allocate(capacity: Int(errorLen))
+            defer { error.deallocate() }
+            zcashlc_error_message_utf8(error, errorLen)
+            if let msg = String(validatingUTF8: error) {
+                return msg
+            }
+        }
+        return fallback
+    }
+}

--- a/Tests/OfflineTests/VotingRustBackendTests.swift
+++ b/Tests/OfflineTests/VotingRustBackendTests.swift
@@ -1,0 +1,60 @@
+//
+//  VotingRustBackendTests.swift
+//  ZcashLightClientKitTests
+//
+
+import XCTest
+@testable import ZcashLightClientKit
+
+final class VotingRustBackendTests: XCTestCase {
+    func test_computeShareNullifier_returnsExpectedValueForKnownFixture() throws {
+        // Well-formed 32-byte fixtures.
+        var voteCommitment = [UInt8](repeating: 0, count: 32)
+        voteCommitment[0] = 0x01
+        var primaryBlind = [UInt8](repeating: 0, count: 32)
+        primaryBlind[0] = 0x03
+
+        let nullifier = try VotingRustBackend.computeShareNullifier(
+            voteCommitment: voteCommitment,
+            shareIndex: 0,
+            primaryBlind: primaryBlind
+        )
+
+        // Captured from the Rust reference implementation
+        // (`zcash_voting::share_tracking::compute_share_nullifier`) for the
+        // fixture above. Update only if the upstream algorithm intentionally
+        // changes. A mismatch otherwise indicates the FFI wrapper is feeding
+        // arguments incorrectly or mangling the output.
+        XCTAssertEqual(
+            nullifier,
+            "058ffd2e1ba7acaf97b167accfb4ec141b91c0ee2a0f552631851ac97ca1e61d"
+        )
+    }
+
+    func test_computeShareNullifier_throwsInvalidData_whenInputsAreNot32Bytes() {
+        let valid = [UInt8](repeating: 0x01, count: 32)
+        let tooShort = [UInt8](repeating: 0x01, count: 31)
+        let tooLong = [UInt8](repeating: 0x01, count: 33)
+
+        for (vc, blind, label) in [
+            (tooShort, valid, "voteCommitment too short"),
+            (tooLong, valid, "voteCommitment too long"),
+            (valid, tooShort, "primaryBlind too short"),
+            (valid, tooLong, "primaryBlind too long")
+        ] {
+            XCTAssertThrowsError(
+                try VotingRustBackend.computeShareNullifier(
+                    voteCommitment: vc,
+                    shareIndex: 0,
+                    primaryBlind: blind
+                ),
+                label
+            ) { error in
+                guard case VotingRustBackendError.invalidData = error else {
+                    XCTFail("\(label): expected .invalidData, got \(error)")
+                    return
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Tracks #1661.

This PR lands the **first Swift wrapper** on top of voting Rust backend: a thin, public Swift entry point for share-nullifier computation, plus the minimum error and helper scaffolding that subsequent voting wrappers will reuse unchanged.

The Rust FFI for this was merged here: https://github.com/zcash/zcash-swift-wallet-sdk/pull/1699

No breaking Swift API changes.

## Tests

`Tests/OfflineTests/VotingRustBackendTests.swift` exercises the end-to-end FFI round-trip on the happy path (output is a 64-character lowercase hex string) and verifies the boundary check throws `.invalidData` for arrays of length 31 or 33 on either input. Both tests run under:

```bash
swift test --filter VotingRustBackendTests
```