### PR TITLE
Add voting round recovery FFI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `libzcashlc` voting key-utility FFI: `zcashlc_voting_extract_orchard_fvk_from_ufvk`. Decodes a UFVK string and returns the raw 96-byte Orchard FVK. Returns null on missing Orchard component, malformed UFVK, or invalid `network_id`.
 - `libzcashlc` voting utility FFI: `zcashlc_voting_warm_proving_caches`, `zcashlc_voting_decompose_weight`, `zcashlc_voting_generate_delegation_inputs`, `zcashlc_voting_generate_delegation_inputs_with_fvk`, `zcashlc_voting_extract_pczt_sighash`, `zcashlc_voting_extract_spend_auth_sig`, `zcashlc_voting_extract_nc_root`, and `zcashlc_voting_verify_witness`. These cover voting proof setup, PCZT/signature extraction, note-commitment root extraction, and witness verification.
 - `libzcashlc` voting FFI return structs and free helpers for round state, hotkeys, bundle setup results, round summaries, and vote records.
+- `libzcashlc` voting round, recovery, and share-delegation tracking FFI for persisted round state and crash-recovery metadata. No Swift API surface is added in this step.
 
 ## Changed
 - Bumped Rust dependencies to current crates.io releases (`zcash_address` 0.10→0.11, `zcash_client_backend` 0.21→0.22, `zcash_client_sqlite` 0.19→0.20, `zcash_primitives`/`zcash_proofs` 0.26→0.27, `zcash_protocol` 0.7→0.8, `zcash_transparent` 0.6→0.7, `sapling-crypto` 0.6→0.7, `orchard` 0.12→0.13, `pczt` 0.5→0.6) and removed the `[patch.crates-io]` git-rev overrides. No public Swift API changes.

--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -43,6 +43,11 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `VotingDatabaseHandle` now also carries a
   `zcash_voting::tree_sync::VoteTreeSync`, constructed in
   `zcashlc_voting_db_open` and consumed by the tree-sync FFI above.
+- `zcashlc_voting_init_round`, `zcashlc_voting_get_round_state`,
+  `zcashlc_voting_list_rounds`, `zcashlc_voting_get_votes`,
+  `zcashlc_voting_clear_round`, `zcashlc_voting_delete_skipped_bundles`,
+  recovery-state transaction/hash/signature helpers, and share-delegation
+  tracking helpers for persisted voting round state.
 - `zcashlc_voting_get_wallet_notes`: Load unspent Orchard notes for a wallet
   account at a snapshot height and return them as JSON-encoded
   `Vec<NoteInfo>` in a `*mut FfiBoxedSlice`. `account_uuid` must be a non-null

--- a/rust/src/voting.rs
+++ b/rust/src/voting.rs
@@ -9,6 +9,8 @@ pub mod ffi_types;
 pub mod helpers;
 pub mod json;
 pub mod notes;
+pub mod recovery;
+pub mod rounds;
 pub mod share_tracking;
 pub mod tree;
 pub mod util;

