### PR TITLE
[#1661] Add voting tree-sync FFI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,10 +19,12 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `Broadcaster.createTransactionFromPCZT(pcztWithProofs:pcztWithSigs:)` — extracts and stores a transaction from PCZT data without submitting.
   - `Broadcaster.submit(_:to:)` — submits raw transaction bytes to a specific `LightWalletEndpoint`. Respects Tor configuration.
 - `Synchronizer.broadcaster` property, also exposed through the closure and Combine synchronizer facades, to access the `Broadcaster` from SDK synchronizer instances.
+- `libzcashlc` voting tree-sync FFI: `zcashlc_voting_sync_vote_tree`, `zcashlc_voting_generate_van_witness`, and `zcashlc_voting_reset_tree_client`. Operate on the existing `VotingDatabaseHandle`, which also carries a `zcash_voting::tree_sync::VoteTreeSync` constructed in `zcashlc_voting_db_open`.
 
 ## Changed
 - Bumped Rust dependencies to current crates.io releases (`zcash_address` 0.10→0.11, `zcash_client_backend` 0.21→0.22, `zcash_client_sqlite` 0.19→0.20, `zcash_primitives`/`zcash_proofs` 0.26→0.27, `zcash_protocol` 0.7→0.8, `zcash_transparent` 0.6→0.7, `sapling-crypto` 0.6→0.7, `orchard` 0.12→0.13, `pczt` 0.5→0.6) and removed the `[patch.crates-io]` git-rev overrides. No public Swift API changes.
 - Pinned `orchard` to `=0.13.1` and enabled its `unstable-voting-circuits` feature, required transitively by `zcash_voting`. No public Swift API changes.
+- Enabled the `client-tree-sync` feature on `zcash_voting`, required by the new voting tree-sync FFI listed above.
 
 # 2.4.9 - 2026-04-04
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6148,6 +6148,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
+name = "vote-commitment-tree"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0fb2456313f571003c0bed8d38fb166d78da85653caf828823c1a82f4e1aef1"
+dependencies = [
+ "anyhow",
+ "ff",
+ "halo2_gadgets",
+ "imt-tree",
+ "incrementalmerkletree",
+ "lazy_static",
+ "libc",
+ "pasta_curves",
+ "shardtree",
+]
+
+[[package]]
+name = "vote-commitment-tree-client"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb05b7a0434a89c2d9017bbab9a5157f1992fb746dce58a1077669e9dd0a13c5"
+dependencies = [
+ "base64",
+ "ff",
+ "hex",
+ "pasta_curves",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "vote-commitment-tree",
+]
+
+[[package]]
 name = "voting-circuits"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7117,6 +7150,9 @@ dependencies = [
  "serde_json",
  "subtle",
  "thiserror 2.0.18",
+ "tokio",
+ "vote-commitment-tree",
+ "vote-commitment-tree-client",
  "voting-circuits",
  "zcash_keys",
  "zcash_primitives",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,7 +83,10 @@ rust_decimal = { version = "1", default-features = false, features = ["c-repr"] 
 xz2 = { version = "0.1", features = ["static"] }
 
 # Voting
-zcash_voting = { version = "0.5.2", default-features = false, features = ["client-pir"] }
+zcash_voting = { version = "0.5.2", default-features = false, features = [
+    "client-pir",
+    "client-tree-sync",
+] }
 
 [build-dependencies]
 bindgen = "0.72"

--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -21,12 +21,26 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `zcashlc_voting_precompute_delegation_pir`: Precompute and cache delegation
   PIR IMT proofs for a voting bundle using the configured voting database and
   caller-supplied PIR endpoint.
+- `zcashlc_voting_sync_vote_tree`: Sync the vote commitment tree for a round
+  from a chain node URL, returning the latest synced block height (>= 0) on
+  success, or -1 on error.
+- `zcashlc_voting_generate_van_witness`: Generate a vote authroity note Merkle witness for
+  the second voting ZKP and return it as a JSON-encoded `VanWitness`
+  (`auth_path`, `position`, `anchor_height`) in a `*mut FfiBoxedSlice`.
+- `zcashlc_voting_reset_tree_client`: Drop the in-memory tree client for a
+  round so the next `zcashlc_voting_sync_vote_tree` call creates a fresh one.
+- `VotingDatabaseHandle` now also carries a
+  `zcash_voting::tree_sync::VoteTreeSync`, constructed in
+  `zcashlc_voting_db_open` and consumed by the tree-sync FFI above.
 - Added `zcash_voting 0.5.2` (`default-features = false`, `client-pir`) as a
   Rust dependency.
 
 ### Changed
 - Pinned `orchard` to `=0.13.1` and enabled its `unstable-voting-circuits`
   feature (required transitively by `zcash_voting`).
+- Enabled the `client-tree-sync` feature on `zcash_voting`, required by the
+  new tree-sync FFI symbols and by the `VoteTreeSync` field on
+  `VotingDatabaseHandle`.
 
 ## 2.4.6 - 2026-03-12
 

--- a/rust/src/voting.rs
+++ b/rust/src/voting.rs
@@ -8,3 +8,4 @@ pub mod delegation;
 pub mod helpers;
 pub mod json;
 pub mod share_tracking;
+pub mod tree;

--- a/rust/src/voting/db.rs
+++ b/rust/src/voting/db.rs
@@ -4,14 +4,16 @@ use std::sync::Arc;
 use anyhow::anyhow;
 use ffi_helpers::panic::catch_panic;
 use zcash_voting::storage::VotingDb;
+use zcash_voting::tree_sync::VoteTreeSync;
 
 use crate::{unwrap_exc_or, unwrap_exc_or_null};
 
 use super::helpers::str_from_ptr;
 
-/// Opaque handle wrapping the voting database.
+/// Opaque handle wrapping the voting database and its tree-sync state.
 pub struct VotingDatabaseHandle {
     pub(super) db: Arc<VotingDb>,
+    pub(super) tree_sync: VoteTreeSync,
 }
 
 /// Open a voting database at the given path.
@@ -35,6 +37,7 @@ pub unsafe extern "C" fn zcashlc_voting_db_open(
             .map_err(|e| anyhow!("Error opening voting database: {}", e))?;
         Ok(Box::into_raw(Box::new(VotingDatabaseHandle {
             db: Arc::new(db),
+            tree_sync: VoteTreeSync::new(),
         })))
     });
     unwrap_exc_or_null(res)

--- a/rust/src/voting/json.rs
+++ b/rust/src/voting/json.rs
@@ -46,3 +46,24 @@ impl From<voting::DelegationPirPrecomputeResult> for JsonDelegationPirPrecompute
         }
     }
 }
