### PR TITLE
Draft: Coinholder Polling Feature Branch

### DIFF
--- a/Sources/ZcashLightClientKit/Synchronizer/SDKSynchronizer.swift
+++ b/Sources/ZcashLightClientKit/Synchronizer/SDKSynchronizer.swift
@@ -371,7 +371,7 @@ public class SDKSynchronizer: Synchronizer {
             await httpTor?.sleep()
             stopped = true
         }
-        
+
         // called when a new account is imported
         let chainTip = try? await UInt32(
             initializer.lightWalletService.latestBlockHeight(
@@ -384,7 +384,7 @@ public class SDKSynchronizer: Synchronizer {
         guard let chainTip else {
             throw ZcashError.synchronizerNotPrepared
         }
-        
+
         let checkpoint = checkpointSource.birthday(for: birthday ?? BlockHeight(chainTip))
 
         let accountUUID = try await initializer.rustBackend.importAccount(
@@ -402,7 +402,7 @@ public class SDKSynchronizer: Synchronizer {
         if stopped {
             try await start(retry: false)
         }
-        
+
         return accountUUID
     }
 


### PR DESCRIPTION
## Overview

See [Shielded Voting — Changes vs Upstream](https://hackmd.io/@greg-nagy/zodl-shielded-vote-integration) for the full cross-repo picture (librustzcash PRs, zcash_voting, this SDK layer, and the zodl-ios application layer).

## Summary

Adds the iOS SDK integration layer for shielded voting: a hand-rolled C FFI for `zcash_voting`, Swift wrappers, and the wallet↔voting data plumbing needed to drive the delegation → vote → share-submission lifecycle from a Swift client.

- **58 `extern "C"` FFI functions** in `rust/src/voting.rs` covering round management, wallet note queries, hotkey generation, delegation proof construction, vote commitment, share encryption, submission, crash-recovery state persistence, and commitment-tree sync
- **Swift wrappers** (`VotingRustBackend.swift`, `VotingTypes.swift`) with thread-safe handle management, `Codable` boundary types, and secret stripping at the FFI boundary
- **New SDK API** `Synchronizer.getTreeState(height:)` for commitment-tree witness generation, with a throwing default impl in a protocol extension so out-of-repo conformers remain source-compatible
- **`fullyScannedHeight` exposed on `SynchronizerState`** — callers that need authoritative wallet state at a snapshot height (voting power lookup) gate on this rather than the chain tip or head-first scan progress
- **Build integration** — `build.rs` watches all Rust source files for `cbindgen` rebuild; `SystemConfiguration` framework linked for macOS `reqwest` proxy detection

## Architecture

The SDK is the glue between `librustzcash` (wallet) and `zcash_voting` (voting):

zodl-ios (Swift/TCA)
  └─ zcash-swift-wallet-sdk (SPM)
       ├─ VotingRustBackend.swift (wraps C FFI)
       └─ libzcashlc.a (Rust staticlib)
            ├─ librustzcash ← wallet DB queries
            └─ zcash_voting ← voting DB, ZKP proofs, encryption

`zcash_voting` never touches the wallet DB. The SDK FFI queries notes/witnesses via `librustzcash` and passes them to `zcash_voting` as arguments. A small number of FFI functions do this wallet↔voting plumbing; the rest are thin pass-throughs to `zcash_voting`.

Complex types cross the FFI boundary via JSON serde (`serde_json` ↔ `Codable`); simple types use `#[repr(C)]` structs. Encrypted share secrets are stripped at the boundary — only ciphertext components are exposed to Swift.

## Voting workflow

1. **Round init** → hotkey generation (from seed or standalone)
2. **Bundle setup** → note selection at snapshot height, per-wallet isolation via account UUID
3. **Delegation** → voting PCZT construction, witness generation, ZKP proof, Keystone signature
4. **Voting** → vote commitment (second ZKP), share encryption, submission with cast-vote signature
5. **Recovery** → persistent state for TX hashes, commitment bundles, and Keystone signatures across app restarts

## Branch layout

The fork-only changes (dep redirections, xcframework URL, fork release scripts) are isolated in the `[REVERT_ME]` commit and reverted on top. HEAD is upstream-clean; HEAD~1 is the buildable fork state for anyone who wants to pull and run end-to-end.

## Key files

| File | Purpose |
|------|---------|
| `rust/src/voting.rs` | 58 `extern "C"` FFI functions + helpers |
| `Sources/.../VotingTypes.swift` | Codable Swift types matching Rust JSON serde |
| `Sources/.../VotingRustBackend.swift` | Thread-safe Swift wrapper over opaque `VotingDatabaseHandle` |
| `Cargo.toml` | `zcash_voting` dep + `[patch.crates-io]` alignment |

Closes MOB-983. Supersedes #1657.