--- a/rust/src/voting/recovery.rs
+++ b/rust/src/voting/recovery.rs
@@ -1,0 +1,311 @@
+use std::panic::AssertUnwindSafe;
+
+use anyhow::anyhow;
+use ffi_helpers::panic::catch_panic;
+
+use crate::{unwrap_exc_or, unwrap_exc_or_null};
+
+use super::db::VotingDatabaseHandle;
+use super::helpers::{bytes_from_ptr, json_to_boxed_slice, str_from_ptr};
+
+/// Persist the on-chain transaction hash of a submitted delegation bundle.
+///
+/// # Safety
+///
+/// - `db` must be a valid, non-null `VotingDatabaseHandle` pointer.
+/// - `round_id` and `tx_hash` must be valid UTF-8 pointers with their stated lengths.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn zcashlc_voting_store_delegation_tx_hash(
+    db: *mut VotingDatabaseHandle,
+    round_id: *const u8,
+    round_id_len: usize,
+    bundle_index: u32,
+    tx_hash: *const u8,
+    tx_hash_len: usize,
+) -> i32 {
+    let db = AssertUnwindSafe(db);
+    let res = catch_panic(|| {
+        let handle =
+            unsafe { db.as_ref() }.ok_or_else(|| anyhow!("VotingDatabaseHandle is null"))?;
+        let round_id_str = unsafe { str_from_ptr(round_id, round_id_len) }?;
+        let tx_hash_str = unsafe { str_from_ptr(tx_hash, tx_hash_len) }?;
+        handle
+            .db
+            .store_delegation_tx_hash(&round_id_str, bundle_index, &tx_hash_str)
+            .map_err(|e| anyhow!("store_delegation_tx_hash failed: {}", e))?;
+        Ok(0)
+    });
+    unwrap_exc_or(res, -1)
+}
+
+/// Load a previously stored delegation transaction hash.
+///
+/// Returns a JSON-encoded `Option<String>`.
+///
+/// # Safety
+///
+/// - `db` must be a valid, non-null `VotingDatabaseHandle` pointer.
+/// - `round_id` must be a valid UTF-8 pointer with its stated length.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn zcashlc_voting_get_delegation_tx_hash(
+    db: *mut VotingDatabaseHandle,
+    round_id: *const u8,
+    round_id_len: usize,
+    bundle_index: u32,
+) -> *mut crate::ffi::BoxedSlice {
+    let db = AssertUnwindSafe(db);
+    let res = catch_panic(|| {
+        let handle =
+            unsafe { db.as_ref() }.ok_or_else(|| anyhow!("VotingDatabaseHandle is null"))?;
+        let round_id_str = unsafe { str_from_ptr(round_id, round_id_len) }?;
+        let hash = handle
+            .db
+            .get_delegation_tx_hash(&round_id_str, bundle_index)
+            .map_err(|e| anyhow!("get_delegation_tx_hash failed: {}", e))?;
+        json_to_boxed_slice(&hash)
+    });
+    unwrap_exc_or_null(res)
+}
+
+/// Persist the on-chain transaction hash of a submitted vote.
+///
+/// # Safety
+///
+/// - `db` must be a valid, non-null `VotingDatabaseHandle` pointer.
+/// - `round_id` and `tx_hash` must be valid UTF-8 pointers with their stated lengths.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn zcashlc_voting_store_vote_tx_hash(
+    db: *mut VotingDatabaseHandle,
+    round_id: *const u8,
+    round_id_len: usize,
+    bundle_index: u32,
+    proposal_id: u32,
+    tx_hash: *const u8,
+    tx_hash_len: usize,
+) -> i32 {
+    let db = AssertUnwindSafe(db);
+    let res = catch_panic(|| {
+        let handle =
+            unsafe { db.as_ref() }.ok_or_else(|| anyhow!("VotingDatabaseHandle is null"))?;
+        let round_id_str = unsafe { str_from_ptr(round_id, round_id_len) }?;
+        let tx_hash_str = unsafe { str_from_ptr(tx_hash, tx_hash_len) }?;
+        handle
+            .db
+            .store_vote_tx_hash(&round_id_str, bundle_index, proposal_id, &tx_hash_str)
+            .map_err(|e| anyhow!("store_vote_tx_hash failed: {}", e))?;
+        Ok(0)
+    });
+    unwrap_exc_or(res, -1)
+}
+
+/// Load a previously stored vote transaction hash.
+///
+/// Returns a JSON-encoded `Option<String>`.
+///
+/// # Safety
+///
+/// - `db` must be a valid, non-null `VotingDatabaseHandle` pointer.
+/// - `round_id` must be a valid UTF-8 pointer with its stated length.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn zcashlc_voting_get_vote_tx_hash(
+    db: *mut VotingDatabaseHandle,
+    round_id: *const u8,
+    round_id_len: usize,
+    bundle_index: u32,
+    proposal_id: u32,
+) -> *mut crate::ffi::BoxedSlice {
+    let db = AssertUnwindSafe(db);
+    let res = catch_panic(|| {
+        let handle =
+            unsafe { db.as_ref() }.ok_or_else(|| anyhow!("VotingDatabaseHandle is null"))?;
+        let round_id_str = unsafe { str_from_ptr(round_id, round_id_len) }?;
+        let hash = handle
+            .db
+            .get_vote_tx_hash(&round_id_str, bundle_index, proposal_id)
+            .map_err(|e| anyhow!("get_vote_tx_hash failed: {}", e))?;
+        json_to_boxed_slice(&hash)
+    });
+    unwrap_exc_or_null(res)
+}
+
+/// Persist a vote commitment bundle and vote-commitment-tree position.
+///
+/// # Safety
+///
+/// - `db` must be a valid, non-null `VotingDatabaseHandle` pointer.
+/// - `round_id` and `bundle_json` must be valid UTF-8 pointers with their stated lengths.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn zcashlc_voting_store_commitment_bundle(
+    db: *mut VotingDatabaseHandle,
+    round_id: *const u8,
+    round_id_len: usize,
+    bundle_index: u32,
+    proposal_id: u32,
+    bundle_json: *const u8,
+    bundle_json_len: usize,
+    vc_tree_position: u64,
+) -> i32 {
+    let db = AssertUnwindSafe(db);
+    let res = catch_panic(|| {
+        let handle =
+            unsafe { db.as_ref() }.ok_or_else(|| anyhow!("VotingDatabaseHandle is null"))?;
+        let round_id_str = unsafe { str_from_ptr(round_id, round_id_len) }?;
+        let json_str = unsafe { str_from_ptr(bundle_json, bundle_json_len) }?;
+        handle
+            .db
+            .store_commitment_bundle(
+                &round_id_str,
+                bundle_index,
+                proposal_id,
+                &json_str,
+                vc_tree_position,
+            )
+            .map_err(|e| anyhow!("store_commitment_bundle failed: {}", e))?;
+        Ok(0)
+    });
+    unwrap_exc_or(res, -1)
+}
+
+/// Load a stored commitment bundle and vote-commitment-tree position.
+///
+/// Returns a JSON-encoded `Option<(String, u64)>`.
+///
+/// # Safety
+///
+/// - `db` must be a valid, non-null `VotingDatabaseHandle` pointer.
+/// - `round_id` must be a valid UTF-8 pointer with its stated length.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn zcashlc_voting_get_commitment_bundle(
+    db: *mut VotingDatabaseHandle,
+    round_id: *const u8,
+    round_id_len: usize,
+    bundle_index: u32,
+    proposal_id: u32,
+) -> *mut crate::ffi::BoxedSlice {
+    let db = AssertUnwindSafe(db);
+    let res = catch_panic(|| {
+        let handle =
+            unsafe { db.as_ref() }.ok_or_else(|| anyhow!("VotingDatabaseHandle is null"))?;
+        let round_id_str = unsafe { str_from_ptr(round_id, round_id_len) }?;
+        let result = handle
+            .db
+            .get_commitment_bundle(&round_id_str, bundle_index, proposal_id)
+            .map_err(|e| anyhow!("get_commitment_bundle failed: {}", e))?;
+        json_to_boxed_slice(&result)
+    });
+    unwrap_exc_or_null(res)
+}
+
+/// Persist a Keystone-produced PCZT signature.
+///
+/// # Safety
+///
+/// - `db` must be a valid, non-null `VotingDatabaseHandle` pointer.
+/// - `round_id` must be a valid UTF-8 pointer with its stated length.
+/// - `sig`, `sighash`, and `rk` must be valid for reads of their stated lengths.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn zcashlc_voting_store_keystone_signature(
+    db: *mut VotingDatabaseHandle,
+    round_id: *const u8,
+    round_id_len: usize,
+    bundle_index: u32,
+    sig: *const u8,
+    sig_len: usize,
+    sighash: *const u8,
+    sighash_len: usize,
+    rk: *const u8,
+    rk_len: usize,
+) -> i32 {
+    let db = AssertUnwindSafe(db);
+    let res = catch_panic(|| {
+        let handle =
+            unsafe { db.as_ref() }.ok_or_else(|| anyhow!("VotingDatabaseHandle is null"))?;
+        let round_id_str = unsafe { str_from_ptr(round_id, round_id_len) }?;
+        let sig_bytes = unsafe { bytes_from_ptr(sig, sig_len) }?;
+        let sighash_bytes = unsafe { bytes_from_ptr(sighash, sighash_len) }?;
+        let rk_bytes = unsafe { bytes_from_ptr(rk, rk_len) }?;
+        handle
+            .db
+            .store_keystone_signature(
+                &round_id_str,
+                bundle_index,
+                sig_bytes,
+                sighash_bytes,
+                rk_bytes,
+            )
+            .map_err(|e| anyhow!("store_keystone_signature failed: {}", e))?;
+        Ok(0)
+    });
+    unwrap_exc_or(res, -1)
+}
+
+/// Load all Keystone signatures stored for a round.
+///
+/// # Safety
+///
+/// - `db` must be a valid, non-null `VotingDatabaseHandle` pointer.
+/// - `round_id` must be a valid UTF-8 pointer with its stated length.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn zcashlc_voting_get_keystone_signatures(
+    db: *mut VotingDatabaseHandle,
+    round_id: *const u8,
+    round_id_len: usize,
+) -> *mut crate::ffi::BoxedSlice {
+    let db = AssertUnwindSafe(db);
+    let res = catch_panic(|| {
+        let handle =
+            unsafe { db.as_ref() }.ok_or_else(|| anyhow!("VotingDatabaseHandle is null"))?;
+        let round_id_str = unsafe { str_from_ptr(round_id, round_id_len) }?;
+        let sigs = handle
+            .db
+            .get_keystone_signatures(&round_id_str)
+            .map_err(|e| anyhow!("get_keystone_signatures failed: {}", e))?;
+
+        #[derive(serde::Serialize)]
+        struct SigOut {
+            bundle_index: u32,
+            sig: Vec<u8>,
+            sighash: Vec<u8>,
+            rk: Vec<u8>,
+        }
+
+        let out: Vec<SigOut> = sigs
+            .into_iter()
+            .map(|s| SigOut {
+                bundle_index: s.bundle_index,
+                sig: s.sig,
+                sighash: s.sighash,
+                rk: s.rk,
+            })
+            .collect();
+
+        json_to_boxed_slice(&out)
+    });
+    unwrap_exc_or_null(res)
+}
+
+/// Remove all recovery-state rows for a round.
+///
+/// # Safety
+///
+/// - `db` must be a valid, non-null `VotingDatabaseHandle` pointer.
+/// - `round_id` must be a valid UTF-8 pointer with its stated length.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn zcashlc_voting_clear_recovery_state(
+    db: *mut VotingDatabaseHandle,
+    round_id: *const u8,
+    round_id_len: usize,
+) -> i32 {
+    let db = AssertUnwindSafe(db);
+    let res = catch_panic(|| {
+        let handle =
+            unsafe { db.as_ref() }.ok_or_else(|| anyhow!("VotingDatabaseHandle is null"))?;
+        let round_id_str = unsafe { str_from_ptr(round_id, round_id_len) }?;
+        handle
+            .db
+            .clear_recovery_state(&round_id_str)
+            .map_err(|e| anyhow!("clear_recovery_state failed: {}", e))?;
+        Ok(0)
+    });
+    unwrap_exc_or(res, -1)
+}