+
+/// JSON-serializable VanWitness.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct JsonVanWitness {
+    /// The authentication path for the witness.
+    pub auth_path: Vec<Vec<u8>>,
+    /// The position of the witness.
+    pub position: u32,
+    /// The anchor height of the witness.
+    pub anchor_height: u32,
+}
+
+impl From<voting::tree_sync::VanWitness> for JsonVanWitness {
+    fn from(w: voting::tree_sync::VanWitness) -> Self {
+        Self {
+            auth_path: w.auth_path.iter().map(|h| h.to_vec()).collect(),
+            position: w.position,
+            anchor_height: w.anchor_height,
+        }
+    }
+}

--- a/rust/src/voting/tree.rs
+++ b/rust/src/voting/tree.rs
@@ -1,0 +1,106 @@
+use std::panic::AssertUnwindSafe;
+
+use anyhow::anyhow;
+use ffi_helpers::panic::catch_panic;
+
+use crate::{unwrap_exc_or, unwrap_exc_or_null};
+
+use super::db::VotingDatabaseHandle;
+use super::helpers::{json_to_boxed_slice, str_from_ptr};
+use super::json::JsonVanWitness;
+
+// =============================================================================
+// VotingDatabase methods — Tree sync
+// =============================================================================
+
+/// Sync the vote commitment tree from a chain node.
+///
+/// Returns the latest synced block height on success (>= 0), or -1 on error.
+///
+/// # Safety
+///
+/// - `db` must be a valid, non-null `VotingDatabaseHandle` pointer.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn zcashlc_voting_sync_vote_tree(
+    db: *mut VotingDatabaseHandle,
+    round_id: *const u8,
+    round_id_len: usize,
+    node_url: *const u8,
+    node_url_len: usize,
+) -> i64 {
+    let db = AssertUnwindSafe(db);
+    let res = catch_panic(|| {
+        let handle =
+            unsafe { db.as_ref() }.ok_or_else(|| anyhow!("VotingDatabaseHandle is null"))?;
+        let round_id_str = unsafe { str_from_ptr(round_id, round_id_len) }?;
+        let url = unsafe { str_from_ptr(node_url, node_url_len) }?;
+
+        let height = handle
+            .tree_sync
+            .sync(&handle.db, &round_id_str, &url)
+            .map_err(|e| anyhow!("sync_vote_tree failed: {}", e))?;
+        Ok(height as i64)
+    });
+    unwrap_exc_or(res, -1)
+}
+
+/// Generate a Vote Authority Note (VAN) Merkle witness.
+///
+/// Returns JSON-encoded `VanWitness` as `*mut FfiBoxedSlice`, or null on error.
+///
+/// # Safety
+///
+/// - `db` must be a valid, non-null `VotingDatabaseHandle` pointer.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn zcashlc_voting_generate_van_witness(
+    db: *mut VotingDatabaseHandle,
+    round_id: *const u8,
+    round_id_len: usize,
+    bundle_index: u32,
+    anchor_height: u32,
+) -> *mut crate::ffi::BoxedSlice {
+    let db = AssertUnwindSafe(db);
+    let res = catch_panic(|| {
+        let handle =
+            unsafe { db.as_ref() }.ok_or_else(|| anyhow!("VotingDatabaseHandle is null"))?;
+        let round_id_str = unsafe { str_from_ptr(round_id, round_id_len) }?;
+
+        let witness = handle
+            .tree_sync
+            .generate_van_witness(&handle.db, &round_id_str, bundle_index, anchor_height)
+            .map_err(|e| anyhow!("generate_van_witness failed: {}", e))?;
+
+        let json_witness: JsonVanWitness = witness.into();
+        json_to_boxed_slice(&json_witness)
+    });
+    unwrap_exc_or_null(res)
+}
+
+/// Drop the in-memory TreeClient so the next `sync_vote_tree()` call
+/// creates a fresh one.
+///
+/// Returns 0 on success, -1 on error.
+///
+/// # Safety
+///
+/// - `db` must be a valid, non-null `VotingDatabaseHandle` pointer.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn zcashlc_voting_reset_tree_client(
+    db: *mut VotingDatabaseHandle,
+    round_id: *const u8,
+    round_id_len: usize,
+) -> i32 {
+    let db = AssertUnwindSafe(db);
+    let res = catch_panic(|| {
+        let handle =
+            unsafe { db.as_ref() }.ok_or_else(|| anyhow!("VotingDatabaseHandle is null"))?;
+        let round_id_str = unsafe { str_from_ptr(round_id, round_id_len) }?;
+
+        handle
+            .tree_sync
+            .reset(&round_id_str)
+            .map_err(|e| anyhow!("reset_tree_client failed: {}", e))?;
+        Ok(0)
+    });
+    unwrap_exc_or(res, -1)
+}


### PR DESCRIPTION
References zcash/zcash-swift-wallet-sdk#1661

## Summary

This PR enables the vote commitment tree import from `zcash_voting`

See the tree crate [here](https://github.com/valargroup/zcash_voting/tree/main/vote-commitment-tree) and the client [here](https://github.com/valargroup/zcash_voting/tree/main/vote-commitment-tree-client).

Vote commitment tree is a tree of [Vote Authority Notes](https://valargroup.gitbook.io/shielded-vote-docs/data-types/data-types#vote-authority-note-van) and [Vote Commitments](https://valargroup.gitbook.io/shielded-vote-docs/data-types/data-types#vote-commitment-vc).

Under the hood, it is the same shard tree implementation as Zcash mainnet is for notes, with the replacement of Sinsemilla hash to Poseidon for performance reasons.

See context [here](https://valargroup.gitbook.io/shielded-vote-docs/data-types/data-types#vote-commitment-tree-vct)

This PR brings in the import and all APIs that use the vote-commitment tree. 