### PR TITLE
[#1661] Voting FFI in VotingRustBackend.swift (database, PR, VAN witness gen)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,13 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `zcash_voting` dependency foundation: SDK Rust crate now depends on `zcash_voting 0.5.2` (`default-features = false`, `client-pir`) and exposes pure-function FFI symbols for share-nullifier computation and PIR proof validation. No Swift API surface is added in this step.
 - `PirSnapshotResolver`, `PirSnapshotResolverError`, `PirSnapshotProbeOutcome`, `PirSnapshotProbing`, and `HTTPPirSnapshotProbe`: Select a vote-nullifier PIR endpoint whose `/root` metadata exactly matches a voting round's expected snapshot height.
 - `Voting*` Swift types: public type contract for the shielded voting FFI boundary, in `Sources/ZcashLightClientKit/Rust/Voting/VotingTypes.swift`.
-- `VotingRustBackend`: Swift wrapper for the voting `libzcashlc` surface. Exposes the static `computeShareNullifier` over `zcashlc_voting_compute_share_nullifier` and the `VotingRustBackendError` error type.
+- `VotingRustBackend`: Swift wrapper for the voting `libzcashlc` surface. A `final class` that owns an opaque `VotingDatabaseHandle` for the duration of a voting session. Exposes:
+  - Database lifecycle: `init()`, `open(path:)`, `close()` (idempotent), and `deinit` cleanup, over `zcashlc_voting_db_open` / `zcashlc_voting_db_free`.
+  - `setWalletId(_:)` over `zcashlc_voting_set_wallet_id`.
+  - `precomputeDelegationPir(roundId:bundleIndex:notes:pirEndpoints:expectedSnapshotHeight:networkId:pirResolver:)` over `zcashlc_voting_precompute_delegation_pir`, with `PirSnapshotResolver`-driven endpoint selection.
+  - Vote-tree sync: `syncVoteTree(roundId:nodeUrl:)`, `generateVanWitness(roundId:bundleIndex:anchorHeight:)`, and `resetTreeClient(roundId:)` over the corresponding `zcashlc_voting_sync_vote_tree` / `_generate_van_witness` / `_reset_tree_client` FFI.
+  - The static `computeShareNullifier(voteCommitment:shareIndex:primaryBlind:)` over `zcashlc_voting_compute_share_nullifier`, with 32-byte input validation.
+  - `VotingRustBackendError` cases `databaseAlreadyOpen` / `databaseNotOpen` for handle-state errors, alongside the existing `rustError` and `invalidData`.
 - `Broadcaster` protocol — separates transaction creation from submission, enabling custom broadcast strategies (e.g. submitting to multiple lightwalletd servers in parallel).
   - `Broadcaster.createProposedTransactions(proposal:spendingKey:)` — creates transactions locally without broadcasting, returning `[ZcashTransaction.Overview]` with raw bytes.
   - `Broadcaster.createTransactionFromPCZT(pcztWithProofs:pcztWithSigs:)` — extracts and stores a transaction from PCZT data without submitting.

--- a/Sources/ZcashLightClientKit/Rust/Voting/VotingRustBackend.swift
+++ b/Sources/ZcashLightClientKit/Rust/Voting/VotingRustBackend.swift
@@ -35,10 +35,225 @@ public enum VotingRustBackendError: LocalizedError, Equatable {
 
 // MARK: - VotingRustBackend
 
-/// Swift wrapper for the voting `libzcashlc` surface.
-public enum VotingRustBackend {}
+/// Wraps the voting `libzcashlc` C FFI surface.
+///
+/// Manages an opaque `VotingDatabaseHandle` pointer for the database-bound
+/// methods. Stateless / static FFI (e.g. `computeShareNullifier`) is exposed
+/// as type methods so callers do not need to open a database.
+///
+/// Thread safety: handle access is serialized by an `NSLock`. The lock guards
+/// the handle slot only — it is released before the FFI call runs, so callers
+/// must not race `close()` against in-flight operations.
+public final class VotingRustBackend: @unchecked Sendable {
+    private let lock = NSLock()
+    private var handle: OpaquePointer?
 
-// MARK: - Share tracking
+    public init() {}
+
+    deinit {
+        if let handle {
+            zcashlc_voting_db_free(handle)
+        }
+    }
+
+    // MARK: - Database lifecycle
+
+    /// Open the voting database at `path`.
+    ///
+    /// Throws `VotingRustBackendError.databaseAlreadyOpen` if the backend
+    /// already holds an open handle.
+    public func open(path: String) throws {
+        lock.lock()
+        defer { lock.unlock() }
+
+        guard handle == nil else {
+            throw VotingRustBackendError.databaseAlreadyOpen
+        }
+
+        let pathBytes = [UInt8](path.utf8)
+        guard let ptr = pathBytes.withUnsafeBufferPointer({ buf in
+            zcashlc_voting_db_open(buf.baseAddress, UInt(buf.count))
+        }) else {
+            throw VotingRustBackendError.rustError(
+                Self.staticLastErrorMessage(fallback: "`voting_db_open` failed")
+            )
+        }
+        handle = ptr
+    }
+
+    /// Close the voting database, freeing the underlying handle.
+    ///
+    /// Idempotent: calling `close()` on an already-closed backend is a no-op.
+    public func close() {
+        lock.lock()
+        defer { lock.unlock() }
+
+        if let dbh = handle {
+            zcashlc_voting_db_free(dbh)
+            handle = nil
+        }
+    }
+}
+
+// MARK: - Wallet identity
+
+extension VotingRustBackend {
+    /// Set the wallet identifier for all subsequent voting operations.
+    ///
+    /// Must be called after `open(path:)` and before any round operations.
+    public func setWalletId(_ walletId: String) throws {
+        let dbh = try requireHandle()
+        let walletIdBytes = [UInt8](walletId.utf8)
+
+        let result = walletIdBytes.withUnsafeBufferPointer { buf in
+            zcashlc_voting_set_wallet_id(dbh, buf.baseAddress, UInt(buf.count))
+        }
+
+        guard result == 0 else {
+            throw VotingRustBackendError.rustError(lastErrorMessage(fallback: "`set_wallet_id` failed"))
+        }
+    }
+}
+
+// MARK: - Delegation (PIR precompute)
+
+extension VotingRustBackend {
+    /// Resolve the round's PIR endpoint, fetch the IMT non-membership proofs
+    /// needed for the delegation ZKP, and cache them in the voting database.
+    ///
+    /// This performs the network PIR lookup only, proof construction happens
+    //  elsewhere.
+    ///
+    /// `pirEndpoints` are probed in parallel via `pirResolver`. The first
+    /// endpoint whose served snapshot height equals `expectedSnapshotHeight`
+    /// exactly is used. See `PirSnapshotResolver` for the failure semantics.
+    // swiftlint:disable:next function_parameter_count
+    public func precomputeDelegationPir(
+        roundId: String,
+        bundleIndex: UInt32,
+        notes: [VotingNoteInfo],
+        pirEndpoints: [String],
+        expectedSnapshotHeight: UInt64,
+        networkId: UInt32,
+        pirResolver: PirSnapshotResolver = PirSnapshotResolver()
+    ) async throws -> VotingDelegationPirPrecomputeResult {
+        // PirSnapshotResolver expects `BlockHeight` (Int); voting snapshot
+        // heights are `UInt64` everywhere else in the voting types, so convert
+        // at the boundary. Snapshot heights well within Int.max in practice.
+        let pirServerUrl = try await pirResolver.resolve(
+            endpoints: pirEndpoints,
+            expectedSnapshotHeight: BlockHeight(expectedSnapshotHeight)
+        )
+
+        let dbh = try requireHandle()
+        let roundIdBytes = [UInt8](roundId.utf8)
+        let notesJson = try JSONEncoder().encode(notes)
+        let notesBytes = [UInt8](notesJson)
+        let urlBytes = [UInt8](pirServerUrl.utf8)
+
+        let ptr: UnsafeMutablePointer<FfiBoxedSlice>? = roundIdBytes.withUnsafeBufferPointer { ridBuf in
+            notesBytes.withUnsafeBufferPointer { notesBuf in
+                urlBytes.withUnsafeBufferPointer { urlBuf in
+                    zcashlc_voting_precompute_delegation_pir(
+                        dbh,
+                        ridBuf.baseAddress,
+                        UInt(ridBuf.count),
+                        bundleIndex,
+                        notesBuf.baseAddress,
+                        UInt(notesBuf.count),
+                        urlBuf.baseAddress,
+                        UInt(urlBuf.count),
+                        networkId
+                    )
+                }
+            }
+        }
+
+        guard let ptr else {
+            throw VotingRustBackendError.rustError(
+                lastErrorMessage(fallback: "`precompute_delegation_pir` failed")
+            )
+        }
+        defer { zcashlc_free_boxed_slice(ptr) }
+        return try decodeJSON(from: ptr)
+    }
+}
+
+// MARK: - Vote-tree sync
+
+extension VotingRustBackend {
+    /// Sync the vote commitment tree from a chain node.
+    ///
+    /// Returns the latest synced block height.
+    public func syncVoteTree(roundId: String, nodeUrl: String) throws -> UInt32 {
+        let dbh = try requireHandle()
+        let roundIdBytes = [UInt8](roundId.utf8)
+        let urlBytes = [UInt8](nodeUrl.utf8)
+
+        let result = roundIdBytes.withUnsafeBufferPointer { ridBuf in
+            urlBytes.withUnsafeBufferPointer { urlBuf in
+                zcashlc_voting_sync_vote_tree(
+                    dbh,
+                    ridBuf.baseAddress,
+                    UInt(ridBuf.count),
+                    urlBuf.baseAddress,
+                    UInt(urlBuf.count)
+                )
+            }
+        }
+
+        guard result >= 0 else {
+            throw VotingRustBackendError.rustError(lastErrorMessage(fallback: "`sync_vote_tree` failed"))
+        }
+        return UInt32(result)
+    }
+
+    /// Generate a Vote Authority Note (VAN) Merkle witness for the given
+    /// bundle at `anchorHeight`.
+    public func generateVanWitness(
+        roundId: String,
+        bundleIndex: UInt32,
+        anchorHeight: UInt32
+    ) throws -> VotingVanWitness {
+        let dbh = try requireHandle()
+        let roundIdBytes = [UInt8](roundId.utf8)
+
+        let ptr: UnsafeMutablePointer<FfiBoxedSlice>? = roundIdBytes.withUnsafeBufferPointer { buf in
+            zcashlc_voting_generate_van_witness(
+                dbh,
+                buf.baseAddress,
+                UInt(buf.count),
+                bundleIndex,
+                anchorHeight
+            )
+        }
+
+        guard let ptr else {
+            throw VotingRustBackendError.rustError(lastErrorMessage(fallback: "`generate_van_witness` failed"))
+        }
+        defer { zcashlc_free_boxed_slice(ptr) }
+        return try decodeJSON(from: ptr)
+    }
+
+    /// Reset the in-memory tree client for a round, forcing the next
+    /// `syncVoteTree` call to start from a fresh client.
+    ///
+    /// Pass an empty `roundId` to reset all rounds.
+    public func resetTreeClient(roundId: String = "") throws {
+        let dbh = try requireHandle()
+        let roundIdBytes = [UInt8](roundId.utf8)
+
+        let result = roundIdBytes.withUnsafeBufferPointer { buf in
+            zcashlc_voting_reset_tree_client(dbh, buf.baseAddress, UInt(buf.count))
+        }
+
+        guard result == 0 else {
+            throw VotingRustBackendError.rustError(lastErrorMessage(fallback: "`reset_tree_client` failed"))
+        }
+    }
+}
+
+// MARK: - Share tracking (static)
 
 extension VotingRustBackend {
     /// Byte width of a Pallas base-field element as expected by the voting FFI.
@@ -91,6 +306,28 @@ extension VotingRustBackend {
 // MARK: - Private helpers
 
 private extension VotingRustBackend {
+    /// Snapshot the current handle under the lock, throwing if the database
+    /// is not open. The pointer is read-only after `close()` resets it, so the
+    /// snapshot is valid for the duration of the FFI call as long as callers
+    /// do not race `close()` against other operations.
+    func requireHandle() throws -> OpaquePointer {
+        lock.lock()
+        defer { lock.unlock() }
+        guard let dbh = handle else {
+            throw VotingRustBackendError.databaseNotOpen
+        }
+        return dbh
+    }
+
+    func lastErrorMessage(fallback: String) -> String {
+        Self.staticLastErrorMessage(fallback: fallback)
+    }
+
+    func decodeJSON<T: Decodable>(from ptr: UnsafeMutablePointer<FfiBoxedSlice>) throws -> T {
+        let data = Data(bytes: ptr.pointee.ptr, count: Int(ptr.pointee.len))
+        return try JSONDecoder().decode(T.self, from: data)
+    }
+
     /// Reads the last error recorded by `libzcashlc` and clears it as a side
     /// effect, so subsequent failures do not surface a stale message.
     static func staticLastErrorMessage(fallback: String) -> String {

--- a/Sources/ZcashLightClientKit/Rust/Voting/VotingRustBackend.swift
+++ b/Sources/ZcashLightClientKit/Rust/Voting/VotingRustBackend.swift
@@ -41,9 +41,9 @@ public enum VotingRustBackendError: LocalizedError, Equatable {
 /// methods. Stateless / static FFI (e.g. `computeShareNullifier`) is exposed
 /// as type methods so callers do not need to open a database.
 ///
-/// Thread safety: handle access is serialized by an `NSLock`. The lock guards
-/// the handle slot only — it is released before the FFI call runs, so callers
-/// must not race `close()` against in-flight operations.
+/// Thread safety: handle access is serialized by an `NSLock`. Database-bound
+/// FFI calls hold the lock for their full duration so `close()` cannot free the
+/// handle while Rust is using it.
 public final class VotingRustBackend: @unchecked Sendable {
     private let lock = NSLock()
     private var handle: OpaquePointer?
@@ -102,15 +102,16 @@ extension VotingRustBackend {
     ///
     /// Must be called after `open(path:)` and before any round operations.
     public func setWalletId(_ walletId: String) throws {
-        let dbh = try requireHandle()
         let walletIdBytes = [UInt8](walletId.utf8)
 
-        let result = walletIdBytes.withUnsafeBufferPointer { buf in
-            zcashlc_voting_set_wallet_id(dbh, buf.baseAddress, UInt(buf.count))
-        }
+        try withHandle { dbh in
+            let result = walletIdBytes.withUnsafeBufferPointer { buf in
+                zcashlc_voting_set_wallet_id(dbh, buf.baseAddress, UInt(buf.count))
+            }
 
-        guard result == 0 else {
-            throw VotingRustBackendError.rustError(lastErrorMessage(fallback: "`set_wallet_id` failed"))
+            guard result == 0 else {
+                throw VotingRustBackendError.rustError(lastErrorMessage(fallback: "`set_wallet_id` failed"))
+            }
         }
     }
 }
@@ -145,34 +146,36 @@ extension VotingRustBackend {
             expectedSnapshotHeight: BlockHeight(expectedSnapshotHeight)
         )
 
-        let dbh = try requireHandle()
         let roundIdBytes = [UInt8](roundId.utf8)
         let notesJson = try JSONEncoder().encode(notes)
         let notesBytes = [UInt8](notesJson)
         let urlBytes = [UInt8](pirServerUrl.utf8)
 
-        let ptr: UnsafeMutablePointer<FfiBoxedSlice>? = roundIdBytes.withUnsafeBufferPointer { ridBuf in
-            notesBytes.withUnsafeBufferPointer { notesBuf in
-                urlBytes.withUnsafeBufferPointer { urlBuf in
-                    zcashlc_voting_precompute_delegation_pir(
-                        dbh,
-                        ridBuf.baseAddress,
-                        UInt(ridBuf.count),
-                        bundleIndex,
-                        notesBuf.baseAddress,
-                        UInt(notesBuf.count),
-                        urlBuf.baseAddress,
-                        UInt(urlBuf.count),
-                        networkId
-                    )
+        let ptr: UnsafeMutablePointer<FfiBoxedSlice> = try withHandle { dbh in
+            let ptr: UnsafeMutablePointer<FfiBoxedSlice>? = roundIdBytes.withUnsafeBufferPointer { ridBuf in
+                notesBytes.withUnsafeBufferPointer { notesBuf in
+                    urlBytes.withUnsafeBufferPointer { urlBuf in
+                        zcashlc_voting_precompute_delegation_pir(
+                            dbh,
+                            ridBuf.baseAddress,
+                            UInt(ridBuf.count),
+                            bundleIndex,
+                            notesBuf.baseAddress,
+                            UInt(notesBuf.count),
+                            urlBuf.baseAddress,
+                            UInt(urlBuf.count),
+                            networkId
+                        )
+                    }
                 }
             }
-        }
 
-        guard let ptr else {
-            throw VotingRustBackendError.rustError(
-                lastErrorMessage(fallback: "`precompute_delegation_pir` failed")
-            )
+            guard let ptr else {
+                throw VotingRustBackendError.rustError(
+                    lastErrorMessage(fallback: "`precompute_delegation_pir` failed")
+                )
+            }
+            return ptr
         }
         defer { zcashlc_free_boxed_slice(ptr) }
         return try decodeJSON(from: ptr)
@@ -186,26 +189,27 @@ extension VotingRustBackend {
     ///
     /// Returns the latest synced block height.
     public func syncVoteTree(roundId: String, nodeUrl: String) throws -> UInt32 {
-        let dbh = try requireHandle()
         let roundIdBytes = [UInt8](roundId.utf8)
         let urlBytes = [UInt8](nodeUrl.utf8)
 
-        let result = roundIdBytes.withUnsafeBufferPointer { ridBuf in
-            urlBytes.withUnsafeBufferPointer { urlBuf in
-                zcashlc_voting_sync_vote_tree(
-                    dbh,
-                    ridBuf.baseAddress,
-                    UInt(ridBuf.count),
-                    urlBuf.baseAddress,
-                    UInt(urlBuf.count)
-                )
+        return try withHandle { dbh in
+            let result = roundIdBytes.withUnsafeBufferPointer { ridBuf in
+                urlBytes.withUnsafeBufferPointer { urlBuf in
+                    zcashlc_voting_sync_vote_tree(
+                        dbh,
+                        ridBuf.baseAddress,
+                        UInt(ridBuf.count),
+                        urlBuf.baseAddress,
+                        UInt(urlBuf.count)
+                    )
+                }
             }
-        }
 
-        guard result >= 0 else {
-            throw VotingRustBackendError.rustError(lastErrorMessage(fallback: "`sync_vote_tree` failed"))
+            guard result >= 0 else {
+                throw VotingRustBackendError.rustError(lastErrorMessage(fallback: "`sync_vote_tree` failed"))
+            }
+            return UInt32(result)
         }
-        return UInt32(result)
     }
 
     /// Generate a Vote Authority Note (VAN) Merkle witness for the given
@@ -215,21 +219,23 @@ extension VotingRustBackend {
         bundleIndex: UInt32,
         anchorHeight: UInt32
     ) throws -> VotingVanWitness {
-        let dbh = try requireHandle()
         let roundIdBytes = [UInt8](roundId.utf8)
 
-        let ptr: UnsafeMutablePointer<FfiBoxedSlice>? = roundIdBytes.withUnsafeBufferPointer { buf in
-            zcashlc_voting_generate_van_witness(
-                dbh,
-                buf.baseAddress,
-                UInt(buf.count),
-                bundleIndex,
-                anchorHeight
-            )
-        }
+        let ptr: UnsafeMutablePointer<FfiBoxedSlice> = try withHandle { dbh in
+            let ptr: UnsafeMutablePointer<FfiBoxedSlice>? = roundIdBytes.withUnsafeBufferPointer { buf in
+                zcashlc_voting_generate_van_witness(
+                    dbh,
+                    buf.baseAddress,
+                    UInt(buf.count),
+                    bundleIndex,
+                    anchorHeight
+                )
+            }
 
-        guard let ptr else {
-            throw VotingRustBackendError.rustError(lastErrorMessage(fallback: "`generate_van_witness` failed"))
+            guard let ptr else {
+                throw VotingRustBackendError.rustError(lastErrorMessage(fallback: "`generate_van_witness` failed"))
+            }
+            return ptr
         }
         defer { zcashlc_free_boxed_slice(ptr) }
         return try decodeJSON(from: ptr)
@@ -240,15 +246,16 @@ extension VotingRustBackend {
     ///
     /// Pass an empty `roundId` to reset all rounds.
     public func resetTreeClient(roundId: String = "") throws {
-        let dbh = try requireHandle()
         let roundIdBytes = [UInt8](roundId.utf8)
 
-        let result = roundIdBytes.withUnsafeBufferPointer { buf in
-            zcashlc_voting_reset_tree_client(dbh, buf.baseAddress, UInt(buf.count))
-        }
+        try withHandle { dbh in
+            let result = roundIdBytes.withUnsafeBufferPointer { buf in
+                zcashlc_voting_reset_tree_client(dbh, buf.baseAddress, UInt(buf.count))
+            }
 
-        guard result == 0 else {
-            throw VotingRustBackendError.rustError(lastErrorMessage(fallback: "`reset_tree_client` failed"))
+            guard result == 0 else {
+                throw VotingRustBackendError.rustError(lastErrorMessage(fallback: "`reset_tree_client` failed"))
+            }
         }
     }
 }
@@ -306,17 +313,16 @@ extension VotingRustBackend {
 // MARK: - Private helpers
 
 private extension VotingRustBackend {
-    /// Snapshot the current handle under the lock, throwing if the database
-    /// is not open. The pointer is read-only after `close()` resets it, so the
-    /// snapshot is valid for the duration of the FFI call as long as callers
-    /// do not race `close()` against other operations.
-    func requireHandle() throws -> OpaquePointer {
+    /// Runs a database-bound operation while holding the handle lock. Keeping
+    /// the lock through the FFI call prevents `close()` from freeing the handle
+    /// before Rust is done using it.
+    func withHandle<T>(_ operation: (OpaquePointer) throws -> T) throws -> T {
         lock.lock()
         defer { lock.unlock() }
         guard let dbh = handle else {
             throw VotingRustBackendError.databaseNotOpen
         }
-        return dbh
+        return try operation(dbh)
     }
 
     func lastErrorMessage(fallback: String) -> String {
@@ -345,3 +351,13 @@ private extension VotingRustBackend {
         return fallback
     }
 }
+
+#if DEBUG
+extension VotingRustBackend {
+    func _withLockedHandleForTesting(_ operation: () -> Void) throws {
+        try withHandle { _ in
+            operation()
+        }
+    }
+}
+#endif

--- a/Sources/ZcashLightClientKit/Rust/Voting/VotingRustBackend.swift
+++ b/Sources/ZcashLightClientKit/Rust/Voting/VotingRustBackend.swift
@@ -365,7 +365,7 @@ private extension VotingRustBackend {
 
 #if DEBUG
 extension VotingRustBackend {
-    func _withLockedHandleForTesting(_ operation: () -> Void) throws {
+    func withLockedHandleForTesting(_ operation: () -> Void) throws {
         try withHandle { _ in
             operation()
         }

--- a/Sources/ZcashLightClientKit/Rust/Voting/VotingRustBackend.swift
+++ b/Sources/ZcashLightClientKit/Rust/Voting/VotingRustBackend.swift
@@ -138,6 +138,8 @@ extension VotingRustBackend {
         networkId: UInt32,
         pirResolver: PirSnapshotResolver = PirSnapshotResolver()
     ) async throws -> VotingDelegationPirPrecomputeResult {
+        try requireOpenDatabase()
+
         // PirSnapshotResolver expects `BlockHeight` (Int); voting snapshot
         // heights are `UInt64` everywhere else in the voting types, so convert
         // at the boundary. Snapshot heights well within Int.max in practice.
@@ -323,6 +325,15 @@ private extension VotingRustBackend {
             throw VotingRustBackendError.databaseNotOpen
         }
         return try operation(dbh)
+    }
+
+    func requireOpenDatabase() throws {
+        lock.lock()
+        defer { lock.unlock() }
+
+        guard handle != nil else {
+            throw VotingRustBackendError.databaseNotOpen
+        }
     }
 
     func lastErrorMessage(fallback: String) -> String {

--- a/Tests/OfflineTests/VotingRustBackendTests.swift
+++ b/Tests/OfflineTests/VotingRustBackendTests.swift
@@ -7,6 +7,18 @@ import XCTest
 @testable import ZcashLightClientKit
 
 final class VotingRustBackendTests: XCTestCase {
+    private var dbPath: String?
+
+    override func tearDown() {
+        if let dbPath {
+            try? FileManager.default.removeItem(atPath: dbPath)
+        }
+        dbPath = nil
+        super.tearDown()
+    }
+
+    // MARK: - computeShareNullifier
+
     func test_computeShareNullifier_returnsExpectedValueForKnownFixture() throws {
         // Well-formed 32-byte fixtures.
         var voteCommitment = [UInt8](repeating: 0, count: 32)
@@ -56,5 +68,181 @@ final class VotingRustBackendTests: XCTestCase {
                 }
             }
         }
+    }
+
+    // MARK: - Database lifecycle
+
+    func test_open_succeedsAndCreatesFile() throws {
+        let backend = VotingRustBackend()
+        let path = makeTempDbPath()
+
+        try backend.open(path: path)
+        backend.close()
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: path))
+    }
+
+    func test_open_secondTime_throwsDatabaseAlreadyOpen() throws {
+        let backend = VotingRustBackend()
+        let path = makeTempDbPath()
+
+        try backend.open(path: path)
+        defer { backend.close() }
+
+        XCTAssertThrowsError(try backend.open(path: path)) { error in
+            guard case VotingRustBackendError.databaseAlreadyOpen = error else {
+                XCTFail("expected .databaseAlreadyOpen, got \(error)")
+                return
+            }
+        }
+    }
+
+    func test_close_isIdempotent() throws {
+        let backend = VotingRustBackend()
+        let path = makeTempDbPath()
+
+        try backend.open(path: path)
+        backend.close()
+        backend.close() // second close must not crash
+
+        // Re-opening after close must succeed.
+        try backend.open(path: path)
+        backend.close()
+    }
+
+    // MARK: - requireHandle gating
+
+    func test_setWalletId_beforeOpen_throwsDatabaseNotOpen() {
+        let backend = VotingRustBackend()
+        XCTAssertThrowsError(try backend.setWalletId("wallet")) { error in
+            guard case VotingRustBackendError.databaseNotOpen = error else {
+                XCTFail("expected .databaseNotOpen, got \(error)")
+                return
+            }
+        }
+    }
+
+    func test_resetTreeClient_beforeOpen_throwsDatabaseNotOpen() {
+        let backend = VotingRustBackend()
+        XCTAssertThrowsError(try backend.resetTreeClient()) { error in
+            guard case VotingRustBackendError.databaseNotOpen = error else {
+                XCTFail("expected .databaseNotOpen, got \(error)")
+                return
+            }
+        }
+    }
+
+    func test_generateVanWitness_beforeOpen_throwsDatabaseNotOpen() {
+        let backend = VotingRustBackend()
+        XCTAssertThrowsError(
+            try backend.generateVanWitness(roundId: "round1", bundleIndex: 0, anchorHeight: 0)
+        ) { error in
+            guard case VotingRustBackendError.databaseNotOpen = error else {
+                XCTFail("expected .databaseNotOpen, got \(error)")
+                return
+            }
+        }
+    }
+
+    func test_syncVoteTree_beforeOpen_throwsDatabaseNotOpen() {
+        let backend = VotingRustBackend()
+        XCTAssertThrowsError(
+            try backend.syncVoteTree(roundId: "round1", nodeUrl: "http://localhost")
+        ) { error in
+            guard case VotingRustBackendError.databaseNotOpen = error else {
+                XCTFail("expected .databaseNotOpen, got \(error)")
+                return
+            }
+        }
+    }
+
+    func test_precomputeDelegationPir_beforeOpen_throwsDatabaseNotOpen() async {
+        let backend = VotingRustBackend()
+        do {
+            _ = try await backend.precomputeDelegationPir(
+                roundId: "round1",
+                bundleIndex: 0,
+                notes: [],
+                pirEndpoints: ["https://stub"],
+                expectedSnapshotHeight: 0,
+                networkId: 1,
+                pirResolver: PirSnapshotResolver(probe: AlwaysMatchingProbe())
+            )
+            XCTFail("expected .databaseNotOpen")
+        } catch let error as VotingRustBackendError {
+            guard case .databaseNotOpen = error else {
+                XCTFail("expected .databaseNotOpen, got \(error)")
+                return
+            }
+        } catch {
+            XCTFail("unexpected error: \(error)")
+        }
+    }
+
+    // MARK: - setWalletId
+
+    func test_setWalletId_succeedsAfterOpen() throws {
+        let backend = VotingRustBackend()
+        try backend.open(path: makeTempDbPath())
+        defer { backend.close() }
+
+        XCTAssertNoThrow(try backend.setWalletId("wallet-id-1"))
+        // Idempotent: setting again must succeed too.
+        XCTAssertNoThrow(try backend.setWalletId("wallet-id-2"))
+    }
+
+    // MARK: - resetTreeClient
+
+    func test_resetTreeClient_succeedsAfterOpen_withEmptyRoundId() throws {
+        let backend = VotingRustBackend()
+        try backend.open(path: makeTempDbPath())
+        defer { backend.close() }
+
+        // Empty round ID resets all in-memory tree clients; safe to call on a
+        // fresh handle that has no clients yet.
+        XCTAssertNoThrow(try backend.resetTreeClient())
+    }
+
+    // MARK: - precomputeDelegationPir resolver gating
+
+    func test_precomputeDelegationPir_emptyEndpoints_throwsResolverError() async throws {
+        let backend = VotingRustBackend()
+        try backend.open(path: makeTempDbPath())
+        defer { backend.close() }
+
+        do {
+            _ = try await backend.precomputeDelegationPir(
+                roundId: "round1",
+                bundleIndex: 0,
+                notes: [],
+                pirEndpoints: [],
+                expectedSnapshotHeight: 0,
+                networkId: 1
+            )
+            XCTFail("expected PirSnapshotResolverError.noEndpointsConfigured")
+        } catch PirSnapshotResolverError.noEndpointsConfigured {
+            // expected
+        } catch {
+            XCTFail("unexpected error: \(error)")
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func makeTempDbPath() -> String {
+        let path = NSTemporaryDirectory()
+            + "VotingRustBackendTests-\(ProcessInfo.processInfo.globallyUniqueString).sqlite"
+        dbPath = path
+        return path
+    }
+}
+
+// MARK: - Test doubles
+
+/// Probe stub that reports every endpoint as matching, so we can drive the
+/// resolver into the FFI call without contacting a real server.
+private struct AlwaysMatchingProbe: PirSnapshotProbing {
+    func probe(url: String, expectedSnapshotHeight: BlockHeight) async -> PirSnapshotProbeOutcome {
+        PirSnapshotProbeOutcome(url: url, status: .matching(height: expectedSnapshotHeight))
     }
 }

--- a/Tests/OfflineTests/VotingRustBackendTests.swift
+++ b/Tests/OfflineTests/VotingRustBackendTests.swift
@@ -122,7 +122,7 @@ final class VotingRustBackendTests: XCTestCase {
 
         DispatchQueue.global().async {
             do {
-                try backend._withLockedHandleForTesting {
+                try backend.withLockedHandleForTesting {
                     operationStarted.fulfill()
                     releaseOperation.wait()
                 }

--- a/Tests/OfflineTests/VotingRustBackendTests.swift
+++ b/Tests/OfflineTests/VotingRustBackendTests.swift
@@ -110,6 +110,53 @@ final class VotingRustBackendTests: XCTestCase {
         backend.close()
     }
 
+    func test_close_waitsForInFlightDatabaseOperationBeforeFreeingHandle() throws {
+        let backend = VotingRustBackend()
+        let path = makeTempDbPath()
+        try backend.open(path: path)
+
+        let operationStarted = XCTestExpectation(description: "operation started")
+        let operationFinished = XCTestExpectation(description: "operation finished")
+        let releaseOperation = DispatchSemaphore(value: 0)
+        let closeFinished = DispatchSemaphore(value: 0)
+
+        DispatchQueue.global().async {
+            do {
+                try backend._withLockedHandleForTesting {
+                    operationStarted.fulfill()
+                    releaseOperation.wait()
+                }
+                operationFinished.fulfill()
+            } catch {
+                XCTFail("unexpected error: \(error)")
+            }
+        }
+
+        wait(for: [operationStarted], timeout: 1.0)
+
+        DispatchQueue.global().async {
+            backend.close()
+            closeFinished.signal()
+        }
+
+        XCTAssertEqual(
+            closeFinished.wait(timeout: .now() + .milliseconds(100)),
+            .timedOut,
+            "`close()` returned while a database operation still held the handle"
+        )
+
+        releaseOperation.signal()
+        wait(for: [operationFinished], timeout: 1.0)
+        XCTAssertEqual(closeFinished.wait(timeout: .now() + .seconds(1)), .success)
+
+        XCTAssertThrowsError(try backend.setWalletId("wallet-after-close")) { error in
+            guard case VotingRustBackendError.databaseNotOpen = error else {
+                XCTFail("expected .databaseNotOpen, got \(error)")
+                return
+            }
+        }
+    }
+
     // MARK: - requireHandle gating
 
     func test_setWalletId_beforeOpen_throwsDatabaseNotOpen() {

--- a/Tests/OfflineTests/VotingRustBackendTests.swift
+++ b/Tests/OfflineTests/VotingRustBackendTests.swift
@@ -213,7 +213,7 @@ final class VotingRustBackendTests: XCTestCase {
                 pirEndpoints: ["https://stub"],
                 expectedSnapshotHeight: 0,
                 networkId: 1,
-                pirResolver: PirSnapshotResolver(probe: AlwaysMatchingProbe())
+                pirResolver: PirSnapshotResolver(probe: FailingProbe())
             )
             XCTFail("expected .databaseNotOpen")
         } catch let error as VotingRustBackendError {
@@ -291,5 +291,13 @@ final class VotingRustBackendTests: XCTestCase {
 private struct AlwaysMatchingProbe: PirSnapshotProbing {
     func probe(url: String, expectedSnapshotHeight: BlockHeight) async -> PirSnapshotProbeOutcome {
         PirSnapshotProbeOutcome(url: url, status: .matching(height: expectedSnapshotHeight))
+    }
+}
+
+/// Probe stub used where endpoint probing must not happen.
+private struct FailingProbe: PirSnapshotProbing {
+    func probe(url: String, expectedSnapshotHeight: BlockHeight) async -> PirSnapshotProbeOutcome {
+        XCTFail("closed voting backend should fail before probing PIR endpoints")
+        return PirSnapshotProbeOutcome(url: url, status: .matching(height: expectedSnapshotHeight))
     }
 }


### PR DESCRIPTION
Tracks #1661.

This PR lands the next batch of `VotingRustBackend` Swift wrappers.

It also lays the structural groundwork (handle lifecycle + private helpers) that the remaining splits from [#1715](https://github.com/zcash/zcash-swift-wallet-sdk/pull/1715) will build on incrementally, one Rust submodule at a time.

## Summary

- Convert `VotingRustBackend` from a caseless namespace `enum` to a `public final class` that owns an opaque `VotingDatabaseHandle`.
- Add `init()` / `open(path:)` / `close()` (idempotent) / `deinit` over `zcashlc_voting_db_open` and `zcashlc_voting_db_free`. Handle access is serialized by an `NSLock`.
- Wrap the FFI that already lives on `main` but had no Swift entry point:
  - `setWalletId(_:)` → `zcashlc_voting_set_wallet_id`
  - `precomputeDelegationPir(...)` → `zcashlc_voting_precompute_delegation_pir`, with `PirSnapshotResolver`-driven endpoint selection
  - `syncVoteTree(roundId:nodeUrl:)` → `zcashlc_voting_sync_vote_tree`
  - `generateVanWitness(roundId:bundleIndex:anchorHeight:)` → `zcashlc_voting_generate_van_witness`
  - `resetTreeClient(roundId:)` → `zcashlc_voting_reset_tree_client`
- Add `VotingRustBackendError.databaseAlreadyOpen` / `.databaseNotOpen` for handle-state errors. Existing `.rustError` and `.invalidData` are unchanged.
- Add private helpers (`requireHandle()`, `decodeJSON(from:)`, `lastErrorMessage(fallback:)`) that subsequent voting wrappers will reuse unchanged.

No Swift API breakage at any existing call site.

## Tests

`Tests/OfflineTests/VotingRustBackendTests.swift` keeps the existing 2 nullifier tests and adds 11 new ones, all running fully offline.

```bash
swift test --filter OfflineTests.VotingRustBackendTests
```

13 tests, 0 failures locally on macOS arm64.