--- a/rust/src/voting/rounds.rs
+++ b/rust/src/voting/rounds.rs
@@ -1,0 +1,258 @@
+use std::ffi::CString;
+use std::panic::AssertUnwindSafe;
+
+use anyhow::anyhow;
+use ffi_helpers::panic::catch_panic;
+use zcash_voting as voting;
+
+use crate::{unwrap_exc_or, unwrap_exc_or_null};
+
+use super::db::VotingDatabaseHandle;
+use super::ffi_types::{
+    FfiRoundState, FfiRoundSummaries, FfiRoundSummary, FfiVoteRecord, FfiVoteRecords,
+};
+use super::helpers::{bytes_from_ptr, round_phase_to_u32, str_from_ptr};
+
+/// Initialize a voting round.
+///
+/// Returns 0 on success, -1 on error.
+///
+/// # Safety
+///
+/// - `db` must be a valid, non-null `VotingDatabaseHandle` pointer.
+/// - String/byte parameters must be valid for their stated lengths.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn zcashlc_voting_init_round(
+    db: *mut VotingDatabaseHandle,
+    round_id: *const u8,
+    round_id_len: usize,
+    snapshot_height: u64,
+    ea_pk: *const u8,
+    ea_pk_len: usize,
+    nc_root: *const u8,
+    nc_root_len: usize,
+    nullifier_imt_root: *const u8,
+    nullifier_imt_root_len: usize,
+    session_json: *const u8,
+    session_json_len: usize,
+) -> i32 {
+    let db = AssertUnwindSafe(db);
+    let res = catch_panic(|| {
+        let handle =
+            unsafe { db.as_ref() }.ok_or_else(|| anyhow!("VotingDatabaseHandle is null"))?;
+        let round_id_str = unsafe { str_from_ptr(round_id, round_id_len) }?;
+        let ea_pk_bytes = unsafe { bytes_from_ptr(ea_pk, ea_pk_len) }?.to_vec();
+        let nc_root_bytes = unsafe { bytes_from_ptr(nc_root, nc_root_len) }?.to_vec();
+        let nullifier_imt_root_bytes =
+            unsafe { bytes_from_ptr(nullifier_imt_root, nullifier_imt_root_len) }?.to_vec();
+
+        let session = if session_json.is_null() || session_json_len == 0 {
+            None
+        } else {
+            Some(unsafe { str_from_ptr(session_json, session_json_len) }?)
+        };
+
+        let params = voting::VotingRoundParams {
+            vote_round_id: round_id_str,
+            snapshot_height,
+            ea_pk: ea_pk_bytes,
+            nc_root: nc_root_bytes,
+            nullifier_imt_root: nullifier_imt_root_bytes,
+        };
+
+        handle
+            .db
+            .init_round(&params, session.as_deref())
+            .map_err(|e| anyhow!("init_round failed: {}", e))?;
+        Ok(0)
+    });
+    unwrap_exc_or(res, -1)
+}
+
+/// Get the state of a voting round.
+///
+/// Returns a pointer to `FfiRoundState` on success, or null on error.
+/// Call `zcashlc_voting_free_round_state` to free the returned pointer.
+///
+/// # Safety
+///
+/// - `db` must be a valid, non-null `VotingDatabaseHandle` pointer.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn zcashlc_voting_get_round_state(
+    db: *mut VotingDatabaseHandle,
+    round_id: *const u8,
+    round_id_len: usize,
+) -> *mut FfiRoundState {
+    let db = AssertUnwindSafe(db);
+    let res = catch_panic(|| {
+        let handle =
+            unsafe { db.as_ref() }.ok_or_else(|| anyhow!("VotingDatabaseHandle is null"))?;
+        let round_id_str = unsafe { str_from_ptr(round_id, round_id_len) }?;
+
+        let state = handle
+            .db
+            .get_round_state(&round_id_str)
+            .map_err(|e| anyhow!("get_round_state failed: {}", e))?;
+
+        let phase = round_phase_to_u32(state.phase);
+        let ffi_state = FfiRoundState {
+            round_id: CString::new(state.round_id)
+                .map_err(|e| anyhow!("invalid round_id string: {}", e))?
+                .into_raw(),
+            phase,
+            snapshot_height: state.snapshot_height,
+            hotkey_address: match state.hotkey_address {
+                Some(addr) => CString::new(addr)
+                    .map_err(|e| anyhow!("invalid hotkey_address string: {}", e))?
+                    .into_raw(),
+                None => std::ptr::null_mut(),
+            },
+            delegated_weight: state.delegated_weight.map_or(-1, |w| w as i64),
+            proof_generated: state.proof_generated,
+        };
+
+        Ok(Box::into_raw(Box::new(ffi_state)))
+    });
+    unwrap_exc_or_null(res)
+}
+
+/// List all voting rounds.
+///
+/// Returns a pointer to `FfiRoundSummaries` on success, or null on error.
+/// Call `zcashlc_voting_free_round_summaries` to free the returned pointer.
+///
+/// # Safety
+///
+/// - `db` must be a valid, non-null `VotingDatabaseHandle` pointer.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn zcashlc_voting_list_rounds(
+    db: *mut VotingDatabaseHandle,
+) -> *mut FfiRoundSummaries {
+    let db = AssertUnwindSafe(db);
+    let res = catch_panic(|| {
+        let handle =
+            unsafe { db.as_ref() }.ok_or_else(|| anyhow!("VotingDatabaseHandle is null"))?;
+
+        let rounds = handle
+            .db
+            .list_rounds()
+            .map_err(|e| anyhow!("list_rounds failed: {}", e))?;
+
+        let ffi_rounds: Vec<FfiRoundSummary> = rounds
+            .into_iter()
+            .map(|s| {
+                let phase = round_phase_to_u32(s.phase);
+                Ok(FfiRoundSummary {
+                    round_id: CString::new(s.round_id)
+                        .map_err(|e| anyhow!("invalid round_id string: {}", e))?
+                        .into_raw(),
+                    phase,
+                    snapshot_height: s.snapshot_height,
+                    created_at: s.created_at,
+                })
+            })
+            .collect::<anyhow::Result<Vec<_>>>()?;
+
+        let (ptr, len) = crate::ptr_from_vec(ffi_rounds);
+        Ok(Box::into_raw(Box::new(FfiRoundSummaries { ptr, len })))
+    });
+    unwrap_exc_or_null(res)
+}
+
+/// Get vote records for a round.
+///
+/// Returns a pointer to `FfiVoteRecords` on success, or null on error.
+/// Call `zcashlc_voting_free_vote_records` to free the returned pointer.
+///
+/// # Safety
+///
+/// - `db` must be a valid, non-null `VotingDatabaseHandle` pointer.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn zcashlc_voting_get_votes(
+    db: *mut VotingDatabaseHandle,
+    round_id: *const u8,
+    round_id_len: usize,
+) -> *mut FfiVoteRecords {
+    let db = AssertUnwindSafe(db);
+    let res = catch_panic(|| {
+        let handle =
+            unsafe { db.as_ref() }.ok_or_else(|| anyhow!("VotingDatabaseHandle is null"))?;
+        let round_id_str = unsafe { str_from_ptr(round_id, round_id_len) }?;
+
+        let votes = handle
+            .db
+            .get_votes(&round_id_str)
+            .map_err(|e| anyhow!("get_votes failed: {}", e))?;
+
+        let ffi_votes: Vec<FfiVoteRecord> = votes
+            .into_iter()
+            .map(|v| FfiVoteRecord {
+                proposal_id: v.proposal_id,
+                bundle_index: v.bundle_index,
+                choice: v.choice,
+                submitted: v.submitted,
+            })
+            .collect();
+
+        let (ptr, len) = crate::ptr_from_vec(ffi_votes);
+        Ok(Box::into_raw(Box::new(FfiVoteRecords { ptr, len })))
+    });
+    unwrap_exc_or_null(res)
+}
+
+/// Clear all data for a voting round.
+///
+/// Returns 0 on success, -1 on error.
+///
+/// # Safety
+///
+/// - `db` must be a valid, non-null `VotingDatabaseHandle` pointer.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn zcashlc_voting_clear_round(
+    db: *mut VotingDatabaseHandle,
+    round_id: *const u8,
+    round_id_len: usize,
+) -> i32 {
+    let db = AssertUnwindSafe(db);
+    let res = catch_panic(|| {
+        let handle =
+            unsafe { db.as_ref() }.ok_or_else(|| anyhow!("VotingDatabaseHandle is null"))?;
+        let round_id_str = unsafe { str_from_ptr(round_id, round_id_len) }?;
+
+        handle
+            .db
+            .clear_round(&round_id_str)
+            .map_err(|e| anyhow!("clear_round failed: {}", e))?;
+        Ok(0)
+    });
+    unwrap_exc_or(res, -1)
+}
+
+/// Delete bundle rows with index >= `keep_count`, removing skipped bundles.
+///
+/// Returns the number of deleted rows on success, or -1 on error.
+///
+/// # Safety
+///
+/// - `db` must be a valid, non-null `VotingDatabaseHandle` pointer.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn zcashlc_voting_delete_skipped_bundles(
+    db: *mut VotingDatabaseHandle,
+    round_id: *const u8,
+    round_id_len: usize,
+    keep_count: u32,
+) -> i64 {
+    let db = AssertUnwindSafe(db);
+    let res = catch_panic(|| {
+        let handle =
+            unsafe { db.as_ref() }.ok_or_else(|| anyhow!("VotingDatabaseHandle is null"))?;
+        let round_id_str = unsafe { str_from_ptr(round_id, round_id_len) }?;
+
+        let deleted = handle
+            .db
+            .delete_skipped_bundles(&round_id_str, keep_count)
+            .map_err(|e| anyhow!("delete_skipped_bundles failed: {}", e))?;
+        Ok(deleted as i64)
+    });
+    unwrap_exc_or(res, -1)
+}

