### PR TITLE
[#1661] Add voting wallet-notes and Orchard FVK extraction FFI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,11 +20,14 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `Broadcaster.submit(_:to:)` — submits raw transaction bytes to a specific `LightWalletEndpoint`. Respects Tor configuration.
 - `Synchronizer.broadcaster` property, also exposed through the closure and Combine synchronizer facades, to access the `Broadcaster` from SDK synchronizer instances.
 - `libzcashlc` voting tree-sync FFI: `zcashlc_voting_sync_vote_tree`, `zcashlc_voting_generate_van_witness`, and `zcashlc_voting_reset_tree_client`. Operate on the existing `VotingDatabaseHandle`, which also carries a `zcash_voting::tree_sync::VoteTreeSync` constructed in `zcashlc_voting_db_open`.
+- `libzcashlc` voting wallet-notes FFI: `zcashlc_voting_get_wallet_notes`. Loads unspent Orchard notes for a wallet account at a snapshot height and returns them as a JSON-encoded `Vec<NoteInfo>`, suitable as the `notes` input to `zcashlc_voting_precompute_delegation_pir`. `account_uuid` must be a non-null pointer to exactly 16 bytes; otherwise the call fails (returns null).
+- `libzcashlc` voting key-utility FFI: `zcashlc_voting_extract_orchard_fvk_from_ufvk`. Decodes a UFVK string and returns the raw 96-byte Orchard FVK. Returns null on missing Orchard component, malformed UFVK, or invalid `network_id`.
 
 ## Changed
 - Bumped Rust dependencies to current crates.io releases (`zcash_address` 0.10→0.11, `zcash_client_backend` 0.21→0.22, `zcash_client_sqlite` 0.19→0.20, `zcash_primitives`/`zcash_proofs` 0.26→0.27, `zcash_protocol` 0.7→0.8, `zcash_transparent` 0.6→0.7, `sapling-crypto` 0.6→0.7, `orchard` 0.12→0.13, `pczt` 0.5→0.6) and removed the `[patch.crates-io]` git-rev overrides. No public Swift API changes.
 - Pinned `orchard` to `=0.13.1` and enabled its `unstable-voting-circuits` feature, required transitively by `zcash_voting`. No public Swift API changes.
 - Enabled the `client-tree-sync` feature on `zcash_voting`, required by the new voting tree-sync FFI listed above.
+- Added `zcash_keys 0.13` (`orchard` feature) as a Rust dependency, used by the new voting wallet-notes and key-utility FFI to decode UFVKs and derive Orchard FVKs. No public Swift API changes.
 
 # 2.4.9 - 2026-04-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `SDKSynchronizer.rescanFrom(height:)`: Rescans the chain from the given BlockHeight.
 - `SynchronizerState.fullyScannedHeight`: Contiguous-from-birthday scan high-water mark published on `stateStream`/`latestState`. Callers that need an authoritative view of the wallet's note and nullifier state at a specific height (for example, balance anchored at a poll snapshot) should gate on this rather than `latestBlockHeight` (chain tip) or `maxScannedHeight` (head-first scan progress, which can race ahead under Spend-before-Sync).
 - `Synchronizer.getTreeState(height:)`: Fetches the commitment tree state at the given block height from lightwalletd and returns the protobuf-serialized `TreeState` bytes, for app-layer consumers that need to hand tree state to an external component (for example, witness generation via FFI). A throwing default implementation keeps the addition source-compatible for downstream `Synchronizer` conformers.
-- `zcash_voting` dependency foundation: SDK Rust crate now depends on `zcash_voting 0.5.2` (`default-features = false`, `client-pir`) and exposes pure-function FFI symbols for share-nullifier computation and PIR proof validation. No Swift API surface is added in this step.
+- `zcash_voting` dependency foundation: SDK Rust crate now depends on `zcash_voting 0.5.3` (`default-features = false`, `client-pir`) and exposes pure-function FFI symbols for share-nullifier computation and PIR proof validation. No Swift API surface is added in this step.
 - `PirSnapshotResolver`, `PirSnapshotResolverError`, `PirSnapshotProbeOutcome`, `PirSnapshotProbing`, and `HTTPPirSnapshotProbe`: Select a vote-nullifier PIR endpoint whose `/root` metadata exactly matches a voting round's expected snapshot height.
 - `Voting*` Swift types: public type contract for the shielded voting FFI boundary, in `Sources/ZcashLightClientKit/Rust/Voting/VotingTypes.swift`.
 - `VotingRustBackend`: Swift wrapper for the voting `libzcashlc` surface. Exposes the static `computeShareNullifier` over `zcashlc_voting_compute_share_nullifier` and the `VotingRustBackendError` error type.
@@ -28,6 +28,7 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Pinned `orchard` to `=0.13.1` and enabled its `unstable-voting-circuits` feature, required transitively by `zcash_voting`. No public Swift API changes.
 - Enabled the `client-tree-sync` feature on `zcash_voting`, required by the new voting tree-sync FFI listed above.
 - Added `zcash_keys 0.13` (`orchard` feature) as a Rust dependency, used by the new voting wallet-notes and key-utility FFI to decode UFVKs and derive Orchard FVKs. No public Swift API changes.
+- Bumped `zcash_voting` to `0.5.3` so `network_id` matches the SDK (`0` = testnet, `1` = mainnet) end-to-end for wallet-notes JSON consumed by delegation PIR. No public Swift API changes.
 
 # 2.4.9 - 2026-04-04
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7122,9 +7122,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_voting"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d33a1676b7c56bc58724b5537d77c78b24b3eed39aecfcc79323809fe66cfc7f"
+checksum = "90abca13341b344d82315895bf50f26e93a66b5c4d2fbd8591728af604d4d4db"
 dependencies = [
  "anyhow",
  "blake2b_simd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2558,6 +2558,7 @@ dependencies = [
  "zcash_address",
  "zcash_client_backend",
  "zcash_client_sqlite",
+ "zcash_keys",
  "zcash_note_encryption",
  "zcash_primitives",
  "zcash_proofs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,7 +83,7 @@ rust_decimal = { version = "1", default-features = false, features = ["c-repr"] 
 xz2 = { version = "0.1", features = ["static"] }
 
 # Voting
-zcash_voting = { version = "0.5.2", default-features = false, features = [
+zcash_voting = { version = "0.5.3", default-features = false, features = [
     "client-pir",
     "client-tree-sync",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,6 +87,7 @@ zcash_voting = { version = "0.5.2", default-features = false, features = [
     "client-pir",
     "client-tree-sync",
 ] }
+zcash_keys = { version = "0.13", features = ["orchard"] }
 
 [build-dependencies]
 bindgen = "0.72"

--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -42,7 +42,7 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   return the raw 96-byte Orchard full viewing key in a
   `*mut FfiBoxedSlice`. Returns `NULL` on missing Orchard component,
   malformed UFVK, or invalid `network_id`.
-- Added `zcash_voting 0.5.2` (`default-features = false`, `client-pir`,
+- Added `zcash_voting 0.5.3` (`default-features = false`, `client-pir`,
   `client-tree-sync`) as a Rust dependency.
 - Added `zcash_keys 0.13` (`orchard` feature) as a Rust dependency, used by
   the new wallet-notes and key-utility FFI for voting to decode UFVKs and derive

--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -24,7 +24,7 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `zcashlc_voting_sync_vote_tree`: Sync the vote commitment tree for a round
   from a chain node URL, returning the latest synced block height (>= 0) on
   success, or -1 on error.
-- `zcashlc_voting_generate_van_witness`: Generate a vote authroity note Merkle witness for
+- `zcashlc_voting_generate_van_witness`: Generate a vote authority note Merkle witness for
   the second voting ZKP and return it as a JSON-encoded `VanWitness`
   (`auth_path`, `position`, `anchor_height`) in a `*mut FfiBoxedSlice`.
 - `zcashlc_voting_reset_tree_client`: Drop the in-memory tree client for a
@@ -32,8 +32,21 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `VotingDatabaseHandle` now also carries a
   `zcash_voting::tree_sync::VoteTreeSync`, constructed in
   `zcashlc_voting_db_open` and consumed by the tree-sync FFI above.
-- Added `zcash_voting 0.5.2` (`default-features = false`, `client-pir`) as a
-  Rust dependency.
+- `zcashlc_voting_get_wallet_notes`: Load unspent Orchard notes for a wallet
+  account at a snapshot height and return them as JSON-encoded
+  `Vec<NoteInfo>` in a `*mut FfiBoxedSlice`. `account_uuid` must be a non-null
+  pointer to exactly 16 bytes (binary account UUID). Returns `NULL` on error
+  or panic. Output is suitable as the `notes_json` input to
+  `zcashlc_voting_precompute_delegation_pir`.
+- `zcashlc_voting_extract_orchard_fvk_from_ufvk`: Decode a UFVK string and
+  return the raw 96-byte Orchard full viewing key in a
+  `*mut FfiBoxedSlice`. Returns `NULL` on missing Orchard component,
+  malformed UFVK, or invalid `network_id`.
+- Added `zcash_voting 0.5.2` (`default-features = false`, `client-pir`,
+  `client-tree-sync`) as a Rust dependency.
+- Added `zcash_keys 0.13` (`orchard` feature) as a Rust dependency, used by
+  the new wallet-notes and key-utility FFI for voting to decode UFVKs and derive
+  Orchard FVKs.
 
 ### Changed
 - Pinned `orchard` to `=0.13.1` and enabled its `unstable-voting-circuits`

--- a/rust/src/ffi.rs
+++ b/rust/src/ffi.rs
@@ -636,6 +636,21 @@ impl BoxedSlice {
             len: 0,
         }))
     }
+
+    /// Borrow the slice contents. Intended for crate-internal use (notably tests).
+    ///
+    /// # Safety
+    ///
+    /// Same invariants as the [`BoxedSlice`] struct documentation: `ptr` must be valid
+    /// for reads of `len` bytes (or `len == 0`).
+    #[cfg(test)]
+    pub(crate) unsafe fn as_slice(&self) -> &[u8] {
+        if self.len == 0 || self.ptr.is_null() {
+            &[]
+        } else {
+            unsafe { std::slice::from_raw_parts(self.ptr, self.len) }
+        }
+    }
 }
 
 /// Frees a [`BoxedSlice`].

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -4137,13 +4137,23 @@ pub unsafe extern "C" fn zcashlc_tor_lwd_conn_check_single_use_taddr(
 // Utility functions
 //
 
+/// `network_id` value for Testnet, accepted by [`parse_network`] and every
+/// `zcashlc_*` FFI that takes a `network_id` parameter.
+pub(crate) const NETWORK_ID_TESTNET: u32 = 0;
+
+/// `network_id` value for Mainnet, accepted by [`parse_network`] and every
+/// `zcashlc_*` FFI that takes a `network_id` parameter.
+pub(crate) const NETWORK_ID_MAINNET: u32 = 1;
+
 pub(crate) fn parse_network(value: u32) -> anyhow::Result<Network> {
     match value {
-        0 => Ok(TestNetwork),
-        1 => Ok(MainNetwork),
+        NETWORK_ID_TESTNET => Ok(TestNetwork),
+        NETWORK_ID_MAINNET => Ok(MainNetwork),
         _ => Err(anyhow!(
-            "Invalid network type: {}. Expected either 0 or 1 for Testnet or Mainnet, respectively.",
-            value
+            "Invalid network type: {}. Expected either {} or {} for Testnet or Mainnet, respectively.",
+            value,
+            NETWORK_ID_TESTNET,
+            NETWORK_ID_MAINNET,
         )),
     }
 }

--- a/rust/src/voting.rs
+++ b/rust/src/voting.rs
@@ -7,5 +7,7 @@ pub mod db;
 pub mod delegation;
 pub mod helpers;
 pub mod json;
+pub mod notes;
 pub mod share_tracking;
 pub mod tree;
+pub mod util;

--- a/rust/src/voting/delegation.rs
+++ b/rust/src/voting/delegation.rs
@@ -178,7 +178,7 @@ mod tests {
     };
 
     // Golden proof generated from zcash_voting's test-only TestImt helper:
-    // https://github.com/valargroup/zcash_voting/blob/zcash_voting-v0.5.2/zcash_voting/src/zkp1.rs#L573-L708
+    // https://github.com/valargroup/zcash_voting/blob/zcash_voting-v0.5.3/zcash_voting/src/zkp1.rs#L573-L708
     // Keeping the fixture as bytes preserves FFI coverage without direct SDK
     // dev-dependencies on halo2_gadgets or voting-circuits internals.
     const ROOT: &str = "8a9fa2daeb635fbb006af674259cea05e59d71b9a4773e7433942a14ab031801";

--- a/rust/src/voting/helpers.rs
+++ b/rust/src/voting/helpers.rs
@@ -1,5 +1,12 @@
 use anyhow::anyhow;
+use orchard::note::ExtractedNoteCommitment;
 use serde::Serialize;
+use zcash_client_sqlite::util::SystemClock;
+use zcash_keys::keys::UnifiedFullViewingKey;
+use zcash_protocol::consensus;
+use zcash_protocol::consensus::Network;
+use zcash_voting as voting;
+use zip32::Scope;
 
 /// Borrow a byte slice from a raw `(ptr, len)` pair.
 ///
@@ -42,6 +49,65 @@ pub(super) fn json_to_boxed_slice<T: Serialize>(
 ) -> anyhow::Result<*mut crate::ffi::BoxedSlice> {
     let json = serde_json::to_vec(value)?;
     Ok(crate::ffi::BoxedSlice::some(json))
+}
+
+/// Convert a librustzcash ReceivedNote (orchard) into zcash_voting's NoteInfo.
+///
+/// Requires the account's UFVK and network to compute the nullifier and
+/// encode the UFVK string.
+pub(super) fn received_note_to_note_info<P: consensus::Parameters>(
+    note: &zcash_client_backend::wallet::ReceivedNote<
+        zcash_client_sqlite::ReceivedNoteId,
+        orchard::note::Note,
+    >,
+    ufvk: &UnifiedFullViewingKey,
+    network: &P,
+) -> anyhow::Result<voting::NoteInfo> {
+    let orchard_note = note.note();
+    let fvk = ufvk
+        .orchard()
+        .ok_or_else(|| anyhow!("UFVK has no Orchard component"))?;
+
+    let nullifier = orchard_note.nullifier(fvk);
+    // `voting::NoteInfo::commitment` is the wire-form (extracted) cmx, not the affine
+    // note commitment, so the affine value is converted here before serialization.
+    let cmx: ExtractedNoteCommitment = orchard_note.commitment().into();
+
+    // Extract raw fields
+    let diversifier = orchard_note.recipient().diversifier().as_array().to_vec();
+    let value = orchard_note.value().inner();
+    let rho = orchard_note.rho().to_bytes().to_vec();
+    let rseed = orchard_note.rseed().as_bytes().to_vec();
+    let position = u64::from(note.note_commitment_tree_position());
+    let scope = match note.spending_key_scope() {
+        Scope::External => 0u32,
+        Scope::Internal => 1u32,
+    };
+    let ufvk_str = ufvk.encode(network);
+
+    Ok(voting::NoteInfo {
+        commitment: cmx.to_bytes().to_vec(),
+        nullifier: nullifier.to_bytes().to_vec(),
+        value,
+        position,
+        diversifier,
+        rho,
+        rseed,
+        scope,
+        ufvk_str,
+    })
+}
+
+/// Open the wallet database.
+pub(super) fn open_wallet_db(
+    wallet_db_path: &str,
+    network_id: u32,
+) -> anyhow::Result<
+    zcash_client_sqlite::WalletDb<rusqlite::Connection, Network, SystemClock, rand::rngs::OsRng>,
+> {
+    let network = crate::parse_network(network_id)?;
+    zcash_client_sqlite::WalletDb::for_path(wallet_db_path, network, SystemClock, rand::rngs::OsRng)
+        .map_err(|e| anyhow!("failed to open wallet DB: {}", e))
 }
 
 #[cfg(test)]

--- a/rust/src/voting/json.rs
+++ b/rust/src/voting/json.rs
@@ -31,6 +31,22 @@ impl From<JsonNoteInfo> for voting::NoteInfo {
     }
 }
 
+impl From<voting::NoteInfo> for JsonNoteInfo {
+    fn from(n: voting::NoteInfo) -> Self {
+        Self {
+            commitment: n.commitment,
+            nullifier: n.nullifier,
+            value: n.value,
+            position: n.position,
+            diversifier: n.diversifier,
+            rho: n.rho,
+            rseed: n.rseed,
+            scope: n.scope,
+            ufvk_str: n.ufvk_str,
+        }
+    }
+}
+
 /// JSON-serializable `DelegationPirPrecomputeResult`.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct JsonDelegationPirPrecomputeResult {

--- a/rust/src/voting/notes.rs
+++ b/rust/src/voting/notes.rs
@@ -1,0 +1,260 @@
+use std::panic::AssertUnwindSafe;
+
+use anyhow::anyhow;
+use ffi_helpers::panic::catch_panic;
+use zcash_client_backend::data_api::{Account, WalletRead};
+
+use crate::unwrap_exc_or_null;
+
+use super::db::VotingDatabaseHandle;
+use super::helpers::{
+    bytes_from_ptr, json_to_boxed_slice, open_wallet_db, received_note_to_note_info, str_from_ptr,
+};
+use super::json::JsonNoteInfo;
+
+// =============================================================================
+// VotingDatabase methods — Wallet notes
+// =============================================================================
+
+/// Byte length of the binary account UUID passed as `account_uuid` / `account_uuid_len`.
+const ACCOUNT_UUID_BYTE_LEN: usize = 16;
+
+/// Get wallet notes eligible for voting at the given snapshot height.
+///
+/// Returns JSON-encoded `Vec<NoteInfo>` as `*mut FfiBoxedSlice`, or null on error.
+///
+/// `account_uuid` must be a non-null pointer to exactly `ACCOUNT_UUID_BYTE_LEN` bytes
+/// (binary account UUID).
+///
+/// # Safety
+///
+/// - `db` must be a valid, non-null `VotingDatabaseHandle` pointer.
+/// - `wallet_db_path` must be a valid path for reads of `wallet_db_path_len` bytes.
+/// - When `account_uuid_len == ACCOUNT_UUID_BYTE_LEN`, `account_uuid` must be valid for
+///   reads of `ACCOUNT_UUID_BYTE_LEN` bytes.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn zcashlc_voting_get_wallet_notes(
+    db: *mut VotingDatabaseHandle,
+    wallet_db_path: *const u8,
+    wallet_db_path_len: usize,
+    snapshot_height: u64,
+    network_id: u32,
+    account_uuid: *const u8,
+    account_uuid_len: usize,
+) -> *mut crate::ffi::BoxedSlice {
+    let db = AssertUnwindSafe(db);
+    let res = catch_panic(|| {
+        // Enforce that the database handle is not null.
+        let _handle =
+            unsafe { db.as_ref() }.ok_or_else(|| anyhow!("VotingDatabaseHandle is null"))?;
+        let wallet_path_str = unsafe { str_from_ptr(wallet_db_path, wallet_db_path_len) }?;
+
+        if account_uuid.is_null() || account_uuid_len != ACCOUNT_UUID_BYTE_LEN {
+            return Err(anyhow!(
+                "account_uuid must be a non-null pointer to exactly {} bytes (got len {})",
+                ACCOUNT_UUID_BYTE_LEN,
+                account_uuid_len
+            ));
+        }
+
+        let wallet_db = open_wallet_db(&wallet_path_str, network_id)?;
+
+        let uuid_bytes = unsafe { bytes_from_ptr(account_uuid, account_uuid_len) }?;
+        let arr: [u8; ACCOUNT_UUID_BYTE_LEN] = uuid_bytes
+            .try_into()
+            .map_err(|_| anyhow!("account_uuid must be {} bytes", ACCOUNT_UUID_BYTE_LEN))?;
+        let target_id = zcash_client_sqlite::AccountUuid::from_uuid(uuid::Uuid::from_bytes(arr));
+
+        // Get the account from the wallet database.
+        let account = wallet_db
+            .get_account(target_id)?
+            .ok_or_else(|| anyhow!("account not found"))?;
+
+        // Get the UFVK from the account.
+        let ufvk = account
+            .ufvk()
+            .ok_or_else(|| anyhow!("account has no UFVK"))?;
+        let resolved_uuid = account.id();
+
+        // Convert the snapshot height to a block height.
+        let snapshot_height_u32 = u32::try_from(snapshot_height).map_err(|_| {
+            anyhow!(
+                "snapshot_height {} does not fit in u32 (max {})",
+                snapshot_height,
+                u32::MAX
+            )
+        })?;
+
+        // Get the unspent Orchard notes at the historical height.
+        let height = zcash_protocol::consensus::BlockHeight::from_u32(snapshot_height_u32);
+        let received_notes = wallet_db
+            .get_unspent_orchard_notes_at_historical_height(resolved_uuid, height)
+            .map_err(|e| {
+                anyhow!(
+                    "get_unspent_orchard_notes_at_historical_height failed: {}",
+                    e
+                )
+            })?;
+
+        // Convert the notes to JSON.
+        let network = wallet_db.params();
+        let mut json_notes = Vec::with_capacity(received_notes.len());
+        for rn in &received_notes {
+            let note_info = received_note_to_note_info(rn, ufvk, network)?;
+            json_notes.push(JsonNoteInfo::from(note_info));
+        }
+        json_to_boxed_slice(&json_notes)
+    });
+    unwrap_exc_or_null(res)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::NETWORK_ID_MAINNET;
+    use crate::voting::db::{zcashlc_voting_db_free, zcashlc_voting_db_open};
+
+    /// Arbitrary account UUID for FFI tests that only exercise path/network/db errors.
+    const TEST_ACCOUNT_UUID: [u8; super::ACCOUNT_UUID_BYTE_LEN] = [0x7Eu8; super::ACCOUNT_UUID_BYTE_LEN];
+
+    fn open_temp_voting_db(tag: &str) -> (*mut VotingDatabaseHandle, std::path::PathBuf) {
+        let mut path = std::env::temp_dir();
+        path.push(format!(
+            "zcashlc_voting_get_wallet_notes_{}_{}.sqlite",
+            tag,
+            std::process::id()
+        ));
+        let path_bytes = path.to_string_lossy().as_bytes().to_vec();
+        let db = unsafe { zcashlc_voting_db_open(path_bytes.as_ptr(), path_bytes.len()) };
+        assert!(!db.is_null(), "open voting db at {:?}", path);
+        (db, path)
+    }
+
+    fn nonexistent_wallet_path() -> Vec<u8> {
+        // A path inside a directory that almost certainly does not exist; sqlite will
+        // fail to create the file because the parent directory is missing.
+        format!(
+            "/nonexistent-zcashlc-test-{}/wallet.sqlite",
+            std::process::id()
+        )
+        .into_bytes()
+    }
+
+    #[test]
+    fn get_wallet_notes_rejects_null_db() {
+        let wallet_path = b"/tmp/should_not_be_read.sqlite";
+        let result = unsafe {
+            zcashlc_voting_get_wallet_notes(
+                std::ptr::null_mut(),
+                wallet_path.as_ptr(),
+                wallet_path.len(),
+                100,
+                NETWORK_ID_MAINNET,
+                TEST_ACCOUNT_UUID.as_ptr(),
+                TEST_ACCOUNT_UUID.len(),
+            )
+        };
+        assert!(result.is_null());
+    }
+
+    #[test]
+    fn get_wallet_notes_rejects_invalid_utf8_wallet_path() {
+        let (db, voting_path) = open_temp_voting_db("invalid_utf8");
+        let invalid_path = [0xffu8];
+        let result = unsafe {
+            zcashlc_voting_get_wallet_notes(
+                db,
+                invalid_path.as_ptr(),
+                invalid_path.len(),
+                100,
+                NETWORK_ID_MAINNET,
+                TEST_ACCOUNT_UUID.as_ptr(),
+                TEST_ACCOUNT_UUID.len(),
+            )
+        };
+        assert!(result.is_null());
+        unsafe { zcashlc_voting_db_free(db) };
+        let _ = std::fs::remove_file(&voting_path);
+    }
+
+    #[test]
+    fn get_wallet_notes_rejects_invalid_network_id() {
+        let (db, voting_path) = open_temp_voting_db("invalid_network");
+        let wallet_path = b"/tmp/zcashlc_unused_wallet.sqlite";
+        let result = unsafe {
+            zcashlc_voting_get_wallet_notes(
+                db,
+                wallet_path.as_ptr(),
+                wallet_path.len(),
+                100,
+                99, // invalid: parse_network rejects anything outside {0, 1}
+                TEST_ACCOUNT_UUID.as_ptr(),
+                TEST_ACCOUNT_UUID.len(),
+            )
+        };
+        assert!(result.is_null());
+        unsafe { zcashlc_voting_db_free(db) };
+        let _ = std::fs::remove_file(&voting_path);
+    }
+
+    #[test]
+    fn get_wallet_notes_rejects_unopenable_wallet_path() {
+        let (db, voting_path) = open_temp_voting_db("unopenable");
+        let wallet_path = nonexistent_wallet_path();
+        let result = unsafe {
+            zcashlc_voting_get_wallet_notes(
+                db,
+                wallet_path.as_ptr(),
+                wallet_path.len(),
+                100,
+                NETWORK_ID_MAINNET,
+                TEST_ACCOUNT_UUID.as_ptr(),
+                TEST_ACCOUNT_UUID.len(),
+            )
+        };
+        assert!(result.is_null());
+        unsafe { zcashlc_voting_db_free(db) };
+        let _ = std::fs::remove_file(&voting_path);
+    }
+
+    #[test]
+    fn get_wallet_notes_rejects_null_account_uuid() {
+        let (db, voting_path) = open_temp_voting_db("null_uuid");
+        let wallet_path = b"/tmp/zcashlc_unused_wallet.sqlite";
+        let result = unsafe {
+            zcashlc_voting_get_wallet_notes(
+                db,
+                wallet_path.as_ptr(),
+                wallet_path.len(),
+                100,
+                NETWORK_ID_MAINNET,
+                std::ptr::null(),
+                super::ACCOUNT_UUID_BYTE_LEN,
+            )
+        };
+        assert!(result.is_null());
+        unsafe { zcashlc_voting_db_free(db) };
+        let _ = std::fs::remove_file(&voting_path);
+    }
+
+    #[test]
+    fn get_wallet_notes_rejects_wrong_account_uuid_length() {
+        let (db, voting_path) = open_temp_voting_db("bad_uuid_len");
+        let wallet_path = b"/tmp/zcashlc_unused_wallet.sqlite";
+        let short = [0u8; 8];
+        let result = unsafe {
+            zcashlc_voting_get_wallet_notes(
+                db,
+                wallet_path.as_ptr(),
+                wallet_path.len(),
+                100,
+                NETWORK_ID_MAINNET,
+                short.as_ptr(),
+                short.len(),
+            )
+        };
+        assert!(result.is_null());
+        unsafe { zcashlc_voting_db_free(db) };
+        let _ = std::fs::remove_file(&voting_path);
+    }
+}

--- a/rust/src/voting/notes.rs
+++ b/rust/src/voting/notes.rs
@@ -115,7 +115,8 @@ mod tests {
     use crate::voting::db::{zcashlc_voting_db_free, zcashlc_voting_db_open};
 
     /// Arbitrary account UUID for FFI tests that only exercise path/network/db errors.
-    const TEST_ACCOUNT_UUID: [u8; super::ACCOUNT_UUID_BYTE_LEN] = [0x7Eu8; super::ACCOUNT_UUID_BYTE_LEN];
+    const TEST_ACCOUNT_UUID: [u8; super::ACCOUNT_UUID_BYTE_LEN] =
+        [0x7Eu8; super::ACCOUNT_UUID_BYTE_LEN];
 
     fn open_temp_voting_db(tag: &str) -> (*mut VotingDatabaseHandle, std::path::PathBuf) {
         let mut path = std::env::temp_dir();

--- a/rust/src/voting/util.rs
+++ b/rust/src/voting/util.rs
@@ -46,7 +46,7 @@ mod tests {
     use zcash_protocol::consensus::Network;
 
     use super::*;
-    use crate::NETWORK_ID_MAINNET;
+    use crate::{NETWORK_ID_MAINNET, NETWORK_ID_TESTNET};
 
     fn free(ptr: *mut crate::ffi::BoxedSlice) {
         unsafe { crate::ffi::zcashlc_free_boxed_slice(ptr) };
@@ -54,11 +54,10 @@ mod tests {
 
     /// Build a deterministic, well-formed mainnet UFVK fixture and return its
     /// encoded string alongside its raw 96-byte Orchard FVK.
-    fn derive_test_ufvk() -> (String, [u8; 96]) {
+    fn derive_test_ufvk(network: Network) -> (String, [u8; 96]) {
         // 32 zero bytes is a valid seed length for `from_seed`. The exact value is
         // unimportant; we only need a deterministic, well-formed UFVK to round-trip
         // through the FFI.
-        let network = Network::MainNetwork;
         let seed = [0u8; 32];
         let account = zip32::AccountId::try_from(0).expect("account 0");
         let usk = UnifiedSpendingKey::from_seed(&network, &seed, account).expect("from_seed");
@@ -69,8 +68,8 @@ mod tests {
     }
 
     #[test]
-    fn extract_orchard_fvk_returns_orchard_bytes_for_valid_ufvk() {
-        let (ufvk_str, expected) = derive_test_ufvk();
+    fn extract_orchard_fvk_returns_orchard_bytes_for_valid_mainnet_ufvk() {
+        let (ufvk_str, expected) = derive_test_ufvk(Network::MainNetwork);
 
         let result = unsafe {
             zcashlc_voting_extract_orchard_fvk_from_ufvk(
@@ -89,6 +88,40 @@ mod tests {
     }
 
     #[test]
+    fn extract_orchard_fvk_returns_orchard_bytes_for_valid_testnet_ufvk() {
+        let (ufvk_str, expected) = derive_test_ufvk(Network::TestNetwork);
+
+        let result = unsafe {
+            zcashlc_voting_extract_orchard_fvk_from_ufvk(
+                ufvk_str.as_ptr(),
+                ufvk_str.len(),
+                NETWORK_ID_TESTNET,
+            )
+        };
+        assert!(!result.is_null(), "expected non-null BoxedSlice");
+
+        let actual = unsafe { (*result).as_slice() }.to_vec();
+        free(result);
+
+        assert_eq!(actual.len(), 96, "Orchard FVK must be 96 bytes");
+        assert_eq!(actual, expected.to_vec(), "FVK bytes must match");
+    }
+
+    #[test]
+    fn extract_orchard_fvk_rejects_mainnet_ufvk_with_testnet_network_id() {
+        let (ufvk_str, _expected) = derive_test_ufvk(Network::MainNetwork);
+
+        let result = unsafe {
+            zcashlc_voting_extract_orchard_fvk_from_ufvk(
+                ufvk_str.as_ptr(),
+                ufvk_str.len(),
+                NETWORK_ID_TESTNET,
+            )
+        };
+        assert!(result.is_null());
+    }
+
+    #[test]
     fn extract_orchard_fvk_rejects_null_pointer_with_nonzero_len() {
         let result = unsafe {
             zcashlc_voting_extract_orchard_fvk_from_ufvk(std::ptr::null(), 5, NETWORK_ID_MAINNET)
@@ -98,7 +131,7 @@ mod tests {
 
     #[test]
     fn extract_orchard_fvk_rejects_invalid_network_id() {
-        let (ufvk_str, _expected) = derive_test_ufvk();
+        let (ufvk_str, _expected) = derive_test_ufvk(Network::MainNetwork);
         let result = unsafe {
             zcashlc_voting_extract_orchard_fvk_from_ufvk(ufvk_str.as_ptr(), ufvk_str.len(), 99)
         };

--- a/rust/src/voting/util.rs
+++ b/rust/src/voting/util.rs
@@ -1,0 +1,128 @@
+use anyhow::anyhow;
+use ffi_helpers::panic::catch_panic;
+use zcash_keys::keys::UnifiedFullViewingKey;
+
+use crate::{parse_network, unwrap_exc_or_null};
+
+use super::helpers::str_from_ptr;
+
+// =============================================================================
+// Free functions (no VotingDatabase needed)
+// =============================================================================
+
+/// Extract the 96-byte Orchard FVK from a UFVK string.
+///
+/// Returns the raw 96-byte Orchard FVK as `*mut FfiBoxedSlice`, or null on error.
+///
+/// # Safety
+///
+/// - `ufvk_str` must be valid for reads of `ufvk_str_len` bytes (UTF-8 encoded).
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn zcashlc_voting_extract_orchard_fvk_from_ufvk(
+    ufvk_str: *const u8,
+    ufvk_str_len: usize,
+    network_id: u32,
+) -> *mut crate::ffi::BoxedSlice {
+    let res = catch_panic(|| {
+        let ufvk_string = unsafe { str_from_ptr(ufvk_str, ufvk_str_len) }?;
+
+        let network = parse_network(network_id)?;
+        let ufvk = UnifiedFullViewingKey::decode(&network, &ufvk_string)
+            .map_err(|e| anyhow!("failed to decode UFVK string: {}", e))?;
+
+        let orchard_fvk = ufvk
+            .orchard()
+            .ok_or_else(|| anyhow!("UFVK has no Orchard component"))?;
+        Ok(crate::ffi::BoxedSlice::some(
+            orchard_fvk.to_bytes().to_vec(),
+        ))
+    });
+    unwrap_exc_or_null(res)
+}
+
+#[cfg(test)]
+mod tests {
+    use zcash_keys::keys::UnifiedSpendingKey;
+    use zcash_protocol::consensus::Network;
+
+    use super::*;
+    use crate::NETWORK_ID_MAINNET;
+
+    fn free(ptr: *mut crate::ffi::BoxedSlice) {
+        unsafe { crate::ffi::zcashlc_free_boxed_slice(ptr) };
+    }
+
+    /// Build a deterministic, well-formed mainnet UFVK fixture and return its
+    /// encoded string alongside its raw 96-byte Orchard FVK.
+    fn derive_test_ufvk() -> (String, [u8; 96]) {
+        // 32 zero bytes is a valid seed length for `from_seed`. The exact value is
+        // unimportant; we only need a deterministic, well-formed UFVK to round-trip
+        // through the FFI.
+        let network = Network::MainNetwork;
+        let seed = [0u8; 32];
+        let account = zip32::AccountId::try_from(0).expect("account 0");
+        let usk = UnifiedSpendingKey::from_seed(&network, &seed, account).expect("from_seed");
+        let ufvk = usk.to_unified_full_viewing_key();
+        let ufvk_str = ufvk.encode(&network);
+        let orchard_bytes = ufvk.orchard().expect("orchard present").to_bytes();
+        (ufvk_str, orchard_bytes)
+    }
+
+    #[test]
+    fn extract_orchard_fvk_returns_orchard_bytes_for_valid_ufvk() {
+        let (ufvk_str, expected) = derive_test_ufvk();
+
+        let result = unsafe {
+            zcashlc_voting_extract_orchard_fvk_from_ufvk(
+                ufvk_str.as_ptr(),
+                ufvk_str.len(),
+                NETWORK_ID_MAINNET,
+            )
+        };
+        assert!(!result.is_null(), "expected non-null BoxedSlice");
+
+        let actual = unsafe { (*result).as_slice() }.to_vec();
+        free(result);
+
+        assert_eq!(actual.len(), 96, "Orchard FVK must be 96 bytes");
+        assert_eq!(actual, expected.to_vec(), "FVK bytes must match");
+    }
+
+    #[test]
+    fn extract_orchard_fvk_rejects_null_pointer_with_nonzero_len() {
+        let result = unsafe {
+            zcashlc_voting_extract_orchard_fvk_from_ufvk(std::ptr::null(), 5, NETWORK_ID_MAINNET)
+        };
+        assert!(result.is_null());
+    }
+
+    #[test]
+    fn extract_orchard_fvk_rejects_invalid_network_id() {
+        let (ufvk_str, _expected) = derive_test_ufvk();
+        let result = unsafe {
+            zcashlc_voting_extract_orchard_fvk_from_ufvk(ufvk_str.as_ptr(), ufvk_str.len(), 99)
+        };
+        assert!(result.is_null());
+    }
+
+    #[test]
+    fn extract_orchard_fvk_rejects_non_ufvk_string() {
+        let bogus = b"not a ufvk";
+        let result = unsafe {
+            zcashlc_voting_extract_orchard_fvk_from_ufvk(
+                bogus.as_ptr(),
+                bogus.len(),
+                NETWORK_ID_MAINNET,
+            )
+        };
+        assert!(result.is_null());
+    }
+
+    #[test]
+    fn extract_orchard_fvk_rejects_empty_input() {
+        let result = unsafe {
+            zcashlc_voting_extract_orchard_fvk_from_ufvk(std::ptr::null(), 0, NETWORK_ID_MAINNET)
+        };
+        assert!(result.is_null());
+    }
+}


### PR DESCRIPTION
## Summary

Adds two FFI symbols on the path toward exposing shielded voting in the Swift layer. The Swift wrappers and end-to-end wiring will follow in subsequent PRs that consume these symbols.

- **`zcashlc_voting_get_wallet_notes`** — loads unspent Orchard notes for a wallet account at a snapshot height
- **`zcashlc_voting_extract_orchard_fvk_from_ufvk`** — decodes a UFVK string and returns the raw 96-byte Orchard FVK 

### Supporting changes

- Adds `zcash_keys 0.13` (`orchard` feature) as a Rust dependency, used by the new FFI to decode UFVKs and derive Orchard FVKs.
- Adds `received_note_to_note_info` and `open_wallet_db` helpers in `voting/helpers.rs` for the wallet-notes FFI.
- Adds `From<voting::NoteInfo> for JsonNoteInfo` so the Rust-side `voting::NoteInfo` round-trips into the existing JSON shape.
- Hoists `NETWORK_ID_TESTNET` / `NETWORK_ID_MAINNET` constants next to `parse_network` in `lib.rs` so FFI tests stop hardcoding 0/1.
- Adds a `#[cfg(test)] BoxedSlice::as_slice` accessor for crate-internal test inspection of FFI payloads.

Refs #1661.