--- a/rust/src/voting/share_tracking.rs
+++ b/rust/src/voting/share_tracking.rs
@@ -1,12 +1,47 @@
 use std::ffi::CString;
 use std::fmt::Write as _;
 use std::os::raw::c_char;
+use std::panic::AssertUnwindSafe;
 
 use anyhow::anyhow;
 use ffi_helpers::panic::catch_panic;
+use serde::{Deserialize, Serialize};
 use zcash_voting as voting;
 
-use crate::unwrap_exc_or_null;
+use crate::{unwrap_exc_or, unwrap_exc_or_null};
+
+use super::db::VotingDatabaseHandle;
+use super::helpers::{bytes_from_ptr, json_to_boxed_slice, str_from_ptr};
+
+/// JSON representation for share delegation records crossing the FFI boundary.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct JsonShareDelegationRecord {
+    pub round_id: String,
+    pub bundle_index: u32,
+    pub proposal_id: u32,
+    pub share_index: u32,
+    pub sent_to_urls: Vec<String>,
+    pub nullifier: Vec<u8>,
+    pub confirmed: bool,
+    pub submit_at: u64,
+    pub created_at: u64,
+}
+
+impl From<voting::ShareDelegationRecord> for JsonShareDelegationRecord {
+    fn from(r: voting::ShareDelegationRecord) -> Self {
+        Self {
+            round_id: r.round_id,
+            bundle_index: r.bundle_index,
+            proposal_id: r.proposal_id,
+            share_index: r.share_index,
+            sent_to_urls: r.sent_to_urls,
+            nullifier: r.nullifier,
+            confirmed: r.confirmed,
+            submit_at: r.submit_at,
+            created_at: r.created_at,
+        }
+    }
+}
 
 /// Compute the share reveal nullifier from client-known inputs.
 ///
@@ -42,4 +77,189 @@ pub unsafe extern "C" fn zcashlc_voting_compute_share_nullifier(
         Ok(c_str.into_raw())
     });
     unwrap_exc_or_null(res)
+}
+
+/// Record a share delegation after sending to helper servers.
+///
+/// Returns 0 on success, -1 on error.
+///
+/// # Safety
+///
+/// - `db` must be a valid, non-null `VotingDatabaseHandle` pointer.
+/// - String params must be valid UTF-8 pointers with correct lengths.
+/// - `nullifier_ptr` must point to `nullifier_len` bytes.
+/// - `sent_to_urls_json` must be a JSON array of strings.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn zcashlc_voting_record_share_delegation(
+    db: *mut VotingDatabaseHandle,
+    round_id: *const u8,
+    round_id_len: usize,
+    bundle_index: u32,
+    proposal_id: u32,
+    share_index: u32,
+    sent_to_urls_json: *const u8,
+    sent_to_urls_json_len: usize,
+    nullifier_ptr: *const u8,
+    nullifier_len: usize,
+    submit_at: u64,
+) -> i32 {
+    let db = AssertUnwindSafe(db);
+    let res = catch_panic(|| {
+        let handle =
+            unsafe { db.as_ref() }.ok_or_else(|| anyhow!("VotingDatabaseHandle is null"))?;
+        let round_id_str = unsafe { str_from_ptr(round_id, round_id_len) }?;
+        let urls_bytes = unsafe { bytes_from_ptr(sent_to_urls_json, sent_to_urls_json_len) }?;
+        let sent_to_urls: Vec<String> = serde_json::from_slice(urls_bytes)?;
+        let nullifier = unsafe { bytes_from_ptr(nullifier_ptr, nullifier_len) }?;
+
+        handle
+            .db
+            .record_share_delegation(
+                &round_id_str,
+                bundle_index,
+                proposal_id,
+                share_index,
+                &sent_to_urls,
+                nullifier,
+                submit_at,
+            )
+            .map_err(|e| anyhow!("record_share_delegation failed: {}", e))?;
+        Ok(0)
+    });
+    unwrap_exc_or(res, -1)
+}
+
+/// Get all share delegations for a round.
+///
+/// Returns a JSON array of `JsonShareDelegationRecord`, or null on error.
+///
+/// # Safety
+///
+/// - `db` must be a valid, non-null `VotingDatabaseHandle` pointer.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn zcashlc_voting_get_share_delegations(
+    db: *mut VotingDatabaseHandle,
+    round_id: *const u8,
+    round_id_len: usize,
+) -> *mut crate::ffi::BoxedSlice {
+    let db = AssertUnwindSafe(db);
+    let res = catch_panic(|| {
+        let handle =
+            unsafe { db.as_ref() }.ok_or_else(|| anyhow!("VotingDatabaseHandle is null"))?;
+        let round_id_str = unsafe { str_from_ptr(round_id, round_id_len) }?;
+
+        let records = handle
+            .db
+            .get_share_delegations(&round_id_str)
+            .map_err(|e| anyhow!("get_share_delegations failed: {}", e))?;
+
+        let json_records: Vec<JsonShareDelegationRecord> =
+            records.into_iter().map(Into::into).collect();
+        json_to_boxed_slice(&json_records)
+    });
+    unwrap_exc_or_null(res)
+}
+
+/// Get unconfirmed share delegations for a round.
+///
+/// Returns a JSON array of `JsonShareDelegationRecord`, or null on error.
+///
+/// # Safety
+///
+/// - `db` must be a valid, non-null `VotingDatabaseHandle` pointer.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn zcashlc_voting_get_unconfirmed_delegations(
+    db: *mut VotingDatabaseHandle,
+    round_id: *const u8,
+    round_id_len: usize,
+) -> *mut crate::ffi::BoxedSlice {
+    let db = AssertUnwindSafe(db);
+    let res = catch_panic(|| {
+        let handle =
+            unsafe { db.as_ref() }.ok_or_else(|| anyhow!("VotingDatabaseHandle is null"))?;
+        let round_id_str = unsafe { str_from_ptr(round_id, round_id_len) }?;
+
+        let records = handle
+            .db
+            .get_unconfirmed_delegations(&round_id_str)
+            .map_err(|e| anyhow!("get_unconfirmed_delegations failed: {}", e))?;
+
+        let json_records: Vec<JsonShareDelegationRecord> =
+            records.into_iter().map(Into::into).collect();
+        json_to_boxed_slice(&json_records)
+    });
+    unwrap_exc_or_null(res)
+}
+
+/// Mark a share delegation as confirmed on-chain.
+///
+/// Returns 0 on success, -1 on error.
+///
+/// # Safety
+///
+/// - `db` must be a valid, non-null `VotingDatabaseHandle` pointer.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn zcashlc_voting_mark_share_confirmed(
+    db: *mut VotingDatabaseHandle,
+    round_id: *const u8,
+    round_id_len: usize,
+    bundle_index: u32,
+    proposal_id: u32,
+    share_index: u32,
+) -> i32 {
+    let db = AssertUnwindSafe(db);
+    let res = catch_panic(|| {
+        let handle =
+            unsafe { db.as_ref() }.ok_or_else(|| anyhow!("VotingDatabaseHandle is null"))?;
+        let round_id_str = unsafe { str_from_ptr(round_id, round_id_len) }?;
+
+        handle
+            .db
+            .mark_share_confirmed(&round_id_str, bundle_index, proposal_id, share_index)
+            .map_err(|e| anyhow!("mark_share_confirmed failed: {}", e))?;
+        Ok(0)
+    });
+    unwrap_exc_or(res, -1)
+}
+
+/// Append new server URLs to a share delegation's `sent_to_urls`.
+///
+/// Returns 0 on success, -1 on error.
+///
+/// # Safety
+///
+/// - `db` must be a valid, non-null `VotingDatabaseHandle` pointer.
+/// - `new_urls_json` must be a JSON array of strings.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn zcashlc_voting_add_sent_servers(
+    db: *mut VotingDatabaseHandle,
+    round_id: *const u8,
+    round_id_len: usize,
+    bundle_index: u32,
+    proposal_id: u32,
+    share_index: u32,
+    new_urls_json: *const u8,
+    new_urls_json_len: usize,
+) -> i32 {
+    let db = AssertUnwindSafe(db);
+    let res = catch_panic(|| {
+        let handle =
+            unsafe { db.as_ref() }.ok_or_else(|| anyhow!("VotingDatabaseHandle is null"))?;
+        let round_id_str = unsafe { str_from_ptr(round_id, round_id_len) }?;
+        let urls_bytes = unsafe { bytes_from_ptr(new_urls_json, new_urls_json_len) }?;
+        let new_urls: Vec<String> = serde_json::from_slice(urls_bytes)?;
+
+        handle
+            .db
+            .add_sent_servers(
+                &round_id_str,
+                bundle_index,
+                proposal_id,
+                share_index,
+                &new_urls,
+            )
+            .map_err(|e| anyhow!("add_sent_servers failed: {}", e))?;
+        Ok(0)
+    });
+    unwrap_exc_or(res, -1)
 }


### PR DESCRIPTION
Adds the Rust-only stateful voting FFI for round lifecycle, round/vote inspection, recovery metadata persistence, and share-delegation tracking.

This targets the voting FFI foundation branch so the diff excludes the shared helper and return-struct work already under review. No Swift API surface is added here.

Validated with `cargo check --locked` and `cargo clippy --all-targets -- -D warnings`.
