### PR TITLE
[#1661] Add voting delegation workflow Swift wrappers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,7 +72,7 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `getDelegationSubmission(roundId:bundleIndex:senderSeed:networkId:accountIndex:)` → `zcashlc_voting_get_delegation_submission`
   - `getDelegationSubmission(roundId:bundleIndex:keystoneSig:sighash:)` → `zcashlc_voting_get_delegation_submission_with_keystone_sig`
   - `storeVanPosition(roundId:bundleIndex:position:)` → `zcashlc_voting_store_van_position`
-  - `buildAndProveDelegation(roundId:bundleIndex:treeState:roundName:progress:)` (`async`, runs on a detached `Task`) → `zcashlc_voting_build_and_prove_delegation` (with progress callback bridge)
+  - `buildAndProveDelegation(roundId:bundleIndex:notes:hotkeyRawAddress:pirEndpoints:expectedSnapshotHeight:networkId:pirResolver:progress:)` (`async`, resolves the PIR snapshot endpoint, then runs proving on a detached `Task`) → `zcashlc_voting_build_and_prove_delegation` (with progress callback bridge)
 - `Broadcaster` protocol — separates transaction creation from submission, enabling custom broadcast strategies (e.g. submitting to multiple lightwalletd servers in parallel).
   - `Broadcaster.createProposedTransactions(proposal:spendingKey:)` — creates transactions locally without broadcasting, returning `[ZcashTransaction.Overview]` with raw bytes.
   - `Broadcaster.createTransactionFromPCZT(pcztWithProofs:pcztWithSigs:)` — extracts and stores a transaction from PCZT data without submitting.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,59 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Vote-tree sync: `syncVoteTree(roundId:nodeUrl:)`, `generateVanWitness(roundId:bundleIndex:anchorHeight:)`, and `resetTreeClient(roundId:)` over the corresponding `zcashlc_voting_sync_vote_tree` / `_generate_van_witness` / `_reset_tree_client` FFI.
   - The static `computeShareNullifier(voteCommitment:shareIndex:primaryBlind:)` over `zcashlc_voting_compute_share_nullifier`, with 32-byte input validation.
   - `VotingRustBackendError` cases `databaseAlreadyOpen` / `databaseNotOpen` for handle-state errors, alongside the existing `rustError` and `invalidData`.
+- Extends `VotingRustBackend` with additional FFI wrappers and their FFI mappings:
+
+  Foundation helpers (static)
+  - `warmProvingCaches()` → `zcashlc_voting_warm_proving_caches`
+  - `decomposeWeight(_:)` → `zcashlc_voting_decompose_weight`
+  - `generateDelegationInputs(senderSeed:hotkeySeed:networkId:accountIndex:)` → `zcashlc_voting_generate_delegation_inputs`
+  - `generateDelegationInputs(senderFvk:hotkeySeed:networkId:seedFingerprint:)` → `zcashlc_voting_generate_delegation_inputs_with_fvk`
+  - `extractPcztSighash(pczt:)` → `zcashlc_voting_extract_pczt_sighash`
+  - `extractSpendAuthSig(signedPczt:actionIndex:)` → `zcashlc_voting_extract_spend_auth_sig`
+  - `extractOrchardFvk(ufvk:networkId:)` → `zcashlc_voting_extract_orchard_fvk_from_ufvk`
+  - `extractNcRoot(treeState:)` → `zcashlc_voting_extract_nc_root`
+  - `verifyWitness(_:)` → `zcashlc_voting_verify_witness`
+  - `validatePirProof(_:)` → `zcashlc_voting_validate_pir_proof` (takes `VotingPirProof`)
+
+  Round lifecycle
+  - `initRound(roundId:snapshotHeight:eaPublicKey:ncRoot:nullifierImtRoot:sessionJson:)` → `zcashlc_voting_init_round`
+  - `getRoundState(roundId:)` → `zcashlc_voting_get_round_state` (frees `FfiRoundState` via `zcashlc_voting_free_round_state`)
+  - `listRounds()` → `zcashlc_voting_list_rounds` (frees `FfiRoundSummaries` via `zcashlc_voting_free_round_summaries`)
+  - `getVotes(roundId:)` → `zcashlc_voting_get_votes` (frees `FfiVoteRecords` via `zcashlc_voting_free_vote_records`)
+  - `clearRound(roundId:)` → `zcashlc_voting_clear_round`
+  - `deleteSkippedBundles(roundId:keepCount:)` → `zcashlc_voting_delete_skipped_bundles`
+
+  Wallet notes
+  - `getWalletNotes(accountUuidBytes:dataDbPath:snapshotHeight:networkId:)` → `zcashlc_voting_get_wallet_notes`
+
+  Recovery state
+  - `storeDelegationTxHash(roundId:bundleIndex:txHash:)` → `zcashlc_voting_store_delegation_tx_hash`
+  - `getDelegationTxHash(roundId:bundleIndex:)` → `zcashlc_voting_get_delegation_tx_hash`
+  - `storeVoteTxHash(roundId:bundleIndex:proposalId:txHash:)` → `zcashlc_voting_store_vote_tx_hash`
+  - `getVoteTxHash(roundId:bundleIndex:proposalId:)` → `zcashlc_voting_get_vote_tx_hash`
+  - `storeCommitmentBundle(roundId:bundleIndex:proposalId:bundleJson:voteCommitmentTreePosition:)` → `zcashlc_voting_store_commitment_bundle`
+  - `getCommitmentBundle(roundId:bundleIndex:proposalId:)` → `zcashlc_voting_get_commitment_bundle`
+  - `storeKeystoneSignature(roundId:bundleIndex:sig:sighash:randomizedKey:)` → `zcashlc_voting_store_keystone_signature`
+  - `getKeystoneSignatures(roundId:)` → `zcashlc_voting_get_keystone_signatures`
+  - `clearRecoveryState(roundId:)` → `zcashlc_voting_clear_recovery_state`
+
+  Share delegation tracking
+  - `recordShareDelegation(roundId:bundleIndex:proposalId:shareIndex:sentToURLs:nullifier:submitAt:)` → `zcashlc_voting_record_share_delegation`
+  - `getShareDelegations(roundId:)` → `zcashlc_voting_get_share_delegations`
+  - `getUnconfirmedDelegations(roundId:)` → `zcashlc_voting_get_unconfirmed_delegations`
+  - `markShareConfirmed(roundId:bundleIndex:proposalId:shareIndex:)` → `zcashlc_voting_mark_share_confirmed`
+  - `addSentServers(roundId:bundleIndex:proposalId:shareIndex:newURLs:)` → `zcashlc_voting_add_sent_servers`
+
+  Delegation workflow
+  - `generateHotkey(roundId:seed:)` → `zcashlc_voting_generate_hotkey` (frees `FfiVotingHotkey` via `zcashlc_voting_free_hotkey`)
+  - `setupBundles(roundId:notes:)` → `zcashlc_voting_setup_bundles` (frees `FfiBundleSetupResult` via `zcashlc_voting_free_bundle_setup_result`)
+  - `getBundleCount(roundId:)` → `zcashlc_voting_get_bundle_count`
+  - `buildPczt(_:)` → `zcashlc_voting_build_pczt` (takes `VotingBuildPcztParams`)
+  - `storeTreeState(roundId:treeState:)` → `zcashlc_voting_store_tree_state`
+  - `getDelegationSubmission(roundId:bundleIndex:senderSeed:networkId:accountIndex:)` → `zcashlc_voting_get_delegation_submission`
+  - `getDelegationSubmission(roundId:bundleIndex:keystoneSig:sighash:)` → `zcashlc_voting_get_delegation_submission_with_keystone_sig`
+  - `storeVanPosition(roundId:bundleIndex:position:)` → `zcashlc_voting_store_van_position`
+  - `buildAndProveDelegation(roundId:bundleIndex:treeState:roundName:progress:)` (`async`, runs on a detached `Task`) → `zcashlc_voting_build_and_prove_delegation` (with progress callback bridge)
 - `Broadcaster` protocol — separates transaction creation from submission, enabling custom broadcast strategies (e.g. submitting to multiple lightwalletd servers in parallel).
   - `Broadcaster.createProposedTransactions(proposal:spendingKey:)` — creates transactions locally without broadcasting, returning `[ZcashTransaction.Overview]` with raw bytes.
   - `Broadcaster.createTransactionFromPCZT(pcztWithProofs:pcztWithSigs:)` — extracts and stores a transaction from PCZT data without submitting.

--- a/Sources/ZcashLightClientKit/Rust/Voting/VotingConstants.swift
+++ b/Sources/ZcashLightClientKit/Rust/Voting/VotingConstants.swift
@@ -19,3 +19,11 @@ let votingPirPathElementCount = 29
 let votingPirPathByteCount = votingPirPathElementCount * votingPirRootByteCount
 let votingPirNullifierByteCount = 32
 let votingPirExpectedRootByteCount = 32
+
+// ASCII byte bounds used when validating hex-encoded voting inputs.
+let votingCharacterByteZero = UInt8(ascii: "0")
+let votingCharacterByteNine = UInt8(ascii: "9")
+let votingCharacterByteUppercaseA = UInt8(ascii: "A")
+let votingCharacterByteUppercaseF = UInt8(ascii: "F")
+let votingCharacterByteLowercaseA = UInt8(ascii: "a")
+let votingCharacterByteLowercaseF = UInt8(ascii: "f")

--- a/Sources/ZcashLightClientKit/Rust/Voting/VotingConstants.swift
+++ b/Sources/ZcashLightClientKit/Rust/Voting/VotingConstants.swift
@@ -1,0 +1,21 @@
+//
+//  VotingConstants.swift
+//  ZcashLightClientKit
+//
+
+let votingFieldElementByteCount = 32
+let votingAccountUuidByteCount = 16
+let votingOrchardFvkByteCount = 96
+let votingMinSeedByteCount = 32
+let votingSeedFingerprintByteCount = 32
+let votingShareNullifierByteCount = 32
+let votingShareNullifierHexCharacterCount = votingShareNullifierByteCount * 2
+let votingKeystoneSignatureByteCount = 64
+let votingPcztSighashByteCount = 32
+let votingRandomizedKeyByteCount = 32
+let votingPirRootByteCount = 32
+let votingPirNullifierBoundsByteCount = 96
+let votingPirPathElementCount = 29
+let votingPirPathByteCount = votingPirPathElementCount * votingPirRootByteCount
+let votingPirNullifierByteCount = 32
+let votingPirExpectedRootByteCount = 32

--- a/Sources/ZcashLightClientKit/Rust/Voting/VotingRustBackend.swift
+++ b/Sources/ZcashLightClientKit/Rust/Voting/VotingRustBackend.swift
@@ -1537,8 +1537,8 @@ extension VotingRustBackend {
         }
 
         switch result {
-        case 0: return true
-        case 1: return false
+        case 1: return true
+        case 0: return false
         default:
             throw VotingRustBackendError.rustError(
                 staticLastErrorMessage(fallback: "`validate_pir_proof` failed")

--- a/Sources/ZcashLightClientKit/Rust/Voting/VotingRustBackend.swift
+++ b/Sources/ZcashLightClientKit/Rust/Voting/VotingRustBackend.swift
@@ -767,6 +767,12 @@ extension VotingRustBackend {
                 )
             }
         }
+
+        guard try getDelegationTxHash(roundId: roundId, bundleIndex: bundleIndex) == txHash else {
+            throw VotingRustBackendError.rustError(
+                "delegation tx hash was not persisted for round \(roundId) bundle \(bundleIndex)"
+            )
+        }
     }
 
     /// Load a previously-stored delegation transaction hash, if any.
@@ -1037,10 +1043,43 @@ extension VotingRustBackend {
         let roundIdBytes = [UInt8](roundId.utf8)
         let urlsJson = try JSONEncoder().encode(sentToURLs)
         let urlsBytes = [UInt8](urlsJson)
+
+        do {
+            try recordShareDelegation(
+                roundIdBytes: roundIdBytes,
+                bundleIndex: bundleIndex,
+                proposalId: proposalId,
+                shareIndex: shareIndex,
+                urlsBytes: urlsBytes,
+                nullifierArgument: nullifier,
+                submitAt: submitAt
+            )
+        } catch VotingRustBackendError.rustError(let message) where message.contains("invalid utf-8") {
+            try recordShareDelegation(
+                roundIdBytes: roundIdBytes,
+                bundleIndex: bundleIndex,
+                proposalId: proposalId,
+                shareIndex: shareIndex,
+                urlsBytes: urlsBytes,
+                nullifierArgument: [UInt8](Self.hexString(for: nullifier).utf8),
+                submitAt: submitAt
+            )
+        }
+    }
+
+    private func recordShareDelegation(
+        roundIdBytes: [UInt8],
+        bundleIndex: UInt32,
+        proposalId: UInt32,
+        shareIndex: UInt32,
+        urlsBytes: [UInt8],
+        nullifierArgument: [UInt8],
+        submitAt: UInt64
+    ) throws {
         try withHandle { dbh in
             let result = roundIdBytes.withUnsafeBufferPointer { ridBuf in
                 urlsBytes.withUnsafeBufferPointer { urlsBuf in
-                    nullifier.withUnsafeBufferPointer { nfBuf in
+                    nullifierArgument.withUnsafeBufferPointer { nfBuf in
                         zcashlc_voting_record_share_delegation(
                             dbh,
                             ridBuf.baseAddress,
@@ -1601,6 +1640,10 @@ private extension VotingRustBackend {
         }
 
         return phase
+    }
+
+    static func hexString(for bytes: [UInt8]) -> String {
+        bytes.map { String(format: "%02x", $0) }.joined()
     }
 
     /// Decode required C strings from Rust, treating null as an invariant violation.

--- a/Sources/ZcashLightClientKit/Rust/Voting/VotingRustBackend.swift
+++ b/Sources/ZcashLightClientKit/Rust/Voting/VotingRustBackend.swift
@@ -6,6 +6,26 @@
 import Foundation
 import libzcashlc
 
+// MARK: - Constants
+
+private enum VotingByteCount {
+    static let fieldElement = 32
+    static let accountUuid = 16
+    static let orchardFvk = 96
+    static let minSeed = 32
+    static let seedFingerprint = 32
+    static let shareNullifier = 32
+    static let keystoneSignature = 64
+    static let pcztSighash = 32
+    static let randomizedKey = 32
+    static let pirRoot = 32
+    static let pirNullifierBounds = 96
+    static let pirPathElementCount = 29
+    static let pirPath = pirPathElementCount * pirRoot
+    static let pirNullifier = 32
+    static let pirExpectedRoot = 32
+}
+
 // MARK: - Error
 
 /// Error type for voting Rust backend operations.
@@ -265,9 +285,6 @@ extension VotingRustBackend {
 // MARK: - Share tracking (static)
 
 extension VotingRustBackend {
-    /// Byte width of a Pallas base-field element as expected by the voting FFI.
-    private static let fieldElementByteCount = 32
-
     /// Compute the nullifier for a vote share.
     ///
     /// - Parameters:
@@ -284,11 +301,11 @@ extension VotingRustBackend {
         primaryBlind: [UInt8]
     ) throws -> String {
         guard
-            voteCommitment.count == fieldElementByteCount,
-            primaryBlind.count == fieldElementByteCount
+            voteCommitment.count == VotingByteCount.fieldElement,
+            primaryBlind.count == VotingByteCount.fieldElement
         else {
             throw VotingRustBackendError.invalidData(
-                "voteCommitment and primaryBlind must each be exactly \(fieldElementByteCount) bytes"
+                "voteCommitment and primaryBlind must each be exactly \(VotingByteCount.fieldElement) bytes"
             )
         }
 
@@ -309,6 +326,1212 @@ extension VotingRustBackend {
         }
         defer { zcashlc_string_free(ptr) }
         return String(cString: ptr)
+    }
+}
+
+// MARK: - Foundation helpers (static)
+
+extension VotingRustBackend {
+    /// Warm process-lifetime proving-key caches used by voting proofs.
+    ///
+    /// Safe to call multiple times; subsequent calls are cheap. Call once at app
+    /// startup (off the main actor) to avoid a multi-second pause inside the
+    /// first proving call.
+    public static func warmProvingCaches() throws {
+        let result = zcashlc_voting_warm_proving_caches()
+        guard result == 0 else {
+            throw VotingRustBackendError.rustError(
+                staticLastErrorMessage(fallback: "`warm_proving_caches` failed")
+            )
+        }
+    }
+
+    /// Decompose `weight` into the power-of-two components used by voting
+    /// share construction.
+    public static func decomposeWeight(_ weight: UInt64) throws -> [UInt64] {
+        guard let ptr = zcashlc_voting_decompose_weight(weight) else {
+            throw VotingRustBackendError.rustError(
+                staticLastErrorMessage(fallback: "`decompose_weight` failed")
+            )
+        }
+        defer { zcashlc_free_boxed_slice(ptr) }
+        return try staticDecodeJSON(from: ptr)
+    }
+
+    /// Generate the public delegation inputs for a sender seed + hotkey seed pair.
+    ///
+    /// Both seeds must be ≥ 32 bytes. The hotkey is always derived at account
+    /// index 0 to match `zcash_voting`'s signing convention; `accountIndex`
+    /// drives only the sender's UFVK derivation.
+    public static func generateDelegationInputs(
+        senderSeed: [UInt8],
+        hotkeySeed: [UInt8],
+        networkId: UInt32,
+        accountIndex: UInt32
+    ) throws -> VotingDelegationInputs {
+        guard senderSeed.count >= VotingByteCount.minSeed, hotkeySeed.count >= VotingByteCount.minSeed else {
+            throw VotingRustBackendError.invalidData(
+                "senderSeed and hotkeySeed must each be at least \(VotingByteCount.minSeed) bytes"
+            )
+        }
+        let ptr = senderSeed.withUnsafeBufferPointer { senderBuf in
+            hotkeySeed.withUnsafeBufferPointer { hotkeyBuf in
+                zcashlc_voting_generate_delegation_inputs(
+                    senderBuf.baseAddress,
+                    UInt(senderBuf.count),
+                    hotkeyBuf.baseAddress,
+                    UInt(hotkeyBuf.count),
+                    networkId,
+                    accountIndex
+                )
+            }
+        }
+        guard let ptr else {
+            throw VotingRustBackendError.rustError(
+                staticLastErrorMessage(fallback: "`generate_delegation_inputs` failed")
+            )
+        }
+        defer { zcashlc_free_boxed_slice(ptr) }
+        return try staticDecodeJSON(from: ptr)
+    }
+
+    /// Generate delegation inputs from an explicit sender FVK + hotkey seed,
+    /// bypassing sender-seed derivation.
+    public static func generateDelegationInputs(
+        senderFvk: [UInt8],
+        hotkeySeed: [UInt8],
+        networkId: UInt32,
+        seedFingerprint: [UInt8]
+    ) throws -> VotingDelegationInputs {
+        guard senderFvk.count == VotingByteCount.orchardFvk else {
+            throw VotingRustBackendError.invalidData(
+                "senderFvk must be exactly \(VotingByteCount.orchardFvk) bytes"
+            )
+        }
+        guard hotkeySeed.count >= VotingByteCount.minSeed else {
+            throw VotingRustBackendError.invalidData(
+                "hotkeySeed must be at least \(VotingByteCount.minSeed) bytes"
+            )
+        }
+        guard seedFingerprint.count == VotingByteCount.seedFingerprint else {
+            throw VotingRustBackendError.invalidData(
+                "seedFingerprint must be exactly \(VotingByteCount.seedFingerprint) bytes"
+            )
+        }
+        let ptr = senderFvk.withUnsafeBufferPointer { fvkBuf in
+            hotkeySeed.withUnsafeBufferPointer { hotkeyBuf in
+                seedFingerprint.withUnsafeBufferPointer { fpBuf in
+                    zcashlc_voting_generate_delegation_inputs_with_fvk(
+                        fvkBuf.baseAddress,
+                        UInt(fvkBuf.count),
+                        hotkeyBuf.baseAddress,
+                        UInt(hotkeyBuf.count),
+                        networkId,
+                        fpBuf.baseAddress,
+                        UInt(fpBuf.count)
+                    )
+                }
+            }
+        }
+        guard let ptr else {
+            throw VotingRustBackendError.rustError(
+                staticLastErrorMessage(fallback: "`generate_delegation_inputs_with_fvk` failed")
+            )
+        }
+        defer { zcashlc_free_boxed_slice(ptr) }
+        return try staticDecodeJSON(from: ptr)
+    }
+
+    /// Extract the ZIP-244 shielded sighash from a finalized PCZT.
+    public static func extractPcztSighash(pczt: [UInt8]) throws -> [UInt8] {
+        try staticBoxedSliceFFI(fallback: "`extract_pczt_sighash` failed") {
+            pczt.withUnsafeBufferPointer { buf in
+                zcashlc_voting_extract_pczt_sighash(buf.baseAddress, UInt(buf.count))
+            }
+        }
+    }
+
+    /// Extract the spend-auth signature for `actionIndex` from a signed PCZT.
+    public static func extractSpendAuthSig(
+        signedPczt: [UInt8],
+        actionIndex: UInt32
+    ) throws -> [UInt8] {
+        try staticBoxedSliceFFI(fallback: "`extract_spend_auth_sig` failed") {
+            signedPczt.withUnsafeBufferPointer { buf in
+                zcashlc_voting_extract_spend_auth_sig(buf.baseAddress, UInt(buf.count), actionIndex)
+            }
+        }
+    }
+
+    /// Extract the 96-byte Orchard FVK from a UFVK string.
+    public static func extractOrchardFvk(ufvk: String, networkId: UInt32) throws -> [UInt8] {
+        let bytes = [UInt8](ufvk.utf8)
+        return try staticBoxedSliceFFI(fallback: "`extract_orchard_fvk_from_ufvk` failed") {
+            bytes.withUnsafeBufferPointer { buf in
+                zcashlc_voting_extract_orchard_fvk_from_ufvk(buf.baseAddress, UInt(buf.count), networkId)
+            }
+        }
+    }
+
+    /// Extract the 32-byte Orchard note-commitment-tree root from a
+    /// protobuf-encoded `TreeState`.
+    public static func extractNcRoot(treeState: [UInt8]) throws -> [UInt8] {
+        try staticBoxedSliceFFI(fallback: "`extract_nc_root` failed") {
+            treeState.withUnsafeBufferPointer { buf in
+                zcashlc_voting_extract_nc_root(buf.baseAddress, UInt(buf.count))
+            }
+        }
+    }
+
+    /// Verify a Merkle witness against the witness's embedded root.
+    ///
+    /// Returns `true` if valid, `false` if well-formed but invalid.
+    /// Throws `.rustError` if the witness JSON is malformed.
+    public static func verifyWitness(_ witness: VotingWitnessData) throws -> Bool {
+        let json = try JSONEncoder().encode(witness)
+        let bytes = [UInt8](json)
+        let result = bytes.withUnsafeBufferPointer { buf in
+            zcashlc_voting_verify_witness(buf.baseAddress, UInt(buf.count))
+        }
+        switch result {
+        case 1: return true
+        case 0: return false
+        default:
+            throw VotingRustBackendError.rustError(
+                staticLastErrorMessage(fallback: "`verify_witness` failed")
+            )
+        }
+    }
+}
+
+// MARK: - Round lifecycle
+
+extension VotingRustBackend {
+    /// Initialize a voting round.
+    ///
+    /// Round-parameter byte arrays are validated by Rust; invalid lengths
+    /// throw `.rustError` rather than persisting a partial round.
+    /// `sessionJson` is optional; pass `nil` to leave it unset.
+    public func initRound(
+        roundId: String,
+        snapshotHeight: UInt64,
+        eaPublicKey: [UInt8],
+        ncRoot: [UInt8],
+        nullifierImtRoot: [UInt8],
+        sessionJson: String? = nil
+    ) throws {
+        let roundIdBytes = [UInt8](roundId.utf8)
+        let sessionBytes = sessionJson.map { [UInt8]($0.utf8) }
+
+        try withHandle { dbh in
+            let result = roundIdBytes.withUnsafeBufferPointer { ridBuf in
+                eaPublicKey.withUnsafeBufferPointer { eaBuf in
+                    ncRoot.withUnsafeBufferPointer { ncBuf in
+                        nullifierImtRoot.withUnsafeBufferPointer { nullBuf in
+                            withOptionalBufferPointer(sessionBytes) { sessionBuf in
+                                zcashlc_voting_init_round(
+                                    dbh,
+                                    ridBuf.baseAddress,
+                                    UInt(ridBuf.count),
+                                    snapshotHeight,
+                                    eaBuf.baseAddress,
+                                    UInt(eaBuf.count),
+                                    ncBuf.baseAddress,
+                                    UInt(ncBuf.count),
+                                    nullBuf.baseAddress,
+                                    UInt(nullBuf.count),
+                                    sessionBuf?.baseAddress,
+                                    UInt(sessionBuf?.count ?? 0)
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+
+            guard result == 0 else {
+                throw VotingRustBackendError.rustError(lastErrorMessage(fallback: "`init_round` failed"))
+            }
+        }
+    }
+
+    /// Read the persisted state of a round.
+    public func getRoundState(roundId: String) throws -> VotingRoundState {
+        let roundIdBytes = [UInt8](roundId.utf8)
+
+        let ptr: UnsafeMutablePointer<FfiRoundState> = try withHandle { dbh in
+            let ptr: UnsafeMutablePointer<FfiRoundState>? = roundIdBytes.withUnsafeBufferPointer { buf in
+                zcashlc_voting_get_round_state(dbh, buf.baseAddress, UInt(buf.count))
+            }
+            guard let ptr else {
+                throw VotingRustBackendError.rustError(
+                    lastErrorMessage(fallback: "`get_round_state` failed")
+                )
+            }
+            return ptr
+        }
+        defer { zcashlc_voting_free_round_state(ptr) }
+
+        let raw = ptr.pointee
+        let phase = try Self.decodeRoundPhase(raw.phase)
+        let storedRoundId = try Self.decodeRequiredCString(raw.round_id, fieldName: "round_id")
+        let hotkeyAddress = raw.hotkey_address.map { String(cString: $0) }
+        let delegatedWeight: UInt64? = raw.delegated_weight < 0
+            ? nil
+            : UInt64(raw.delegated_weight)
+
+        return VotingRoundState(
+            roundId: storedRoundId,
+            phase: phase,
+            snapshotHeight: raw.snapshot_height,
+            hotkeyAddress: hotkeyAddress,
+            delegatedWeight: delegatedWeight,
+            proofGenerated: raw.proof_generated
+        )
+    }
+
+    /// List all voting rounds known to the database, in storage order.
+    public func listRounds() throws -> [VotingRoundSummary] {
+        let ptr: UnsafeMutablePointer<FfiRoundSummaries> = try withHandle { dbh in
+            guard let ptr = zcashlc_voting_list_rounds(dbh) else {
+                throw VotingRustBackendError.rustError(
+                    lastErrorMessage(fallback: "`list_rounds` failed")
+                )
+            }
+            return ptr
+        }
+        defer { zcashlc_voting_free_round_summaries(ptr) }
+
+        let summariesPtr = ptr.pointee.ptr
+        let count = Int(ptr.pointee.len)
+        guard count > 0, let summariesPtr else { return [] }
+
+        var summaries: [VotingRoundSummary] = []
+        summaries.reserveCapacity(count)
+        for index in 0..<count {
+            let raw = summariesPtr.advanced(by: index).pointee
+            let storedRoundId = try Self.decodeRequiredCString(raw.round_id, fieldName: "round_id")
+            let phase = try Self.decodeRoundPhase(raw.phase)
+            summaries.append(
+                VotingRoundSummary(
+                    roundId: storedRoundId,
+                    phase: phase,
+                    snapshotHeight: raw.snapshot_height,
+                    createdAt: raw.created_at
+                )
+            )
+        }
+        return summaries
+    }
+
+    /// Read all vote records persisted for a round.
+    public func getVotes(roundId: String) throws -> [VotingVoteRecord] {
+        let roundIdBytes = [UInt8](roundId.utf8)
+
+        let ptr: UnsafeMutablePointer<FfiVoteRecords> = try withHandle { dbh in
+            let ptr: UnsafeMutablePointer<FfiVoteRecords>? = roundIdBytes.withUnsafeBufferPointer { buf in
+                zcashlc_voting_get_votes(dbh, buf.baseAddress, UInt(buf.count))
+            }
+            guard let ptr else {
+                throw VotingRustBackendError.rustError(
+                    lastErrorMessage(fallback: "`get_votes` failed")
+                )
+            }
+            return ptr
+        }
+        defer { zcashlc_voting_free_vote_records(ptr) }
+
+        let recordsPtr = ptr.pointee.ptr
+        let count = Int(ptr.pointee.len)
+        guard count > 0, let recordsPtr else { return [] }
+
+        var records: [VotingVoteRecord] = []
+        records.reserveCapacity(count)
+        for index in 0..<count {
+            let raw = recordsPtr.advanced(by: index).pointee
+            records.append(
+                VotingVoteRecord(
+                    proposalId: raw.proposal_id,
+                    bundleIndex: raw.bundle_index,
+                    choice: raw.choice,
+                    submitted: raw.submitted
+                )
+            )
+        }
+        return records
+    }
+
+    /// Clear all persisted data for a round.
+    public func clearRound(roundId: String) throws {
+        let roundIdBytes = [UInt8](roundId.utf8)
+        try withHandle { dbh in
+            let result = roundIdBytes.withUnsafeBufferPointer { buf in
+                zcashlc_voting_clear_round(dbh, buf.baseAddress, UInt(buf.count))
+            }
+            guard result == 0 else {
+                throw VotingRustBackendError.rustError(lastErrorMessage(fallback: "`clear_round` failed"))
+            }
+        }
+    }
+
+    /// Delete bundle rows with index ≥ `keepCount`, returning the number of rows deleted.
+    public func deleteSkippedBundles(roundId: String, keepCount: UInt32) throws -> UInt32 {
+        let roundIdBytes = [UInt8](roundId.utf8)
+        return try withHandle { dbh in
+            let deleted = roundIdBytes.withUnsafeBufferPointer { buf in
+                zcashlc_voting_delete_skipped_bundles(dbh, buf.baseAddress, UInt(buf.count), keepCount)
+            }
+            guard deleted >= 0 else {
+                throw VotingRustBackendError.rustError(
+                    lastErrorMessage(fallback: "`delete_skipped_bundles` failed")
+                )
+            }
+            return UInt32(deleted)
+        }
+    }
+}
+
+// MARK: - Wallet notes
+
+extension VotingRustBackend {
+    /// Read the wallet notes eligible for voting at `snapshotHeight`.
+    ///
+    /// `accountUuidBytes` must be exactly 16 bytes; the FFI scopes the query
+    /// to a specific account and rejects any other length.
+    public func getWalletNotes(
+        accountUuidBytes: [UInt8],
+        dataDbPath: String,
+        snapshotHeight: UInt64,
+        networkId: UInt32
+    ) throws -> [VotingNoteInfo] {
+        guard accountUuidBytes.count == VotingByteCount.accountUuid else {
+            throw VotingRustBackendError.invalidData(
+                "accountUuidBytes must be exactly \(VotingByteCount.accountUuid) bytes"
+            )
+        }
+        let pathBytes = [UInt8](dataDbPath.utf8)
+
+        let ptr: UnsafeMutablePointer<FfiBoxedSlice> = try withHandle { dbh in
+            let ptr: UnsafeMutablePointer<FfiBoxedSlice>? = pathBytes.withUnsafeBufferPointer { pathBuf in
+                accountUuidBytes.withUnsafeBufferPointer { uuidBuf in
+                    zcashlc_voting_get_wallet_notes(
+                        dbh,
+                        pathBuf.baseAddress,
+                        UInt(pathBuf.count),
+                        snapshotHeight,
+                        networkId,
+                        uuidBuf.baseAddress,
+                        UInt(uuidBuf.count)
+                    )
+                }
+            }
+            guard let ptr else {
+                throw VotingRustBackendError.rustError(
+                    lastErrorMessage(fallback: "`get_wallet_notes` failed")
+                )
+            }
+            return ptr
+        }
+        defer { zcashlc_free_boxed_slice(ptr) }
+        return try decodeJSON(from: ptr)
+    }
+}
+
+// MARK: - Recovery state
+
+extension VotingRustBackend {
+    /// Persist the on-chain transaction hash for a submitted delegation bundle.
+    public func storeDelegationTxHash(
+        roundId: String,
+        bundleIndex: UInt32,
+        txHash: String
+    ) throws {
+        let roundIdBytes = [UInt8](roundId.utf8)
+        let txHashBytes = [UInt8](txHash.utf8)
+        try withHandle { dbh in
+            let result = roundIdBytes.withUnsafeBufferPointer { ridBuf in
+                txHashBytes.withUnsafeBufferPointer { txBuf in
+                    zcashlc_voting_store_delegation_tx_hash(
+                        dbh,
+                        ridBuf.baseAddress,
+                        UInt(ridBuf.count),
+                        bundleIndex,
+                        txBuf.baseAddress,
+                        UInt(txBuf.count)
+                    )
+                }
+            }
+            guard result == 0 else {
+                throw VotingRustBackendError.rustError(
+                    lastErrorMessage(fallback: "`store_delegation_tx_hash` failed")
+                )
+            }
+        }
+    }
+
+    /// Load a previously-stored delegation transaction hash, if any.
+    public func getDelegationTxHash(
+        roundId: String,
+        bundleIndex: UInt32
+    ) throws -> VotingTxHashLookup {
+        let roundIdBytes = [UInt8](roundId.utf8)
+        let ptr: UnsafeMutablePointer<FfiBoxedSlice> = try withHandle { dbh in
+            let ptr: UnsafeMutablePointer<FfiBoxedSlice>? = roundIdBytes.withUnsafeBufferPointer { buf in
+                zcashlc_voting_get_delegation_tx_hash(
+                    dbh,
+                    buf.baseAddress,
+                    UInt(buf.count),
+                    bundleIndex
+                )
+            }
+            guard let ptr else {
+                throw VotingRustBackendError.rustError(
+                    lastErrorMessage(fallback: "`get_delegation_tx_hash` failed")
+                )
+            }
+            return ptr
+        }
+        defer { zcashlc_free_boxed_slice(ptr) }
+        let stored: String? = try decodeJSON(from: ptr)
+        return stored.map { .present($0) } ?? .notFound
+    }
+
+    /// Persist the on-chain transaction hash for a submitted vote.
+    public func storeVoteTxHash(
+        roundId: String,
+        bundleIndex: UInt32,
+        proposalId: UInt32,
+        txHash: String
+    ) throws {
+        let roundIdBytes = [UInt8](roundId.utf8)
+        let txHashBytes = [UInt8](txHash.utf8)
+        try withHandle { dbh in
+            let result = roundIdBytes.withUnsafeBufferPointer { ridBuf in
+                txHashBytes.withUnsafeBufferPointer { txBuf in
+                    zcashlc_voting_store_vote_tx_hash(
+                        dbh,
+                        ridBuf.baseAddress,
+                        UInt(ridBuf.count),
+                        bundleIndex,
+                        proposalId,
+                        txBuf.baseAddress,
+                        UInt(txBuf.count)
+                    )
+                }
+            }
+            guard result == 0 else {
+                throw VotingRustBackendError.rustError(
+                    lastErrorMessage(fallback: "`store_vote_tx_hash` failed")
+                )
+            }
+        }
+    }
+
+    /// Load a previously-stored vote transaction hash, if any.
+    public func getVoteTxHash(
+        roundId: String,
+        bundleIndex: UInt32,
+        proposalId: UInt32
+    ) throws -> VotingTxHashLookup {
+        let roundIdBytes = [UInt8](roundId.utf8)
+        let ptr: UnsafeMutablePointer<FfiBoxedSlice> = try withHandle { dbh in
+            let ptr: UnsafeMutablePointer<FfiBoxedSlice>? = roundIdBytes.withUnsafeBufferPointer { buf in
+                zcashlc_voting_get_vote_tx_hash(
+                    dbh,
+                    buf.baseAddress,
+                    UInt(buf.count),
+                    bundleIndex,
+                    proposalId
+                )
+            }
+            guard let ptr else {
+                throw VotingRustBackendError.rustError(
+                    lastErrorMessage(fallback: "`get_vote_tx_hash` failed")
+                )
+            }
+            return ptr
+        }
+        defer { zcashlc_free_boxed_slice(ptr) }
+        let stored: String? = try decodeJSON(from: ptr)
+        return stored.map { .present($0) } ?? .notFound
+    }
+
+    /// Persist a vote-commitment bundle as raw JSON, plus its position in the
+    /// vote-commitment tree.
+    public func storeCommitmentBundle(
+        roundId: String,
+        bundleIndex: UInt32,
+        proposalId: UInt32,
+        bundleJson: String,
+        voteCommitmentTreePosition: UInt64
+    ) throws {
+        let roundIdBytes = [UInt8](roundId.utf8)
+        let bundleBytes = [UInt8](bundleJson.utf8)
+        try withHandle { dbh in
+            let result = roundIdBytes.withUnsafeBufferPointer { ridBuf in
+                bundleBytes.withUnsafeBufferPointer { bundleBuf in
+                    zcashlc_voting_store_commitment_bundle(
+                        dbh,
+                        ridBuf.baseAddress,
+                        UInt(ridBuf.count),
+                        bundleIndex,
+                        proposalId,
+                        bundleBuf.baseAddress,
+                        UInt(bundleBuf.count),
+                        voteCommitmentTreePosition
+                    )
+                }
+            }
+            guard result == 0 else {
+                throw VotingRustBackendError.rustError(
+                    lastErrorMessage(fallback: "`store_commitment_bundle` failed")
+                )
+            }
+        }
+    }
+
+    /// Load a previously-stored commitment bundle, if any.
+    public func getCommitmentBundle(
+        roundId: String,
+        bundleIndex: UInt32,
+        proposalId: UInt32
+    ) throws -> VotingStoredCommitmentBundle? {
+        let roundIdBytes = [UInt8](roundId.utf8)
+        let ptr: UnsafeMutablePointer<FfiBoxedSlice> = try withHandle { dbh in
+            let ptr: UnsafeMutablePointer<FfiBoxedSlice>? = roundIdBytes.withUnsafeBufferPointer { buf in
+                zcashlc_voting_get_commitment_bundle(
+                    dbh,
+                    buf.baseAddress,
+                    UInt(buf.count),
+                    bundleIndex,
+                    proposalId
+                )
+            }
+            guard let ptr else {
+                throw VotingRustBackendError.rustError(
+                    lastErrorMessage(fallback: "`get_commitment_bundle` failed")
+                )
+            }
+            return ptr
+        }
+        defer { zcashlc_free_boxed_slice(ptr) }
+
+        // Rust returns `Option<(String, u64)>`; in JSON that is `null` or
+        // a 2-element array `[bundle_json, vc_tree_position]`.
+        let stored: StoredCommitmentBundleWire? = try decodeJSON(from: ptr)
+        return stored.map {
+            VotingStoredCommitmentBundle(
+                bundleJson: $0.bundleJson,
+                voteCommitmentTreePosition: $0.voteCommitmentTreePosition
+            )
+        }
+    }
+
+    /// Persist a Keystone-produced PCZT signature for a delegation bundle.
+    ///
+    /// `sig` must be exactly 64 bytes; `sighash` and `randomizedKey` must each
+    /// be exactly 32 bytes (matches the Rust-side validation).
+    public func storeKeystoneSignature(
+        roundId: String,
+        bundleIndex: UInt32,
+        sig: [UInt8],
+        sighash: [UInt8],
+        randomizedKey: [UInt8]
+    ) throws {
+        guard sig.count == VotingByteCount.keystoneSignature else {
+            throw VotingRustBackendError.invalidData(
+                "sig must be exactly \(VotingByteCount.keystoneSignature) bytes"
+            )
+        }
+        guard sighash.count == VotingByteCount.pcztSighash else {
+            throw VotingRustBackendError.invalidData(
+                "sighash must be exactly \(VotingByteCount.pcztSighash) bytes"
+            )
+        }
+        guard randomizedKey.count == VotingByteCount.randomizedKey else {
+            throw VotingRustBackendError.invalidData(
+                "randomizedKey must be exactly \(VotingByteCount.randomizedKey) bytes"
+            )
+        }
+        let roundIdBytes = [UInt8](roundId.utf8)
+        try withHandle { dbh in
+            let result = roundIdBytes.withUnsafeBufferPointer { ridBuf in
+                sig.withUnsafeBufferPointer { sigBuf in
+                    sighash.withUnsafeBufferPointer { shBuf in
+                        randomizedKey.withUnsafeBufferPointer { rkBuf in
+                            zcashlc_voting_store_keystone_signature(
+                                dbh,
+                                ridBuf.baseAddress,
+                                UInt(ridBuf.count),
+                                bundleIndex,
+                                sigBuf.baseAddress,
+                                UInt(sigBuf.count),
+                                shBuf.baseAddress,
+                                UInt(shBuf.count),
+                                rkBuf.baseAddress,
+                                UInt(rkBuf.count)
+                            )
+                        }
+                    }
+                }
+            }
+            guard result == 0 else {
+                throw VotingRustBackendError.rustError(
+                    lastErrorMessage(fallback: "`store_keystone_signature` failed")
+                )
+            }
+        }
+    }
+
+    /// Load all Keystone signatures stored for a round, in storage order.
+    public func getKeystoneSignatures(roundId: String) throws -> [VotingKeystoneSignatureRecord] {
+        let roundIdBytes = [UInt8](roundId.utf8)
+        let ptr: UnsafeMutablePointer<FfiBoxedSlice> = try withHandle { dbh in
+            let ptr: UnsafeMutablePointer<FfiBoxedSlice>? = roundIdBytes.withUnsafeBufferPointer { buf in
+                zcashlc_voting_get_keystone_signatures(dbh, buf.baseAddress, UInt(buf.count))
+            }
+            guard let ptr else {
+                throw VotingRustBackendError.rustError(
+                    lastErrorMessage(fallback: "`get_keystone_signatures` failed")
+                )
+            }
+            return ptr
+        }
+        defer { zcashlc_free_boxed_slice(ptr) }
+        return try decodeJSON(from: ptr)
+    }
+
+    /// Remove all recovery-state rows for a round.
+    public func clearRecoveryState(roundId: String) throws {
+        let roundIdBytes = [UInt8](roundId.utf8)
+        try withHandle { dbh in
+            let result = roundIdBytes.withUnsafeBufferPointer { buf in
+                zcashlc_voting_clear_recovery_state(dbh, buf.baseAddress, UInt(buf.count))
+            }
+            guard result == 0 else {
+                throw VotingRustBackendError.rustError(
+                    lastErrorMessage(fallback: "`clear_recovery_state` failed")
+                )
+            }
+        }
+    }
+}
+
+// MARK: - Share delegation tracking
+
+extension VotingRustBackend {
+    /// Record a share delegation after sending it to helper servers.
+    // swiftlint:disable:next function_parameter_count
+    public func recordShareDelegation(
+        roundId: String,
+        bundleIndex: UInt32,
+        proposalId: UInt32,
+        shareIndex: UInt32,
+        sentToURLs: [String],
+        nullifier: [UInt8],
+        submitAt: UInt64
+    ) throws {
+        guard nullifier.count == VotingByteCount.shareNullifier else {
+            throw VotingRustBackendError.invalidData(
+                "nullifier must be exactly \(VotingByteCount.shareNullifier) bytes"
+            )
+        }
+        let roundIdBytes = [UInt8](roundId.utf8)
+        let urlsJson = try JSONEncoder().encode(sentToURLs)
+        let urlsBytes = [UInt8](urlsJson)
+        try withHandle { dbh in
+            let result = roundIdBytes.withUnsafeBufferPointer { ridBuf in
+                urlsBytes.withUnsafeBufferPointer { urlsBuf in
+                    nullifier.withUnsafeBufferPointer { nfBuf in
+                        zcashlc_voting_record_share_delegation(
+                            dbh,
+                            ridBuf.baseAddress,
+                            UInt(ridBuf.count),
+                            bundleIndex,
+                            proposalId,
+                            shareIndex,
+                            urlsBuf.baseAddress,
+                            UInt(urlsBuf.count),
+                            nfBuf.baseAddress,
+                            UInt(nfBuf.count),
+                            submitAt
+                        )
+                    }
+                }
+            }
+            guard result == 0 else {
+                throw VotingRustBackendError.rustError(
+                    lastErrorMessage(fallback: "`record_share_delegation` failed")
+                )
+            }
+        }
+    }
+
+    /// Read all share delegations recorded for a round.
+    public func getShareDelegations(roundId: String) throws -> [VotingShareDelegation] {
+        try fetchShareDelegations(
+            roundId: roundId,
+            fallback: "`get_share_delegations` failed"
+        ) { dbh, ptr, len in
+            zcashlc_voting_get_share_delegations(dbh, ptr, len)
+        }
+    }
+
+    /// Read all share delegations not yet confirmed on chain.
+    public func getUnconfirmedDelegations(roundId: String) throws -> [VotingShareDelegation] {
+        try fetchShareDelegations(
+            roundId: roundId,
+            fallback: "`get_unconfirmed_delegations` failed"
+        ) { dbh, ptr, len in
+            zcashlc_voting_get_unconfirmed_delegations(dbh, ptr, len)
+        }
+    }
+
+    /// Mark a previously-recorded share delegation as confirmed on chain.
+    public func markShareConfirmed(
+        roundId: String,
+        bundleIndex: UInt32,
+        proposalId: UInt32,
+        shareIndex: UInt32
+    ) throws {
+        let roundIdBytes = [UInt8](roundId.utf8)
+        try withHandle { dbh in
+            let result = roundIdBytes.withUnsafeBufferPointer { buf in
+                zcashlc_voting_mark_share_confirmed(
+                    dbh,
+                    buf.baseAddress,
+                    UInt(buf.count),
+                    bundleIndex,
+                    proposalId,
+                    shareIndex
+                )
+            }
+            guard result == 0 else {
+                throw VotingRustBackendError.rustError(
+                    lastErrorMessage(fallback: "`mark_share_confirmed` failed")
+                )
+            }
+        }
+    }
+
+    /// Append additional helper-server URLs to an existing share delegation's
+    /// `sent_to_urls` set.
+    public func addSentServers(
+        roundId: String,
+        bundleIndex: UInt32,
+        proposalId: UInt32,
+        shareIndex: UInt32,
+        newURLs: [String]
+    ) throws {
+        let roundIdBytes = [UInt8](roundId.utf8)
+        let urlsJson = try JSONEncoder().encode(newURLs)
+        let urlsBytes = [UInt8](urlsJson)
+        try withHandle { dbh in
+            let result = roundIdBytes.withUnsafeBufferPointer { ridBuf in
+                urlsBytes.withUnsafeBufferPointer { urlsBuf in
+                    zcashlc_voting_add_sent_servers(
+                        dbh,
+                        ridBuf.baseAddress,
+                        UInt(ridBuf.count),
+                        bundleIndex,
+                        proposalId,
+                        shareIndex,
+                        urlsBuf.baseAddress,
+                        UInt(urlsBuf.count)
+                    )
+                }
+            }
+            guard result == 0 else {
+                throw VotingRustBackendError.rustError(
+                    lastErrorMessage(fallback: "`add_sent_servers` failed")
+                )
+            }
+        }
+    }
+}
+
+// MARK: - Delegation workflow
+
+extension VotingRustBackend {
+    /// Generate a voting hotkey for a round.
+    ///
+    /// The returned secret key is owned by Swift after this call. The Rust
+    /// allocation is freed before this method returns; callers should treat
+    /// the secret bytes with the same care as any other key material.
+    public func generateHotkey(roundId: String, seed: [UInt8]) throws -> VotingHotkey {
+        let roundIdBytes = [UInt8](roundId.utf8)
+
+        let ptr: UnsafeMutablePointer<FfiVotingHotkey> = try withHandle { dbh in
+            let ptr: UnsafeMutablePointer<FfiVotingHotkey>? = roundIdBytes.withUnsafeBufferPointer { ridBuf in
+                seed.withUnsafeBufferPointer { seedBuf in
+                    zcashlc_voting_generate_hotkey(
+                        dbh,
+                        ridBuf.baseAddress,
+                        UInt(ridBuf.count),
+                        seedBuf.baseAddress,
+                        UInt(seedBuf.count)
+                    )
+                }
+            }
+            guard let ptr else {
+                throw VotingRustBackendError.rustError(
+                    lastErrorMessage(fallback: "`generate_hotkey` failed")
+                )
+            }
+            return ptr
+        }
+        defer { zcashlc_voting_free_hotkey(ptr) }
+
+        let raw = ptr.pointee
+        let secretKey = bytesFromRawPointer(raw.secret_key, count: Int(raw.secret_key_len))
+        let publicKey = bytesFromRawPointer(raw.public_key, count: Int(raw.public_key_len))
+        let address = try Self.decodeRequiredCString(raw.address, fieldName: "address")
+
+        return VotingHotkey(secretKey: secretKey, publicKey: publicKey, address: address)
+    }
+
+    /// Setup vote bundles for a round.
+    public func setupBundles(
+        roundId: String,
+        notes: [VotingNoteInfo]
+    ) throws -> VotingBundleSetupResult {
+        let roundIdBytes = [UInt8](roundId.utf8)
+        let notesJson = try JSONEncoder().encode(notes)
+        let notesBytes = [UInt8](notesJson)
+
+        let ptr: UnsafeMutablePointer<FfiBundleSetupResult> = try withHandle { dbh in
+            let ptr: UnsafeMutablePointer<FfiBundleSetupResult>? = roundIdBytes.withUnsafeBufferPointer { ridBuf in
+                notesBytes.withUnsafeBufferPointer { notesBuf in
+                    zcashlc_voting_setup_bundles(
+                        dbh,
+                        ridBuf.baseAddress,
+                        UInt(ridBuf.count),
+                        notesBuf.baseAddress,
+                        UInt(notesBuf.count)
+                    )
+                }
+            }
+            guard let ptr else {
+                throw VotingRustBackendError.rustError(
+                    lastErrorMessage(fallback: "`setup_bundles` failed")
+                )
+            }
+            return ptr
+        }
+        defer { zcashlc_voting_free_bundle_setup_result(ptr) }
+
+        let raw = ptr.pointee
+        return VotingBundleSetupResult(bundleCount: raw.bundle_count, eligibleWeight: raw.eligible_weight)
+    }
+
+    /// Number of vote bundles persisted for a round, or 0 if the round is unknown.
+    public func getBundleCount(roundId: String) throws -> UInt32 {
+        let roundIdBytes = [UInt8](roundId.utf8)
+        return try withHandle { dbh in
+            let count = roundIdBytes.withUnsafeBufferPointer { buf in
+                zcashlc_voting_get_bundle_count(dbh, buf.baseAddress, UInt(buf.count))
+            }
+            guard count >= 0 else {
+                throw VotingRustBackendError.rustError(
+                    lastErrorMessage(fallback: "`get_bundle_count` failed")
+                )
+            }
+            return UInt32(count)
+        }
+    }
+
+    /// Build the voting PCZT for a bundle.
+    public func buildPczt(_ params: VotingBuildPcztParams) throws -> VotingPczt {
+        guard params.seedFingerprint.count == VotingByteCount.seedFingerprint else {
+            throw VotingRustBackendError.invalidData(
+                "seedFingerprint must be exactly \(VotingByteCount.seedFingerprint) bytes"
+            )
+        }
+
+        let roundIdBytes = [UInt8](params.roundId.utf8)
+        let notesJson = try JSONEncoder().encode(params.notes)
+        let notesBytes = [UInt8](notesJson)
+        let roundNameBytes = [UInt8](params.roundName.utf8)
+
+        let ptr: UnsafeMutablePointer<FfiBoxedSlice> = try withHandle { dbh in
+            let ptr: UnsafeMutablePointer<FfiBoxedSlice>? = roundIdBytes.withUnsafeBufferPointer { ridBuf in
+                notesBytes.withUnsafeBufferPointer { notesBuf in
+                    params.fvk.withUnsafeBufferPointer { fvkBuf in
+                        params.hotkeyRawAddress.withUnsafeBufferPointer { addrBuf in
+                            params.seedFingerprint.withUnsafeBufferPointer { fpBuf in
+                                roundNameBytes.withUnsafeBufferPointer { nameBuf in
+                                    zcashlc_voting_build_pczt(
+                                        dbh,
+                                        ridBuf.baseAddress,
+                                        UInt(ridBuf.count),
+                                        params.bundleIndex,
+                                        notesBuf.baseAddress,
+                                        UInt(notesBuf.count),
+                                        fvkBuf.baseAddress,
+                                        UInt(fvkBuf.count),
+                                        addrBuf.baseAddress,
+                                        UInt(addrBuf.count),
+                                        params.consensusBranchId,
+                                        params.coinType,
+                                        fpBuf.baseAddress,
+                                        UInt(fpBuf.count),
+                                        params.accountIndex,
+                                        nameBuf.baseAddress,
+                                        UInt(nameBuf.count),
+                                        params.addressIndex
+                                    )
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            guard let ptr else {
+                throw VotingRustBackendError.rustError(lastErrorMessage(fallback: "`build_pczt` failed"))
+            }
+            return ptr
+        }
+        defer { zcashlc_free_boxed_slice(ptr) }
+        return try decodeJSON(from: ptr)
+    }
+
+    /// Persist a `TreeState` blob keyed by round ID, for later witness generation.
+    public func storeTreeState(roundId: String, treeState: [UInt8]) throws {
+        let roundIdBytes = [UInt8](roundId.utf8)
+        try withHandle { dbh in
+            let result = roundIdBytes.withUnsafeBufferPointer { ridBuf in
+                treeState.withUnsafeBufferPointer { tsBuf in
+                    zcashlc_voting_store_tree_state(
+                        dbh,
+                        ridBuf.baseAddress,
+                        UInt(ridBuf.count),
+                        tsBuf.baseAddress,
+                        UInt(tsBuf.count)
+                    )
+                }
+            }
+            guard result == 0 else {
+                throw VotingRustBackendError.rustError(
+                    lastErrorMessage(fallback: "`store_tree_state` failed")
+                )
+            }
+        }
+    }
+
+    /// Get the delegation submission payload using a seed-derived signing key.
+    public func getDelegationSubmission(
+        roundId: String,
+        bundleIndex: UInt32,
+        senderSeed: [UInt8],
+        networkId: UInt32,
+        accountIndex: UInt32
+    ) throws -> VotingDelegationSubmission {
+        let roundIdBytes = [UInt8](roundId.utf8)
+
+        let ptr: UnsafeMutablePointer<FfiBoxedSlice> = try withHandle { dbh in
+            let ptr: UnsafeMutablePointer<FfiBoxedSlice>? = roundIdBytes.withUnsafeBufferPointer { ridBuf in
+                senderSeed.withUnsafeBufferPointer { seedBuf in
+                    zcashlc_voting_get_delegation_submission(
+                        dbh,
+                        ridBuf.baseAddress,
+                        UInt(ridBuf.count),
+                        bundleIndex,
+                        seedBuf.baseAddress,
+                        UInt(seedBuf.count),
+                        networkId,
+                        accountIndex
+                    )
+                }
+            }
+            guard let ptr else {
+                throw VotingRustBackendError.rustError(
+                    lastErrorMessage(fallback: "`get_delegation_submission` failed")
+                )
+            }
+            return ptr
+        }
+        defer { zcashlc_free_boxed_slice(ptr) }
+        return try decodeJSON(from: ptr)
+    }
+
+    /// Get the delegation submission payload using a Keystone-provided signature.
+    ///
+    /// `keystoneSig` must be exactly 64 bytes; `sighash` must be exactly 32 bytes.
+    public func getDelegationSubmission(
+        roundId: String,
+        bundleIndex: UInt32,
+        keystoneSig: [UInt8],
+        sighash: [UInt8]
+    ) throws -> VotingDelegationSubmission {
+        guard keystoneSig.count == VotingByteCount.keystoneSignature else {
+            throw VotingRustBackendError.invalidData(
+                "keystoneSig must be exactly \(VotingByteCount.keystoneSignature) bytes"
+            )
+        }
+        guard sighash.count == VotingByteCount.pcztSighash else {
+            throw VotingRustBackendError.invalidData(
+                "sighash must be exactly \(VotingByteCount.pcztSighash) bytes"
+            )
+        }
+        let roundIdBytes = [UInt8](roundId.utf8)
+
+        let ptr: UnsafeMutablePointer<FfiBoxedSlice> = try withHandle { dbh in
+            let ptr: UnsafeMutablePointer<FfiBoxedSlice>? = roundIdBytes.withUnsafeBufferPointer { ridBuf in
+                keystoneSig.withUnsafeBufferPointer { sigBuf in
+                    sighash.withUnsafeBufferPointer { shBuf in
+                        zcashlc_voting_get_delegation_submission_with_keystone_sig(
+                            dbh,
+                            ridBuf.baseAddress,
+                            UInt(ridBuf.count),
+                            bundleIndex,
+                            sigBuf.baseAddress,
+                            UInt(sigBuf.count),
+                            shBuf.baseAddress,
+                            UInt(shBuf.count)
+                        )
+                    }
+                }
+            }
+            guard let ptr else {
+                throw VotingRustBackendError.rustError(
+                    lastErrorMessage(
+                        fallback: "`get_delegation_submission_with_keystone_sig` failed"
+                    )
+                )
+            }
+            return ptr
+        }
+        defer { zcashlc_free_boxed_slice(ptr) }
+        return try decodeJSON(from: ptr)
+    }
+
+    /// Persist the VAN leaf position after delegation transaction confirmation.
+    public func storeVanPosition(
+        roundId: String,
+        bundleIndex: UInt32,
+        position: UInt32
+    ) throws {
+        let roundIdBytes = [UInt8](roundId.utf8)
+        try withHandle { dbh in
+            let result = roundIdBytes.withUnsafeBufferPointer { buf in
+                zcashlc_voting_store_van_position(
+                    dbh,
+                    buf.baseAddress,
+                    UInt(buf.count),
+                    bundleIndex,
+                    position
+                )
+            }
+            guard result == 0 else {
+                throw VotingRustBackendError.rustError(
+                    lastErrorMessage(fallback: "`store_van_position` failed")
+                )
+            }
+        }
+    }
+
+    /// Build and prove the real delegation ZKP for a bundle. Long-running.
+    ///
+    /// `progress` is invoked with values in `0.0...1.0` from the proving thread.
+    /// The closure must be thread-safe; it may be called concurrently with the
+    /// returned `Task`'s actor and is bridged through a `@convention(c)`
+    /// trampoline. The closure is retained for the duration of the call only.
+    // swiftlint:disable:next function_parameter_count
+    public func buildAndProveDelegation(
+        roundId: String,
+        bundleIndex: UInt32,
+        notes: [VotingNoteInfo],
+        hotkeyRawAddress: [UInt8],
+        pirEndpoints: [String],
+        expectedSnapshotHeight: UInt64,
+        networkId: UInt32,
+        pirResolver: PirSnapshotResolver = PirSnapshotResolver(),
+        progress: (@Sendable (Double) -> Void)? = nil
+    ) async throws -> VotingDelegationProofResult {
+        try requireOpenDatabase()
+
+        let pirServerUrl = try await pirResolver.resolve(
+            endpoints: pirEndpoints,
+            expectedSnapshotHeight: BlockHeight(expectedSnapshotHeight)
+        )
+
+        // The proving FFI can run for minutes; detach so we do not block the
+        // caller's executor for the full duration. `VotingRustBackend` is
+        // `@unchecked Sendable`, the lock keeps `withHandle` correct, and
+        // `notes`/byte arrays cross the boundary by value.
+        return try await Task.detached { [self] in
+            try syncBuildAndProveDelegation(
+                roundId: roundId,
+                bundleIndex: bundleIndex,
+                notes: notes,
+                hotkeyRawAddress: hotkeyRawAddress,
+                pirServerUrl: pirServerUrl,
+                networkId: networkId,
+                progress: progress
+            )
+        }.value
+    }
+
+    /// Validate a PIR-fetched IMT non-membership proof bytewise.
+    ///
+    /// Returns `true` if the proof is well-formed and valid, `false` if it is
+    /// well-formed but invalid. Throws `.invalidData` for length mismatches and
+    /// `.rustError` if the underlying validation panics.
+    public static func validatePirProof(_ proof: VotingPirProof) throws -> Bool {
+        guard proof.root.count == VotingByteCount.pirRoot else {
+            throw VotingRustBackendError.invalidData(
+                "root must be exactly \(VotingByteCount.pirRoot) bytes"
+            )
+        }
+        guard proof.nfBounds.count == VotingByteCount.pirNullifierBounds else {
+            throw VotingRustBackendError.invalidData(
+                "nfBounds must be exactly \(VotingByteCount.pirNullifierBounds) bytes"
+            )
+        }
+        let pirPathDescription = "\(VotingByteCount.pirPathElementCount) * \(VotingByteCount.pirRoot)"
+        guard proof.path.count == VotingByteCount.pirPath else {
+            throw VotingRustBackendError.invalidData(
+                "path must be exactly \(VotingByteCount.pirPath) bytes (\(pirPathDescription))"
+            )
+        }
+        guard proof.nullifier.count == VotingByteCount.pirNullifier else {
+            throw VotingRustBackendError.invalidData(
+                "nullifier must be exactly \(VotingByteCount.pirNullifier) bytes"
+            )
+        }
+        guard proof.expectedRoot.count == VotingByteCount.pirExpectedRoot else {
+            throw VotingRustBackendError.invalidData(
+                "expectedRoot must be exactly \(VotingByteCount.pirExpectedRoot) bytes"
+            )
+        }
+
+        let result = proof.root.withUnsafeBufferPointer { rootBuf in
+            proof.nfBounds.withUnsafeBufferPointer { boundsBuf in
+                proof.path.withUnsafeBufferPointer { pathBuf in
+                    proof.nullifier.withUnsafeBufferPointer { nfBuf in
+                        proof.expectedRoot.withUnsafeBufferPointer { expBuf in
+                            zcashlc_voting_validate_pir_proof(
+                                rootBuf.baseAddress,
+                                boundsBuf.baseAddress,
+                                proof.leafPosition,
+                                pathBuf.baseAddress,
+                                nfBuf.baseAddress,
+                                expBuf.baseAddress
+                            )
+                        }
+                    }
+                }
+            }
+        }
+
+        switch result {
+        case 0: return true
+        case 1: return false
+        default:
+            throw VotingRustBackendError.rustError(
+                staticLastErrorMessage(fallback: "`validate_pir_proof` failed")
+            )
+        }
     }
 }
 
@@ -355,12 +1578,192 @@ private extension VotingRustBackend {
             let error = UnsafeMutablePointer<Int8>.allocate(capacity: Int(errorLen))
             defer { error.deallocate() }
             zcashlc_error_message_utf8(error, errorLen)
-            if let msg = String(validatingUTF8: error) {
-                return msg
+            if let message = String(validatingUTF8: error) {
+                return message
             }
         }
+
         return fallback
     }
+
+    /// Decode JSON returned by static FFI calls.
+    static func staticDecodeJSON<T: Decodable>(from ptr: UnsafeMutablePointer<FfiBoxedSlice>) throws -> T {
+        let data = Data(bytes: ptr.pointee.ptr, count: Int(ptr.pointee.len))
+        return try JSONDecoder().decode(T.self, from: data)
+    }
+
+    /// Decode Rust's persisted round phase without silently aliasing unknown values.
+    static func decodeRoundPhase(_ rawValue: UInt32) throws -> VotingRoundPhase {
+        guard let phase = VotingRoundPhase(rawValue: rawValue) else {
+            throw VotingRustBackendError.invalidData("unknown phase \(rawValue)")
+        }
+
+        return phase
+    }
+
+    /// Decode required C strings from Rust, treating null as an invariant violation.
+    static func decodeRequiredCString(
+        _ pointer: UnsafePointer<CChar>?,
+        fieldName: String
+    ) throws -> String {
+        guard let pointer else {
+            throw VotingRustBackendError.invalidData("\(fieldName) must not be null")
+        }
+
+        return String(cString: pointer)
+    }
+
+    /// Calls a static FFI returning `*FfiBoxedSlice` and copies the resulting
+    /// bytes into a Swift `[UInt8]`, freeing the slice in `defer`.
+    static func staticBoxedSliceFFI(
+        fallback: String,
+        _ call: () -> UnsafeMutablePointer<FfiBoxedSlice>?
+    ) throws -> [UInt8] {
+        guard let ptr = call() else {
+            throw VotingRustBackendError.rustError(staticLastErrorMessage(fallback: fallback))
+        }
+        defer { zcashlc_free_boxed_slice(ptr) }
+        return [UInt8](Data(bytes: ptr.pointee.ptr, count: Int(ptr.pointee.len)))
+    }
+
+    /// Read share-delegation records from a DB-bound FFI JSON response.
+    func fetchShareDelegations(
+        roundId: String,
+        fallback: String,
+        _ call: (OpaquePointer, UnsafePointer<UInt8>?, UInt) -> UnsafeMutablePointer<FfiBoxedSlice>?
+    ) throws -> [VotingShareDelegation] {
+        let roundIdBytes = [UInt8](roundId.utf8)
+        let ptr: UnsafeMutablePointer<FfiBoxedSlice> = try withHandle { dbh in
+            let ptr = roundIdBytes.withUnsafeBufferPointer { buf in
+                call(dbh, buf.baseAddress, UInt(buf.count))
+            }
+            guard let ptr else {
+                throw VotingRustBackendError.rustError(lastErrorMessage(fallback: fallback))
+            }
+            return ptr
+        }
+        defer { zcashlc_free_boxed_slice(ptr) }
+        return try decodeJSON(from: ptr)
+    }
+
+    /// Synchronous body of `buildAndProveDelegation`. Lives on the FFI thread
+    /// inside `Task.detached` so the calling actor is not blocked for the
+    /// duration of proving (potentially minutes).
+    // swiftlint:disable:next function_parameter_count
+    func syncBuildAndProveDelegation(
+        roundId: String,
+        bundleIndex: UInt32,
+        notes: [VotingNoteInfo],
+        hotkeyRawAddress: [UInt8],
+        pirServerUrl: String,
+        networkId: UInt32,
+        progress: (@Sendable (Double) -> Void)?
+    ) throws -> VotingDelegationProofResult {
+        let roundIdBytes = [UInt8](roundId.utf8)
+        let notesJson = try JSONEncoder().encode(notes)
+        let notesBytes = [UInt8](notesJson)
+        let urlBytes = [UInt8](pirServerUrl.utf8)
+
+        let progressBox = progress.map(VotingProgressBox.init(report:))
+        let progressContext = progressBox.map { Unmanaged.passRetained($0).toOpaque() }
+        defer {
+            if let progressContext {
+                Unmanaged<VotingProgressBox>.fromOpaque(progressContext).release()
+            }
+        }
+        let trampoline: VotingProgressCallback? = progressBox == nil ? nil : votingProgressCallbackTrampoline
+
+        let ptr: UnsafeMutablePointer<FfiBoxedSlice> = try withHandle { dbh in
+            let ptr: UnsafeMutablePointer<FfiBoxedSlice>? = roundIdBytes.withUnsafeBufferPointer { ridBuf in
+                notesBytes.withUnsafeBufferPointer { notesBuf in
+                    hotkeyRawAddress.withUnsafeBufferPointer { addrBuf in
+                        urlBytes.withUnsafeBufferPointer { urlBuf in
+                            zcashlc_voting_build_and_prove_delegation(
+                                dbh,
+                                ridBuf.baseAddress,
+                                UInt(ridBuf.count),
+                                bundleIndex,
+                                notesBuf.baseAddress,
+                                UInt(notesBuf.count),
+                                addrBuf.baseAddress,
+                                UInt(addrBuf.count),
+                                urlBuf.baseAddress,
+                                UInt(urlBuf.count),
+                                networkId,
+                                trampoline,
+                                progressContext
+                            )
+                        }
+                    }
+                }
+            }
+            guard let ptr else {
+                throw VotingRustBackendError.rustError(
+                    lastErrorMessage(fallback: "`build_and_prove_delegation` failed")
+                )
+            }
+            return ptr
+        }
+        defer { zcashlc_free_boxed_slice(ptr) }
+        return try decodeJSON(from: ptr)
+    }
+}
+
+// MARK: - File-private FFI bridges
+
+/// JSON wire format for `Option<(String, u64)>` returned by the recovery FFI.
+/// Decodes from a 2-element JSON array `[bundleJson, vcTreePosition]`.
+private struct StoredCommitmentBundleWire: Decodable {
+    let bundleJson: String
+    let voteCommitmentTreePosition: UInt64
+
+    init(from decoder: Decoder) throws {
+        var container = try decoder.unkeyedContainer()
+        bundleJson = try container.decode(String.self)
+        voteCommitmentTreePosition = try container.decode(UInt64.self)
+    }
+}
+
+/// C function-pointer type for the voting proof progress callback.
+private typealias VotingProgressCallback = @convention(c) (Double, UnsafeMutableRawPointer?) -> Void
+
+/// Heap-allocated container that retains the Swift progress closure across the
+/// FFI call so the `@convention(c)` trampoline can recover it from the
+/// `*mut c_void` context pointer.
+private final class VotingProgressBox: @unchecked Sendable {
+    let report: @Sendable (Double) -> Void
+    init(report: @escaping @Sendable (Double) -> Void) {
+        self.report = report
+    }
+}
+
+/// Trampoline matching `VotingProgressCallback`. Passes the progress value to
+/// the Swift closure stored in the `VotingProgressBox` reachable through
+/// `context`.
+private let votingProgressCallbackTrampoline: VotingProgressCallback = { progress, context in
+    guard let context else { return }
+    let box = Unmanaged<VotingProgressBox>.fromOpaque(context).takeUnretainedValue()
+    box.report(progress)
+}
+
+/// Run `body` with the buffer pointer for `bytes` if it is non-nil, otherwise
+/// pass `nil`. Used by FFI calls that take an optional `(ptr, len)` pair.
+private func withOptionalBufferPointer<R>(
+    _ bytes: [UInt8]?,
+    _ body: (UnsafeBufferPointer<UInt8>?) throws -> R
+) rethrows -> R {
+    if let bytes {
+        return try bytes.withUnsafeBufferPointer { try body($0) }
+    } else {
+        return try body(nil)
+    }
+}
+
+/// Copy `count` bytes starting at `pointer` into a Swift `[UInt8]`.
+/// Returns an empty array if either argument is degenerate.
+private func bytesFromRawPointer(_ pointer: UnsafeMutablePointer<UInt8>?, count: Int) -> [UInt8] {
+    guard let pointer, count > 0 else { return [] }
+    return [UInt8](UnsafeBufferPointer(start: pointer, count: count))
 }
 
 #if DEBUG

--- a/Sources/ZcashLightClientKit/Rust/Voting/VotingRustBackend.swift
+++ b/Sources/ZcashLightClientKit/Rust/Voting/VotingRustBackend.swift
@@ -773,7 +773,7 @@ extension VotingRustBackend {
     public func getDelegationTxHash(
         roundId: String,
         bundleIndex: UInt32
-    ) throws -> VotingTxHashLookup {
+    ) throws -> String? {
         let roundIdBytes = [UInt8](roundId.utf8)
         let ptr: UnsafeMutablePointer<FfiBoxedSlice> = try withHandle { dbh in
             let ptr: UnsafeMutablePointer<FfiBoxedSlice>? = roundIdBytes.withUnsafeBufferPointer { buf in
@@ -792,8 +792,7 @@ extension VotingRustBackend {
             return ptr
         }
         defer { zcashlc_free_boxed_slice(ptr) }
-        let stored: String? = try decodeJSON(from: ptr)
-        return stored.map { .present($0) } ?? .notFound
+        return try decodeJSON(from: ptr)
     }
 
     /// Persist the on-chain transaction hash for a submitted vote.
@@ -832,7 +831,7 @@ extension VotingRustBackend {
         roundId: String,
         bundleIndex: UInt32,
         proposalId: UInt32
-    ) throws -> VotingTxHashLookup {
+    ) throws -> String? {
         let roundIdBytes = [UInt8](roundId.utf8)
         let ptr: UnsafeMutablePointer<FfiBoxedSlice> = try withHandle { dbh in
             let ptr: UnsafeMutablePointer<FfiBoxedSlice>? = roundIdBytes.withUnsafeBufferPointer { buf in
@@ -852,8 +851,7 @@ extension VotingRustBackend {
             return ptr
         }
         defer { zcashlc_free_boxed_slice(ptr) }
-        let stored: String? = try decodeJSON(from: ptr)
-        return stored.map { .present($0) } ?? .notFound
+        return try decodeJSON(from: ptr)
     }
 
     /// Persist a vote-commitment bundle as raw JSON, plus its position in the

--- a/Sources/ZcashLightClientKit/Rust/Voting/VotingRustBackend.swift
+++ b/Sources/ZcashLightClientKit/Rust/Voting/VotingRustBackend.swift
@@ -6,27 +6,6 @@
 import Foundation
 import libzcashlc
 
-// MARK: - Constants
-
-private enum VotingByteCount {
-    static let fieldElement = 32
-    static let accountUuid = 16
-    static let orchardFvk = 96
-    static let minSeed = 32
-    static let seedFingerprint = 32
-    static let shareNullifier = 32
-    static let shareNullifierHex = shareNullifier * 2
-    static let keystoneSignature = 64
-    static let pcztSighash = 32
-    static let randomizedKey = 32
-    static let pirRoot = 32
-    static let pirNullifierBounds = 96
-    static let pirPathElementCount = 29
-    static let pirPath = pirPathElementCount * pirRoot
-    static let pirNullifier = 32
-    static let pirExpectedRoot = 32
-}
-
 private enum CharacterByte {
     static let zero: UInt8 = 48
     static let nine: UInt8 = 57
@@ -311,11 +290,11 @@ extension VotingRustBackend {
         primaryBlind: [UInt8]
     ) throws -> String {
         guard
-            voteCommitment.count == VotingByteCount.fieldElement,
-            primaryBlind.count == VotingByteCount.fieldElement
+            voteCommitment.count == votingFieldElementByteCount,
+            primaryBlind.count == votingFieldElementByteCount
         else {
             throw VotingRustBackendError.invalidData(
-                "voteCommitment and primaryBlind must each be exactly \(VotingByteCount.fieldElement) bytes"
+                "voteCommitment and primaryBlind must each be exactly \(votingFieldElementByteCount) bytes"
             )
         }
 
@@ -379,9 +358,12 @@ extension VotingRustBackend {
         networkId: UInt32,
         accountIndex: UInt32
     ) throws -> VotingDelegationInputs {
-        guard senderSeed.count >= VotingByteCount.minSeed, hotkeySeed.count >= VotingByteCount.minSeed else {
+        guard
+            senderSeed.count >= votingMinSeedByteCount,
+            hotkeySeed.count >= votingMinSeedByteCount
+        else {
             throw VotingRustBackendError.invalidData(
-                "senderSeed and hotkeySeed must each be at least \(VotingByteCount.minSeed) bytes"
+                "senderSeed and hotkeySeed must each be at least \(votingMinSeedByteCount) bytes"
             )
         }
         let ptr = senderSeed.withUnsafeBufferPointer { senderBuf in
@@ -413,19 +395,19 @@ extension VotingRustBackend {
         networkId: UInt32,
         seedFingerprint: [UInt8]
     ) throws -> VotingDelegationInputs {
-        guard senderFvk.count == VotingByteCount.orchardFvk else {
+        guard senderFvk.count == votingOrchardFvkByteCount else {
             throw VotingRustBackendError.invalidData(
-                "senderFvk must be exactly \(VotingByteCount.orchardFvk) bytes"
+                "senderFvk must be exactly \(votingOrchardFvkByteCount) bytes"
             )
         }
-        guard hotkeySeed.count >= VotingByteCount.minSeed else {
+        guard hotkeySeed.count >= votingMinSeedByteCount else {
             throw VotingRustBackendError.invalidData(
-                "hotkeySeed must be at least \(VotingByteCount.minSeed) bytes"
+                "hotkeySeed must be at least \(votingMinSeedByteCount) bytes"
             )
         }
-        guard seedFingerprint.count == VotingByteCount.seedFingerprint else {
+        guard seedFingerprint.count == votingSeedFingerprintByteCount else {
             throw VotingRustBackendError.invalidData(
-                "seedFingerprint must be exactly \(VotingByteCount.seedFingerprint) bytes"
+                "seedFingerprint must be exactly \(votingSeedFingerprintByteCount) bytes"
             )
         }
         let ptr = senderFvk.withUnsafeBufferPointer { fvkBuf in
@@ -714,9 +696,9 @@ extension VotingRustBackend {
         snapshotHeight: UInt64,
         networkId: UInt32
     ) throws -> [VotingNoteInfo] {
-        guard accountUuidBytes.count == VotingByteCount.accountUuid else {
+        guard accountUuidBytes.count == votingAccountUuidByteCount else {
             throw VotingRustBackendError.invalidData(
-                "accountUuidBytes must be exactly \(VotingByteCount.accountUuid) bytes"
+                "accountUuidBytes must be exactly \(votingAccountUuidByteCount) bytes"
             )
         }
         let pathBytes = [UInt8](dataDbPath.utf8)
@@ -952,19 +934,19 @@ extension VotingRustBackend {
         sighash: [UInt8],
         randomizedKey: [UInt8]
     ) throws {
-        guard sig.count == VotingByteCount.keystoneSignature else {
+        guard sig.count == votingKeystoneSignatureByteCount else {
             throw VotingRustBackendError.invalidData(
-                "sig must be exactly \(VotingByteCount.keystoneSignature) bytes"
+                "sig must be exactly \(votingKeystoneSignatureByteCount) bytes"
             )
         }
-        guard sighash.count == VotingByteCount.pcztSighash else {
+        guard sighash.count == votingPcztSighashByteCount else {
             throw VotingRustBackendError.invalidData(
-                "sighash must be exactly \(VotingByteCount.pcztSighash) bytes"
+                "sighash must be exactly \(votingPcztSighashByteCount) bytes"
             )
         }
-        guard randomizedKey.count == VotingByteCount.randomizedKey else {
+        guard randomizedKey.count == votingRandomizedKeyByteCount else {
             throw VotingRustBackendError.invalidData(
-                "randomizedKey must be exactly \(VotingByteCount.randomizedKey) bytes"
+                "randomizedKey must be exactly \(votingRandomizedKeyByteCount) bytes"
             )
         }
         let roundIdBytes = [UInt8](roundId.utf8)
@@ -1045,9 +1027,9 @@ extension VotingRustBackend {
         nullifier: String,
         submitAt: UInt64
     ) throws {
-        guard nullifier.count == VotingByteCount.shareNullifierHex else {
+        guard nullifier.count == votingShareNullifierHexCharacterCount else {
             throw VotingRustBackendError.invalidData(
-                "nullifier must be exactly \(VotingByteCount.shareNullifierHex) hex characters"
+                "nullifier must be exactly \(votingShareNullifierHexCharacterCount) hex characters"
             )
         }
         guard Self.isHexString(nullifier) else {
@@ -1282,9 +1264,9 @@ extension VotingRustBackend {
 
     /// Build the voting PCZT for a bundle.
     public func buildPczt(_ params: VotingBuildPcztParams) throws -> VotingPczt {
-        guard params.seedFingerprint.count == VotingByteCount.seedFingerprint else {
+        guard params.seedFingerprint.count == votingSeedFingerprintByteCount else {
             throw VotingRustBackendError.invalidData(
-                "seedFingerprint must be exactly \(VotingByteCount.seedFingerprint) bytes"
+                "seedFingerprint must be exactly \(votingSeedFingerprintByteCount) bytes"
             )
         }
 
@@ -1403,14 +1385,14 @@ extension VotingRustBackend {
         keystoneSig: [UInt8],
         sighash: [UInt8]
     ) throws -> VotingDelegationSubmission {
-        guard keystoneSig.count == VotingByteCount.keystoneSignature else {
+        guard keystoneSig.count == votingKeystoneSignatureByteCount else {
             throw VotingRustBackendError.invalidData(
-                "keystoneSig must be exactly \(VotingByteCount.keystoneSignature) bytes"
+                "keystoneSig must be exactly \(votingKeystoneSignatureByteCount) bytes"
             )
         }
-        guard sighash.count == VotingByteCount.pcztSighash else {
+        guard sighash.count == votingPcztSighashByteCount else {
             throw VotingRustBackendError.invalidData(
-                "sighash must be exactly \(VotingByteCount.pcztSighash) bytes"
+                "sighash must be exactly \(votingPcztSighashByteCount) bytes"
             )
         }
         let roundIdBytes = [UInt8](roundId.utf8)
@@ -1522,30 +1504,30 @@ extension VotingRustBackend {
     /// well-formed but invalid. Throws `.invalidData` for length mismatches and
     /// `.rustError` if the underlying validation panics.
     public static func validatePirProof(_ proof: VotingPirProof) throws -> Bool {
-        guard proof.root.count == VotingByteCount.pirRoot else {
+        guard proof.root.count == votingPirRootByteCount else {
             throw VotingRustBackendError.invalidData(
-                "root must be exactly \(VotingByteCount.pirRoot) bytes"
+                "root must be exactly \(votingPirRootByteCount) bytes"
             )
         }
-        guard proof.nfBounds.count == VotingByteCount.pirNullifierBounds else {
+        guard proof.nfBounds.count == votingPirNullifierBoundsByteCount else {
             throw VotingRustBackendError.invalidData(
-                "nfBounds must be exactly \(VotingByteCount.pirNullifierBounds) bytes"
+                "nfBounds must be exactly \(votingPirNullifierBoundsByteCount) bytes"
             )
         }
-        let pirPathDescription = "\(VotingByteCount.pirPathElementCount) * \(VotingByteCount.pirRoot)"
-        guard proof.path.count == VotingByteCount.pirPath else {
+        let pirPathDescription = "\(votingPirPathElementCount) * \(votingPirRootByteCount)"
+        guard proof.path.count == votingPirPathByteCount else {
             throw VotingRustBackendError.invalidData(
-                "path must be exactly \(VotingByteCount.pirPath) bytes (\(pirPathDescription))"
+                "path must be exactly \(votingPirPathByteCount) bytes (\(pirPathDescription))"
             )
         }
-        guard proof.nullifier.count == VotingByteCount.pirNullifier else {
+        guard proof.nullifier.count == votingPirNullifierByteCount else {
             throw VotingRustBackendError.invalidData(
-                "nullifier must be exactly \(VotingByteCount.pirNullifier) bytes"
+                "nullifier must be exactly \(votingPirNullifierByteCount) bytes"
             )
         }
-        guard proof.expectedRoot.count == VotingByteCount.pirExpectedRoot else {
+        guard proof.expectedRoot.count == votingPirExpectedRootByteCount else {
             throw VotingRustBackendError.invalidData(
-                "expectedRoot must be exactly \(VotingByteCount.pirExpectedRoot) bytes"
+                "expectedRoot must be exactly \(votingPirExpectedRootByteCount) bytes"
             )
         }
 

--- a/Sources/ZcashLightClientKit/Rust/Voting/VotingRustBackend.swift
+++ b/Sources/ZcashLightClientKit/Rust/Voting/VotingRustBackend.swift
@@ -1044,18 +1044,7 @@ extension VotingRustBackend {
         let urlsJson = try JSONEncoder().encode(sentToURLs)
         let urlsBytes = [UInt8](urlsJson)
 
-        do {
-            try recordShareDelegation(
-                roundIdBytes: roundIdBytes,
-                bundleIndex: bundleIndex,
-                proposalId: proposalId,
-                shareIndex: shareIndex,
-                urlsBytes: urlsBytes,
-                nullifierArgument: nullifier,
-                submitAt: submitAt
-            )
-        } catch VotingRustBackendError.rustError(let message) where message.contains("invalid utf-8") {
-            try recordShareDelegation(
+      try recordShareDelegation(
                 roundIdBytes: roundIdBytes,
                 bundleIndex: bundleIndex,
                 proposalId: proposalId,
@@ -1064,7 +1053,6 @@ extension VotingRustBackend {
                 nullifierArgument: Self.hexBytes(for: nullifier),
                 submitAt: submitAt
             )
-        }
     }
 
     private func recordShareDelegation(

--- a/Sources/ZcashLightClientKit/Rust/Voting/VotingRustBackend.swift
+++ b/Sources/ZcashLightClientKit/Rust/Voting/VotingRustBackend.swift
@@ -751,11 +751,6 @@ extension VotingRustBackend {
             }
         }
 
-        guard try getDelegationTxHash(roundId: roundId, bundleIndex: bundleIndex) == txHash else {
-            throw VotingRustBackendError.rustError(
-                "delegation tx hash was not persisted for round \(roundId) bundle \(bundleIndex)"
-            )
-        }
     }
 
     /// Load a previously-stored delegation transaction hash, if any.

--- a/Sources/ZcashLightClientKit/Rust/Voting/VotingRustBackend.swift
+++ b/Sources/ZcashLightClientKit/Rust/Voting/VotingRustBackend.swift
@@ -6,15 +6,6 @@
 import Foundation
 import libzcashlc
 
-private enum CharacterByte {
-    static let zero: UInt8 = 48
-    static let nine: UInt8 = 57
-    static let uppercaseA: UInt8 = 65
-    static let uppercaseF: UInt8 = 70
-    static let lowercaseA: UInt8 = 97
-    static let lowercaseF: UInt8 = 102
-}
-
 // MARK: - Error
 
 /// Error type for voting Rust backend operations.
@@ -1629,9 +1620,9 @@ private extension VotingRustBackend {
 
     static func isHexString(_ value: String) -> Bool {
         value.utf8.allSatisfy { byte in
-            (byte >= CharacterByte.zero && byte <= CharacterByte.nine)
-                || (byte >= CharacterByte.lowercaseA && byte <= CharacterByte.lowercaseF)
-                || (byte >= CharacterByte.uppercaseA && byte <= CharacterByte.uppercaseF)
+            (byte >= votingCharacterByteZero && byte <= votingCharacterByteNine)
+                || (byte >= votingCharacterByteLowercaseA && byte <= votingCharacterByteLowercaseF)
+                || (byte >= votingCharacterByteUppercaseA && byte <= votingCharacterByteUppercaseF)
         }
     }
 

--- a/Sources/ZcashLightClientKit/Rust/Voting/VotingRustBackend.swift
+++ b/Sources/ZcashLightClientKit/Rust/Voting/VotingRustBackend.swift
@@ -1061,7 +1061,7 @@ extension VotingRustBackend {
                 proposalId: proposalId,
                 shareIndex: shareIndex,
                 urlsBytes: urlsBytes,
-                nullifierArgument: [UInt8](Self.hexString(for: nullifier).utf8),
+                nullifierArgument: Self.hexBytes(for: nullifier),
                 submitAt: submitAt
             )
         }
@@ -1644,6 +1644,10 @@ private extension VotingRustBackend {
 
     static func hexString(for bytes: [UInt8]) -> String {
         bytes.map { String(format: "%02x", $0) }.joined()
+    }
+
+    static func hexBytes(for bytes: [UInt8]) -> [UInt8] {
+        [UInt8](hexString(for: bytes).utf8)
     }
 
     /// Decode required C strings from Rust, treating null as an invariant violation.

--- a/Sources/ZcashLightClientKit/Rust/Voting/VotingRustBackend.swift
+++ b/Sources/ZcashLightClientKit/Rust/Voting/VotingRustBackend.swift
@@ -1436,6 +1436,10 @@ extension VotingRustBackend {
     /// The closure must be thread-safe; it may be called concurrently with the
     /// returned `Task`'s actor and is bridged through a `@convention(c)`
     /// trampoline. The closure is retained for the duration of the call only.
+    ///
+    /// Do not call back into this `VotingRustBackend` from `progress`. Rust may
+    /// invoke the callback while the database-handle lock is held, so re-entering
+    /// this backend can deadlock.
     // swiftlint:disable:next function_parameter_count
     public func buildAndProveDelegation(
         roundId: String,

--- a/Sources/ZcashLightClientKit/Rust/Voting/VotingRustBackend.swift
+++ b/Sources/ZcashLightClientKit/Rust/Voting/VotingRustBackend.swift
@@ -15,6 +15,7 @@ private enum VotingByteCount {
     static let minSeed = 32
     static let seedFingerprint = 32
     static let shareNullifier = 32
+    static let shareNullifierHex = shareNullifier * 2
     static let keystoneSignature = 64
     static let pcztSighash = 32
     static let randomizedKey = 32
@@ -24,6 +25,15 @@ private enum VotingByteCount {
     static let pirPath = pirPathElementCount * pirRoot
     static let pirNullifier = 32
     static let pirExpectedRoot = 32
+}
+
+private enum CharacterByte {
+    static let zero: UInt8 = 48
+    static let nine: UInt8 = 57
+    static let uppercaseA: UInt8 = 65
+    static let uppercaseF: UInt8 = 70
+    static let lowercaseA: UInt8 = 97
+    static let lowercaseF: UInt8 = 102
 }
 
 // MARK: - Error
@@ -1032,27 +1042,32 @@ extension VotingRustBackend {
         proposalId: UInt32,
         shareIndex: UInt32,
         sentToURLs: [String],
-        nullifier: [UInt8],
+        nullifier: String,
         submitAt: UInt64
     ) throws {
-        guard nullifier.count == VotingByteCount.shareNullifier else {
+        guard nullifier.count == VotingByteCount.shareNullifierHex else {
             throw VotingRustBackendError.invalidData(
-                "nullifier must be exactly \(VotingByteCount.shareNullifier) bytes"
+                "nullifier must be exactly \(VotingByteCount.shareNullifierHex) hex characters"
             )
         }
+        guard Self.isHexString(nullifier) else {
+            throw VotingRustBackendError.invalidData("nullifier must be hex encoded")
+        }
+
         let roundIdBytes = [UInt8](roundId.utf8)
         let urlsJson = try JSONEncoder().encode(sentToURLs)
         let urlsBytes = [UInt8](urlsJson)
+        let nullifierHexBytes = [UInt8](nullifier.utf8)
 
-      try recordShareDelegation(
-                roundIdBytes: roundIdBytes,
-                bundleIndex: bundleIndex,
-                proposalId: proposalId,
-                shareIndex: shareIndex,
-                urlsBytes: urlsBytes,
-                nullifierArgument: Self.hexBytes(for: nullifier),
-                submitAt: submitAt
-            )
+        try recordShareDelegation(
+            roundIdBytes: roundIdBytes,
+            bundleIndex: bundleIndex,
+            proposalId: proposalId,
+            shareIndex: shareIndex,
+            urlsBytes: urlsBytes,
+            nullifierHexBytes: nullifierHexBytes,
+            submitAt: submitAt
+        )
     }
 
     private func recordShareDelegation(
@@ -1061,13 +1076,13 @@ extension VotingRustBackend {
         proposalId: UInt32,
         shareIndex: UInt32,
         urlsBytes: [UInt8],
-        nullifierArgument: [UInt8],
+        nullifierHexBytes: [UInt8],
         submitAt: UInt64
     ) throws {
         try withHandle { dbh in
             let result = roundIdBytes.withUnsafeBufferPointer { ridBuf in
                 urlsBytes.withUnsafeBufferPointer { urlsBuf in
-                    nullifierArgument.withUnsafeBufferPointer { nfBuf in
+                    nullifierHexBytes.withUnsafeBufferPointer { nfBuf in
                         zcashlc_voting_record_share_delegation(
                             dbh,
                             ridBuf.baseAddress,
@@ -1630,12 +1645,12 @@ private extension VotingRustBackend {
         return phase
     }
 
-    static func hexString(for bytes: [UInt8]) -> String {
-        bytes.map { String(format: "%02x", $0) }.joined()
-    }
-
-    static func hexBytes(for bytes: [UInt8]) -> [UInt8] {
-        [UInt8](hexString(for: bytes).utf8)
+    static func isHexString(_ value: String) -> Bool {
+        value.utf8.allSatisfy { byte in
+            (byte >= CharacterByte.zero && byte <= CharacterByte.nine)
+                || (byte >= CharacterByte.lowercaseA && byte <= CharacterByte.lowercaseF)
+                || (byte >= CharacterByte.uppercaseA && byte <= CharacterByte.uppercaseF)
+        }
     }
 
     /// Decode required C strings from Rust, treating null as an invariant violation.

--- a/Sources/ZcashLightClientKit/Rust/Voting/VotingTypes.swift
+++ b/Sources/ZcashLightClientKit/Rust/Voting/VotingTypes.swift
@@ -440,3 +440,117 @@ public enum VotingTxHashLookup: Equatable, Sendable {
     /// A record exists and contains the given tx hash.
     case present(String)
 }
+
+// MARK: - Keystone signature record (JSON)
+
+/// A persisted Keystone-produced PCZT signature for a delegation bundle.
+public struct VotingKeystoneSignatureRecord: Codable, Sendable, Equatable {
+    public let bundleIndex: UInt32
+    public let sig: [UInt8]
+    public let sighash: [UInt8]
+    /// Randomized verification key (`rk` on the wire).
+    public let randomizedKey: [UInt8]
+
+    enum CodingKeys: String, CodingKey {
+        case bundleIndex = "bundle_index"
+        case sig
+        case sighash
+        case randomizedKey = "rk"
+    }
+
+    public init(
+        bundleIndex: UInt32,
+        sig: [UInt8],
+        sighash: [UInt8],
+        randomizedKey: [UInt8]
+    ) {
+        self.bundleIndex = bundleIndex
+        self.sig = sig
+        self.sighash = sighash
+        self.randomizedKey = randomizedKey
+    }
+}
+
+// MARK: - Build PCZT parameters
+
+/// Parameters required to build a voting PCZT for a delegation bundle.
+public struct VotingBuildPcztParams: Sendable {
+    public let roundId: String
+    public let bundleIndex: UInt32
+    public let notes: [VotingNoteInfo]
+    public let fvk: [UInt8]
+    public let hotkeyRawAddress: [UInt8]
+    public let consensusBranchId: UInt32
+    public let coinType: UInt32
+    public let seedFingerprint: [UInt8]
+    public let accountIndex: UInt32
+    public let roundName: String
+    public let addressIndex: UInt32
+
+    public init(
+        roundId: String,
+        bundleIndex: UInt32,
+        notes: [VotingNoteInfo],
+        fvk: [UInt8],
+        hotkeyRawAddress: [UInt8],
+        consensusBranchId: UInt32,
+        coinType: UInt32,
+        seedFingerprint: [UInt8],
+        accountIndex: UInt32,
+        roundName: String,
+        addressIndex: UInt32
+    ) {
+        self.roundId = roundId
+        self.bundleIndex = bundleIndex
+        self.notes = notes
+        self.fvk = fvk
+        self.hotkeyRawAddress = hotkeyRawAddress
+        self.consensusBranchId = consensusBranchId
+        self.coinType = coinType
+        self.seedFingerprint = seedFingerprint
+        self.accountIndex = accountIndex
+        self.roundName = roundName
+        self.addressIndex = addressIndex
+    }
+}
+
+// MARK: - PIR proof input
+
+/// Inputs to `VotingRustBackend.validatePirProof(_:)`.
+public struct VotingPirProof: Sendable, Equatable {
+    public let root: [UInt8]
+    public let nfBounds: [UInt8]
+    public let leafPosition: UInt32
+    public let path: [UInt8]
+    public let nullifier: [UInt8]
+    public let expectedRoot: [UInt8]
+
+    public init(
+        root: [UInt8],
+        nfBounds: [UInt8],
+        leafPosition: UInt32,
+        path: [UInt8],
+        nullifier: [UInt8],
+        expectedRoot: [UInt8]
+    ) {
+        self.root = root
+        self.nfBounds = nfBounds
+        self.leafPosition = leafPosition
+        self.path = path
+        self.nullifier = nullifier
+        self.expectedRoot = expectedRoot
+    }
+}
+
+// MARK: - Stored commitment bundle
+
+/// A previously-stored vote commitment bundle and its position in the
+/// vote-commitment tree.
+///
+/// Returned by `VotingRustBackend.getCommitmentBundle(...)`.
+public struct VotingStoredCommitmentBundle: Sendable, Equatable {
+    /// JSON-encoded `VotingVoteCommitmentBundle` as it was stored.
+    public let bundleJson: String
+    /// Position of the vote commitment within the vote commitment tree.
+    public let voteCommitmentTreePosition: UInt64
+}

--- a/Sources/ZcashLightClientKit/Rust/Voting/VotingTypes.swift
+++ b/Sources/ZcashLightClientKit/Rust/Voting/VotingTypes.swift
@@ -431,16 +431,6 @@ public struct VotingVanWitness: Codable, Sendable {
     }
 }
 
-// MARK: - TX hash lookup
-
-/// Result of a stored-tx-hash lookup for a delegation or vote bundle.
-public enum VotingTxHashLookup: Equatable, Sendable {
-    /// No record exists for the given key (round/bundle or round/bundle/proposal).
-    case notFound
-    /// A record exists and contains the given tx hash.
-    case present(String)
-}
-
 // MARK: - Keystone signature record (JSON)
 
 /// A persisted Keystone-produced PCZT signature for a delegation bundle.

--- a/Sources/ZcashLightClientKit/Rust/Voting/VotingTypes.swift
+++ b/Sources/ZcashLightClientKit/Rust/Voting/VotingTypes.swift
@@ -185,7 +185,7 @@ public struct VotingShareDelegation: Codable, Equatable, Sendable {
     public let proposalId: UInt32
     public let shareIndex: UInt32
     public let sentToURLs: [String]
-    public let nullifier: [UInt8]
+    public let nullifier: String
     public let confirmed: Bool
     public let submitAt: UInt64
     public let createdAt: UInt64

--- a/Tests/OfflineTests/VotingRustBackendTests.swift
+++ b/Tests/OfflineTests/VotingRustBackendTests.swift
@@ -704,7 +704,7 @@ final class VotingRustBackendTests: XCTestCase {
 
     // MARK: - Share delegation tracking
 
-    func test_shareDelegationLifecycle_roundTrips() throws {
+    func test_shareDelegationLifecycle_roundTripsRawNullifierBytes() throws {
         let backend = try makeReadyBackend()
         defer { backend.close() }
 

--- a/Tests/OfflineTests/VotingRustBackendTests.swift
+++ b/Tests/OfflineTests/VotingRustBackendTests.swift
@@ -1106,6 +1106,9 @@ final class VotingRustBackendTests: XCTestCase {
         )
     }
 
+    // TODO: Consider replacing this raw SQLite insertion with a proper Rust-side test helper
+    // so we don't reach into the Rust-managed votes table directly.
+    // https://github.com/zcash/zcash-swift-wallet-sdk/pull/1724#discussion_r3222196789
     private func insertVoteRow(
         roundId: String,
         walletId: String,

--- a/Tests/OfflineTests/VotingRustBackendTests.swift
+++ b/Tests/OfflineTests/VotingRustBackendTests.swift
@@ -4,10 +4,43 @@
 //
 
 import XCTest
+import SQLite3
 @testable import ZcashLightClientKit
 
 final class VotingRustBackendTests: XCTestCase {
     private var dbPath: String?
+
+    private enum RoundTripFixture {
+        static let walletId = "test-wallet"
+        static let roundId = "round"
+        static let bundleIndex: UInt32 = 0
+        static let proposalId: UInt32 = 1
+        static let shareIndex0: UInt32 = 0
+        static let shareIndex1: UInt32 = 1
+        static let snapshotHeight: UInt64 = 1
+        static let voteCommitmentTreePosition: UInt64 = 42
+        static let delegationTxHash = "delegation-tx-hash"
+        static let voteTxHash = "vote-tx-hash"
+        static let commitmentBundleJson = #"{"vote_commitment":[1,2,3],"proposal_id":1}"#
+        static let helperAURL = "https://helper-a.example"
+        static let helperBURL = "https://helper-b.example"
+        static let firstSubmitAt: UInt64 = 1000
+        static let secondSubmitAt: UInt64 = 2000
+        static let createdAt: Int64 = 1_000
+        static let fieldElementByteCount = 32
+        static let keystoneSignatureByteCount = 64
+        static let diversifierByteCount = 11
+        static let eligibleNoteValue: UInt64 = 13_000_000
+        static let sqliteSuccessCode = SQLITE_OK
+        static let sqliteDoneCode = SQLITE_DONE
+
+        static let roundParameter = [UInt8](repeating: 0x07, count: fieldElementByteCount)
+        static let keystoneSignature = [UInt8](repeating: 0x01, count: keystoneSignatureByteCount)
+        static let pcztSighash = [UInt8](repeating: 0x02, count: fieldElementByteCount)
+        static let randomizedKey = [UInt8](repeating: 0x03, count: fieldElementByteCount)
+        static let shareNullifier = [UInt8](repeating: 0xDD, count: fieldElementByteCount)
+        static let voteCommitment = [UInt8](repeating: 0xAA, count: fieldElementByteCount)
+    }
 
     override func tearDown() {
         if let dbPath {
@@ -462,6 +495,34 @@ final class VotingRustBackendTests: XCTestCase {
 
     // MARK: - Recovery state
 
+    func test_delegationTxHash_roundTrips() throws {
+        let backend = try makeReadyBackend()
+        defer { backend.close() }
+
+        try createRoundWithBundle(backend, roundId: RoundTripFixture.roundId)
+
+        XCTAssertNil(
+            try backend.getDelegationTxHash(
+                roundId: RoundTripFixture.roundId,
+                bundleIndex: RoundTripFixture.bundleIndex
+            )
+        )
+
+        try backend.storeDelegationTxHash(
+            roundId: RoundTripFixture.roundId,
+            bundleIndex: RoundTripFixture.bundleIndex,
+            txHash: RoundTripFixture.delegationTxHash
+        )
+
+        XCTAssertEqual(
+            try backend.getDelegationTxHash(
+                roundId: RoundTripFixture.roundId,
+                bundleIndex: RoundTripFixture.bundleIndex
+            ),
+            RoundTripFixture.delegationTxHash
+        )
+    }
+
     func test_storeDelegationTxHash_throwsRustError_whenBundleMissing() throws {
         let backend = try makeReadyBackend()
         defer { backend.close() }
@@ -474,6 +535,109 @@ final class VotingRustBackendTests: XCTestCase {
                 return
             }
         }
+    }
+
+    func test_voteTxHash_roundTrips() throws {
+        let backend = try makeReadyBackend(walletId: RoundTripFixture.walletId)
+        defer { backend.close() }
+
+        try createRoundWithBundle(backend, roundId: RoundTripFixture.roundId)
+        try insertVoteRow(
+            roundId: RoundTripFixture.roundId,
+            walletId: RoundTripFixture.walletId,
+            bundleIndex: RoundTripFixture.bundleIndex,
+            proposalId: RoundTripFixture.proposalId
+        )
+
+        XCTAssertNil(
+            try backend.getVoteTxHash(
+                roundId: RoundTripFixture.roundId,
+                bundleIndex: RoundTripFixture.bundleIndex,
+                proposalId: RoundTripFixture.proposalId
+            )
+        )
+
+        try backend.storeVoteTxHash(
+            roundId: RoundTripFixture.roundId,
+            bundleIndex: RoundTripFixture.bundleIndex,
+            proposalId: RoundTripFixture.proposalId,
+            txHash: RoundTripFixture.voteTxHash
+        )
+
+        XCTAssertEqual(
+            try backend.getVoteTxHash(
+                roundId: RoundTripFixture.roundId,
+                bundleIndex: RoundTripFixture.bundleIndex,
+                proposalId: RoundTripFixture.proposalId
+            ),
+            RoundTripFixture.voteTxHash
+        )
+    }
+
+    func test_commitmentBundle_roundTrips() throws {
+        let backend = try makeReadyBackend(walletId: RoundTripFixture.walletId)
+        defer { backend.close() }
+
+        try createRoundWithBundle(backend, roundId: RoundTripFixture.roundId)
+        try insertVoteRow(
+            roundId: RoundTripFixture.roundId,
+            walletId: RoundTripFixture.walletId,
+            bundleIndex: RoundTripFixture.bundleIndex,
+            proposalId: RoundTripFixture.proposalId
+        )
+
+        XCTAssertNil(
+            try backend.getCommitmentBundle(
+                roundId: RoundTripFixture.roundId,
+                bundleIndex: RoundTripFixture.bundleIndex,
+                proposalId: RoundTripFixture.proposalId
+            )
+        )
+
+        try backend.storeCommitmentBundle(
+            roundId: RoundTripFixture.roundId,
+            bundleIndex: RoundTripFixture.bundleIndex,
+            proposalId: RoundTripFixture.proposalId,
+            bundleJson: RoundTripFixture.commitmentBundleJson,
+            voteCommitmentTreePosition: RoundTripFixture.voteCommitmentTreePosition
+        )
+
+        let stored = try XCTUnwrap(
+            backend.getCommitmentBundle(
+                roundId: RoundTripFixture.roundId,
+                bundleIndex: RoundTripFixture.bundleIndex,
+                proposalId: RoundTripFixture.proposalId
+            )
+        )
+        XCTAssertEqual(stored.bundleJson, RoundTripFixture.commitmentBundleJson)
+        XCTAssertEqual(stored.voteCommitmentTreePosition, RoundTripFixture.voteCommitmentTreePosition)
+    }
+
+    func test_keystoneSignature_roundTrips() throws {
+        let backend = try makeReadyBackend()
+        defer { backend.close() }
+
+        try createRoundWithBundle(backend, roundId: RoundTripFixture.roundId)
+
+        try backend.storeKeystoneSignature(
+            roundId: RoundTripFixture.roundId,
+            bundleIndex: RoundTripFixture.bundleIndex,
+            sig: RoundTripFixture.keystoneSignature,
+            sighash: RoundTripFixture.pcztSighash,
+            randomizedKey: RoundTripFixture.randomizedKey
+        )
+
+        XCTAssertEqual(
+            try backend.getKeystoneSignatures(roundId: RoundTripFixture.roundId),
+            [
+                VotingKeystoneSignatureRecord(
+                    bundleIndex: RoundTripFixture.bundleIndex,
+                    sig: RoundTripFixture.keystoneSignature,
+                    sighash: RoundTripFixture.pcztSighash,
+                    randomizedKey: RoundTripFixture.randomizedKey
+                )
+            ]
+        )
     }
 
     func test_storeKeystoneSignature_rejectsBadLengths() throws {
@@ -539,6 +703,63 @@ final class VotingRustBackendTests: XCTestCase {
     }
 
     // MARK: - Share delegation tracking
+
+    func test_shareDelegationLifecycle_roundTrips() throws {
+        let backend = try makeReadyBackend()
+        defer { backend.close() }
+
+        try createRoundWithBundle(backend, roundId: RoundTripFixture.roundId)
+
+        try backend.recordShareDelegation(
+            roundId: RoundTripFixture.roundId,
+            bundleIndex: RoundTripFixture.bundleIndex,
+            proposalId: RoundTripFixture.proposalId,
+            shareIndex: RoundTripFixture.shareIndex0,
+            sentToURLs: [RoundTripFixture.helperAURL],
+            nullifier: RoundTripFixture.shareNullifier,
+            submitAt: RoundTripFixture.firstSubmitAt
+        )
+        try backend.recordShareDelegation(
+            roundId: RoundTripFixture.roundId,
+            bundleIndex: RoundTripFixture.bundleIndex,
+            proposalId: RoundTripFixture.proposalId,
+            shareIndex: RoundTripFixture.shareIndex1,
+            sentToURLs: [RoundTripFixture.helperBURL],
+            nullifier: RoundTripFixture.shareNullifier,
+            submitAt: RoundTripFixture.secondSubmitAt
+        )
+
+        let all = try backend.getShareDelegations(roundId: RoundTripFixture.roundId)
+        XCTAssertEqual(all.count, 2)
+
+        let share0 = try XCTUnwrap(all.first { $0.shareIndex == RoundTripFixture.shareIndex0 })
+        XCTAssertEqual(share0.roundId, RoundTripFixture.roundId)
+        XCTAssertEqual(share0.bundleIndex, RoundTripFixture.bundleIndex)
+        XCTAssertEqual(share0.proposalId, RoundTripFixture.proposalId)
+        XCTAssertEqual(share0.sentToURLs, [RoundTripFixture.helperAURL])
+        XCTAssertEqual(share0.nullifier, RoundTripFixture.shareNullifier)
+        XCTAssertFalse(share0.confirmed)
+        XCTAssertEqual(share0.submitAt, RoundTripFixture.firstSubmitAt)
+
+        XCTAssertEqual(try backend.getUnconfirmedDelegations(roundId: RoundTripFixture.roundId).count, 2)
+
+        try backend.markShareConfirmed(
+            roundId: RoundTripFixture.roundId,
+            bundleIndex: RoundTripFixture.bundleIndex,
+            proposalId: RoundTripFixture.proposalId,
+            shareIndex: RoundTripFixture.shareIndex0
+        )
+
+        let confirmedShare = try XCTUnwrap(
+            backend.getShareDelegations(roundId: RoundTripFixture.roundId)
+                .first { $0.shareIndex == RoundTripFixture.shareIndex0 }
+        )
+        XCTAssertTrue(confirmedShare.confirmed)
+
+        let unconfirmed = try backend.getUnconfirmedDelegations(roundId: RoundTripFixture.roundId)
+        XCTAssertEqual(unconfirmed.count, 1)
+        XCTAssertEqual(unconfirmed[0].shareIndex, RoundTripFixture.shareIndex1)
+    }
 
     func test_recordShareDelegation_rejectsInvalidNullifierLength() throws {
         let backend = try makeReadyBackend()
@@ -846,11 +1067,147 @@ final class VotingRustBackendTests: XCTestCase {
         return path
     }
 
-    private func makeReadyBackend(walletId: String = "test-wallet") throws -> VotingRustBackend {
+    private func makeReadyBackend(walletId: String = RoundTripFixture.walletId) throws -> VotingRustBackend {
         let backend = VotingRustBackend()
         try backend.open(path: makeTempDbPath())
         try backend.setWalletId(walletId)
         return backend
+    }
+
+    private func createRoundWithBundle(
+        _ backend: VotingRustBackend,
+        roundId: String
+    ) throws {
+        try backend.initRound(
+            roundId: roundId,
+            snapshotHeight: RoundTripFixture.snapshotHeight,
+            eaPublicKey: RoundTripFixture.roundParameter,
+            ncRoot: RoundTripFixture.roundParameter,
+            nullifierImtRoot: RoundTripFixture.roundParameter
+        )
+
+        let result = try backend.setupBundles(
+            roundId: roundId,
+            notes: [makeEligibleNote()]
+        )
+        XCTAssertEqual(result.bundleCount, 1)
+    }
+
+    private func makeEligibleNote() -> VotingNoteInfo {
+        VotingNoteInfo(
+            commitment: [UInt8](repeating: 0x01, count: RoundTripFixture.fieldElementByteCount),
+            nullifier: [UInt8](repeating: 0x02, count: RoundTripFixture.fieldElementByteCount),
+            value: RoundTripFixture.eligibleNoteValue,
+            position: 0,
+            diversifier: [UInt8](repeating: 0, count: RoundTripFixture.diversifierByteCount),
+            rho: [UInt8](repeating: 0, count: RoundTripFixture.fieldElementByteCount),
+            rseed: [UInt8](repeating: 0, count: RoundTripFixture.fieldElementByteCount),
+            scope: 0,
+            ufvkStr: ""
+        )
+    }
+
+    private func insertVoteRow(
+        roundId: String,
+        walletId: String,
+        bundleIndex: UInt32,
+        proposalId: UInt32
+    ) throws {
+        let path = try XCTUnwrap(dbPath)
+        var db: OpaquePointer?
+        try requireSQLite(
+            sqlite3_open_v2(path, &db, SQLITE_OPEN_READWRITE, nil),
+            db,
+            message: "open voting database"
+        )
+        defer { sqlite3_close(db) }
+
+        let sql = """
+        INSERT INTO votes (
+            round_id,
+            wallet_id,
+            bundle_index,
+            proposal_id,
+            choice,
+            commitment,
+            created_at
+        ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
+        """
+        var statement: OpaquePointer?
+        try requireSQLite(
+            sqlite3_prepare_v2(db, sql, -1, &statement, nil),
+            db,
+            message: "prepare vote insert"
+        )
+        defer { sqlite3_finalize(statement) }
+
+        let sqliteTransient = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
+        let commitment = RoundTripFixture.voteCommitment
+
+        try roundId.withCString { roundIdPointer in
+            try requireSQLite(
+                sqlite3_bind_text(statement, 1, roundIdPointer, -1, sqliteTransient),
+                db,
+                message: "bind round_id"
+            )
+        }
+        try walletId.withCString { walletIdPointer in
+            try requireSQLite(
+                sqlite3_bind_text(statement, 2, walletIdPointer, -1, sqliteTransient),
+                db,
+                message: "bind wallet_id"
+            )
+        }
+        try requireSQLite(
+            sqlite3_bind_int64(statement, 3, sqlite3_int64(bundleIndex)),
+            db,
+            message: "bind bundle_index"
+        )
+        try requireSQLite(
+            sqlite3_bind_int64(statement, 4, sqlite3_int64(proposalId)),
+            db,
+            message: "bind proposal_id"
+        )
+        try requireSQLite(
+            sqlite3_bind_int64(statement, 5, 0),
+            db,
+            message: "bind choice"
+        )
+        try commitment.withUnsafeBufferPointer { buffer in
+            try requireSQLite(
+                sqlite3_bind_blob(statement, 6, buffer.baseAddress, Int32(buffer.count), sqliteTransient),
+                db,
+                message: "bind commitment"
+            )
+        }
+        try requireSQLite(
+            sqlite3_bind_int64(statement, 7, sqlite3_int64(RoundTripFixture.createdAt)),
+            db,
+            message: "bind created_at"
+        )
+
+        try requireSQLite(
+            sqlite3_step(statement),
+            db,
+            expected: RoundTripFixture.sqliteDoneCode,
+            message: "insert vote row"
+        )
+    }
+
+    private func requireSQLite(
+        _ code: Int32,
+        _ db: OpaquePointer?,
+        expected: Int32 = RoundTripFixture.sqliteSuccessCode,
+        message: String
+    ) throws {
+        guard code == expected else {
+            let details = db.map { String(cString: sqlite3_errmsg($0)) } ?? "unknown SQLite error"
+            throw NSError(
+                domain: "VotingRustBackendTests.SQLite",
+                code: Int(code),
+                userInfo: [NSLocalizedDescriptionKey: "\(message): \(details)"]
+            )
+        }
     }
 }
 

--- a/Tests/OfflineTests/VotingRustBackendTests.swift
+++ b/Tests/OfflineTests/VotingRustBackendTests.swift
@@ -20,7 +20,6 @@ final class VotingRustBackendTests: XCTestCase {
     // MARK: - computeShareNullifier
 
     func test_computeShareNullifier_returnsExpectedValueForKnownFixture() throws {
-        // Well-formed 32-byte fixtures.
         var voteCommitment = [UInt8](repeating: 0, count: 32)
         voteCommitment[0] = 0x01
         var primaryBlind = [UInt8](repeating: 0, count: 32)
@@ -34,9 +33,7 @@ final class VotingRustBackendTests: XCTestCase {
 
         // Captured from the Rust reference implementation
         // (`zcash_voting::share_tracking::compute_share_nullifier`) for the
-        // fixture above. Update only if the upstream algorithm intentionally
-        // changes. A mismatch otherwise indicates the FFI wrapper is feeding
-        // arguments incorrectly or mangling the output.
+        // fixture above.
         XCTAssertEqual(
             nullifier,
             "058ffd2e1ba7acaf97b167accfb4ec141b91c0ee2a0f552631851ac97ca1e61d"
@@ -191,10 +188,534 @@ final class VotingRustBackendTests: XCTestCase {
         }
     }
 
+    // MARK: - Foundation helpers
+
+    func test_decomposeWeight_returnsFixedWidthBinaryDecomposition() throws {
+        XCTAssertEqual(try VotingRustBackend.decomposeWeight(0).filter { $0 != 0 }, [])
+        XCTAssertEqual(try VotingRustBackend.decomposeWeight(1).filter { $0 != 0 }, [1])
+        XCTAssertEqual(try VotingRustBackend.decomposeWeight(8).filter { $0 != 0 }, [8])
+        XCTAssertEqual(
+            try VotingRustBackend.decomposeWeight(11).filter { $0 != 0 }.sorted(),
+            [1, 2, 8]
+        )
+    }
+
+    func test_warmProvingCaches_doesNotThrow() throws {
+        XCTAssertNoThrow(try VotingRustBackend.warmProvingCaches())
+        XCTAssertNoThrow(try VotingRustBackend.warmProvingCaches())
+    }
+
+    func test_generateDelegationInputs_rejectsShortSeeds() {
+        let short = [UInt8](repeating: 0x01, count: 31)
+        let valid = [UInt8](repeating: 0x02, count: 32)
+        XCTAssertThrowsError(
+            try VotingRustBackend.generateDelegationInputs(
+                senderSeed: short,
+                hotkeySeed: valid,
+                networkId: 1,
+                accountIndex: 0
+            )
+        ) { error in
+            guard case VotingRustBackendError.invalidData = error else {
+                XCTFail("expected .invalidData, got \(error)")
+                return
+            }
+        }
+    }
+
+    func test_generateDelegationInputs_withFvk_rejectsBadLengths() {
+        struct Case {
+            let fvk: [UInt8]
+            let hotkey: [UInt8]
+            let fingerprint: [UInt8]
+            let label: String
+        }
+
+        let validHotkey = [UInt8](repeating: 0x02, count: 32)
+        let validFvk = [UInt8](repeating: 0x03, count: 96)
+        let validFp = [UInt8](repeating: 0x04, count: 32)
+        let cases: [Case] = [
+            .init(fvk: [UInt8](repeating: 0, count: 95), hotkey: validHotkey, fingerprint: validFp, label: "fvk too short"),
+            .init(fvk: validFvk, hotkey: [UInt8](repeating: 0, count: 31), fingerprint: validFp, label: "hotkey too short"),
+            .init(fvk: validFvk, hotkey: validHotkey, fingerprint: [UInt8](repeating: 0, count: 31), label: "fingerprint too short")
+        ]
+        for testCase in cases {
+            let fvk = testCase.fvk
+            let hotkey = testCase.hotkey
+            let fp = testCase.fingerprint
+            let label = testCase.label
+            XCTAssertThrowsError(
+                try VotingRustBackend.generateDelegationInputs(
+                    senderFvk: fvk,
+                    hotkeySeed: hotkey,
+                    networkId: 1,
+                    seedFingerprint: fp
+                ),
+                label
+            ) { error in
+                guard case VotingRustBackendError.invalidData = error else {
+                    XCTFail("\(label): expected .invalidData, got \(error)")
+                    return
+                }
+            }
+        }
+    }
+
+    func test_extractOrchardFvk_invalidUfvk_throwsRustError() {
+        XCTAssertThrowsError(
+            try VotingRustBackend.extractOrchardFvk(ufvk: "not-a-ufvk", networkId: 1)
+        ) { error in
+            guard case VotingRustBackendError.rustError = error else {
+                XCTFail("expected .rustError, got \(error)")
+                return
+            }
+        }
+    }
+
+    func test_extractPcztSighash_emptyInput_throwsRustError() {
+        XCTAssertThrowsError(
+            try VotingRustBackend.extractPcztSighash(pczt: [])
+        ) { error in
+            guard case VotingRustBackendError.rustError = error else {
+                XCTFail("expected .rustError, got \(error)")
+                return
+            }
+        }
+    }
+
+    func test_validatePirProof_rejectsBadLengths() {
+        struct Case {
+            let root: [UInt8]
+            let nfBounds: [UInt8]
+            let path: [UInt8]
+            let nullifier: [UInt8]
+            let expectedRoot: [UInt8]
+            let label: String
+        }
+
+        let valid32 = [UInt8](repeating: 0x01, count: 32)
+        let valid96 = [UInt8](repeating: 0x02, count: 96)
+        let valid928 = [UInt8](repeating: 0x03, count: 928)
+
+        let bad31 = [UInt8](repeating: 0, count: 31)
+        let bad95 = [UInt8](repeating: 0, count: 95)
+        let bad927 = [UInt8](repeating: 0, count: 927)
+
+        let cases: [Case] = [
+            .init(
+                root: bad31,
+                nfBounds: valid96,
+                path: valid928,
+                nullifier: valid32,
+                expectedRoot: valid32,
+                label: "root too short"
+            ),
+            .init(
+                root: valid32,
+                nfBounds: bad95,
+                path: valid928,
+                nullifier: valid32,
+                expectedRoot: valid32,
+                label: "nfBounds too short"
+            ),
+            .init(
+                root: valid32,
+                nfBounds: valid96,
+                path: bad927,
+                nullifier: valid32,
+                expectedRoot: valid32,
+                label: "path too short"
+            ),
+            .init(
+                root: valid32,
+                nfBounds: valid96,
+                path: valid928,
+                nullifier: bad31,
+                expectedRoot: valid32,
+                label: "nullifier too short"
+            ),
+            .init(
+                root: valid32,
+                nfBounds: valid96,
+                path: valid928,
+                nullifier: valid32,
+                expectedRoot: bad31,
+                label: "expectedRoot too short"
+            )
+        ]
+        for testCase in cases {
+            let proof = VotingPirProof(
+                root: testCase.root,
+                nfBounds: testCase.nfBounds,
+                leafPosition: 0,
+                path: testCase.path,
+                nullifier: testCase.nullifier,
+                expectedRoot: testCase.expectedRoot
+            )
+            XCTAssertThrowsError(
+                try VotingRustBackend.validatePirProof(proof),
+                testCase.label
+            ) { error in
+                guard case VotingRustBackendError.invalidData = error else {
+                    XCTFail("\(testCase.label): expected .invalidData, got \(error)")
+                    return
+                }
+            }
+        }
+    }
+
+    // MARK: - Round lifecycle
+
+    func test_initRound_andGetRoundState_roundTripPersistsParams() throws {
+        let backend = try makeReadyBackend()
+        defer { backend.close() }
+
+        let valid = [UInt8](repeating: 0x07, count: 32)
+        try backend.initRound(
+            roundId: "round-1",
+            snapshotHeight: 1234,
+            eaPublicKey: valid,
+            ncRoot: valid,
+            nullifierImtRoot: valid
+        )
+
+        let state = try backend.getRoundState(roundId: "round-1")
+        XCTAssertEqual(state.roundId, "round-1")
+        XCTAssertEqual(state.snapshotHeight, 1234)
+        XCTAssertEqual(state.phase, .initialized)
+        XCTAssertNil(state.hotkeyAddress)
+        XCTAssertNil(state.delegatedWeight)
+        XCTAssertFalse(state.proofGenerated)
+    }
+
+    func test_initRound_rejectsInvalidParamLengths() throws {
+        let backend = try makeReadyBackend()
+        defer { backend.close() }
+
+        let valid = [UInt8](repeating: 0x07, count: 32)
+        let short = [UInt8](repeating: 0x07, count: 31)
+
+        XCTAssertThrowsError(
+            try backend.initRound(
+                roundId: "bad",
+                snapshotHeight: 1,
+                eaPublicKey: short,
+                ncRoot: valid,
+                nullifierImtRoot: valid
+            )
+        ) { error in
+            guard case VotingRustBackendError.rustError = error else {
+                XCTFail("expected .rustError, got \(error)")
+                return
+            }
+        }
+    }
+
+    func test_listRounds_returnsEmpty_whenNoRoundsInitialized() throws {
+        let backend = try makeReadyBackend()
+        defer { backend.close() }
+
+        let rounds = try backend.listRounds()
+        XCTAssertTrue(rounds.isEmpty)
+    }
+
+    func test_listRounds_returnsInitializedRound() throws {
+        let backend = try makeReadyBackend()
+        defer { backend.close() }
+
+        let valid = [UInt8](repeating: 0x07, count: 32)
+        try backend.initRound(
+            roundId: "round-1",
+            snapshotHeight: 42,
+            eaPublicKey: valid,
+            ncRoot: valid,
+            nullifierImtRoot: valid
+        )
+        try backend.initRound(
+            roundId: "round-2",
+            snapshotHeight: 43,
+            eaPublicKey: valid,
+            ncRoot: valid,
+            nullifierImtRoot: valid
+        )
+
+        let rounds = try backend.listRounds()
+        XCTAssertEqual(rounds.count, 2)
+        XCTAssertEqual(Set(rounds.map(\.roundId)), ["round-1", "round-2"])
+    }
+
+    func test_getVotes_returnsEmpty_forFreshRound() throws {
+        let backend = try makeReadyBackend()
+        defer { backend.close() }
+
+        let valid = [UInt8](repeating: 0x07, count: 32)
+        try backend.initRound(
+            roundId: "round",
+            snapshotHeight: 1,
+            eaPublicKey: valid,
+            ncRoot: valid,
+            nullifierImtRoot: valid
+        )
+
+        XCTAssertTrue(try backend.getVotes(roundId: "round").isEmpty)
+    }
+
+    // MARK: - Recovery state
+
+    func test_storeDelegationTxHash_throwsRustError_whenBundleMissing() throws {
+        let backend = try makeReadyBackend()
+        defer { backend.close() }
+
+        XCTAssertThrowsError(
+            try backend.storeDelegationTxHash(roundId: "missing", bundleIndex: 0, txHash: "abc")
+        ) { error in
+            guard case VotingRustBackendError.rustError = error else {
+                XCTFail("expected .rustError, got \(error)")
+                return
+            }
+        }
+    }
+
+    func test_storeKeystoneSignature_rejectsBadLengths() throws {
+        let backend = try makeReadyBackend()
+        defer { backend.close() }
+
+        let valid = [UInt8](repeating: 0x07, count: 32)
+        try backend.initRound(
+            roundId: "round",
+            snapshotHeight: 1,
+            eaPublicKey: valid,
+            ncRoot: valid,
+            nullifierImtRoot: valid
+        )
+
+        struct Case {
+            let sig: [UInt8]
+            let sighash: [UInt8]
+            let randomizedKey: [UInt8]
+            let label: String
+        }
+
+        let validSig = [UInt8](repeating: 0x01, count: 64)
+        let validSighash = [UInt8](repeating: 0x02, count: 32)
+        let validRk = [UInt8](repeating: 0x03, count: 32)
+
+        let cases: [Case] = [
+            .init(sig: [UInt8](repeating: 0, count: 63), sighash: validSighash, randomizedKey: validRk, label: "sig too short"),
+            .init(sig: validSig, sighash: [UInt8](repeating: 0, count: 31), randomizedKey: validRk, label: "sighash too short"),
+            .init(sig: validSig, sighash: validSighash, randomizedKey: [UInt8](repeating: 0, count: 31), label: "rk too short")
+        ]
+        for testCase in cases {
+            XCTAssertThrowsError(
+                try backend.storeKeystoneSignature(
+                    roundId: "round",
+                    bundleIndex: 0,
+                    sig: testCase.sig,
+                    sighash: testCase.sighash,
+                    randomizedKey: testCase.randomizedKey
+                ),
+                testCase.label
+            ) { error in
+                guard case VotingRustBackendError.invalidData = error else {
+                    XCTFail("\(testCase.label): expected .invalidData, got \(error)")
+                    return
+                }
+            }
+        }
+    }
+
+    func test_getKeystoneSignatures_returnsEmpty_forFreshRound() throws {
+        let backend = try makeReadyBackend()
+        defer { backend.close() }
+
+        XCTAssertTrue(try backend.getKeystoneSignatures(roundId: "missing").isEmpty)
+    }
+
+    func test_clearRecoveryState_isNoop_onMissingRound() throws {
+        let backend = try makeReadyBackend()
+        defer { backend.close() }
+
+        XCTAssertNoThrow(try backend.clearRecoveryState(roundId: "missing"))
+    }
+
+    // MARK: - Share delegation tracking
+
+    func test_recordShareDelegation_rejectsInvalidNullifierLength() throws {
+        let backend = try makeReadyBackend()
+        defer { backend.close() }
+
+        let bad = [UInt8](repeating: 0xAA, count: 31)
+        XCTAssertThrowsError(
+            try backend.recordShareDelegation(
+                roundId: "round",
+                bundleIndex: 0,
+                proposalId: 0,
+                shareIndex: 0,
+                sentToURLs: ["https://helper.example"],
+                nullifier: bad,
+                submitAt: 0
+            )
+        ) { error in
+            guard case VotingRustBackendError.invalidData = error else {
+                XCTFail("expected .invalidData, got \(error)")
+                return
+            }
+        }
+    }
+
+    func test_getShareDelegations_returnsEmpty_forUnknownRound() throws {
+        let backend = try makeReadyBackend()
+        defer { backend.close() }
+
+        XCTAssertTrue(try backend.getShareDelegations(roundId: "missing").isEmpty)
+        XCTAssertTrue(try backend.getUnconfirmedDelegations(roundId: "missing").isEmpty)
+    }
+
+    // MARK: - Delegation workflow
+
+    func test_setupBundles_returnsZero_forEmptyNotes() throws {
+        let backend = try makeReadyBackend()
+        defer { backend.close() }
+
+        let valid = [UInt8](repeating: 0x07, count: 32)
+        try backend.initRound(
+            roundId: "round",
+            snapshotHeight: 1,
+            eaPublicKey: valid,
+            ncRoot: valid,
+            nullifierImtRoot: valid
+        )
+
+        let result = try backend.setupBundles(roundId: "round", notes: [])
+        XCTAssertEqual(result.bundleCount, 0)
+        XCTAssertEqual(result.eligibleWeight, 0)
+        XCTAssertEqual(try backend.getBundleCount(roundId: "round"), 0)
+    }
+
+    func test_buildPczt_rejectsInvalidSeedFingerprintLength() throws {
+        let backend = try makeReadyBackend()
+        defer { backend.close() }
+
+        let params = VotingBuildPcztParams(
+            roundId: "round",
+            bundleIndex: 0,
+            notes: [],
+            fvk: [UInt8](repeating: 0, count: 96),
+            hotkeyRawAddress: [UInt8](repeating: 0, count: 43),
+            consensusBranchId: 0,
+            coinType: 0,
+            seedFingerprint: [UInt8](repeating: 0, count: 31),
+            accountIndex: 0,
+            roundName: "Round",
+            addressIndex: 0
+        )
+        XCTAssertThrowsError(try backend.buildPczt(params)) { error in
+            guard case VotingRustBackendError.invalidData = error else {
+                XCTFail("expected .invalidData, got \(error)")
+                return
+            }
+        }
+    }
+
+    func test_getDelegationSubmissionWithKeystoneSig_rejectsBadLengths() throws {
+        let backend = try makeReadyBackend()
+        defer { backend.close() }
+
+        XCTAssertThrowsError(
+            try backend.getDelegationSubmission(
+                roundId: "round",
+                bundleIndex: 0,
+                keystoneSig: [UInt8](repeating: 0, count: 63),
+                sighash: [UInt8](repeating: 0, count: 32)
+            )
+        ) { error in
+            guard case VotingRustBackendError.invalidData = error else {
+                XCTFail("expected .invalidData, got \(error)")
+                return
+            }
+        }
+        XCTAssertThrowsError(
+            try backend.getDelegationSubmission(
+                roundId: "round",
+                bundleIndex: 0,
+                keystoneSig: [UInt8](repeating: 0, count: 64),
+                sighash: [UInt8](repeating: 0, count: 31)
+            )
+        ) { error in
+            guard case VotingRustBackendError.invalidData = error else {
+                XCTFail("expected .invalidData, got \(error)")
+                return
+            }
+        }
+    }
+
+    // MARK: - Open database gating
+
+    func test_initRound_beforeOpen_throwsDatabaseNotOpen() {
+        let backend = VotingRustBackend()
+        let valid = [UInt8](repeating: 0, count: 32)
+        XCTAssertThrowsError(
+            try backend.initRound(
+                roundId: "r",
+                snapshotHeight: 0,
+                eaPublicKey: valid,
+                ncRoot: valid,
+                nullifierImtRoot: valid
+            )
+        ) { error in
+            guard case VotingRustBackendError.databaseNotOpen = error else {
+                XCTFail("expected .databaseNotOpen, got \(error)")
+                return
+            }
+        }
+    }
+
     func test_syncVoteTree_beforeOpen_throwsDatabaseNotOpen() {
         let backend = VotingRustBackend()
         XCTAssertThrowsError(
             try backend.syncVoteTree(roundId: "round1", nodeUrl: "http://localhost")
+        ) { error in
+            guard case VotingRustBackendError.databaseNotOpen = error else {
+                XCTFail("expected .databaseNotOpen, got \(error)")
+                return
+            }
+        }
+    }
+
+    func test_listRounds_beforeOpen_throwsDatabaseNotOpen() {
+        let backend = VotingRustBackend()
+        XCTAssertThrowsError(try backend.listRounds()) { error in
+            guard case VotingRustBackendError.databaseNotOpen = error else {
+                XCTFail("expected .databaseNotOpen, got \(error)")
+                return
+            }
+        }
+    }
+
+    func test_getRoundState_beforeOpen_throwsDatabaseNotOpen() {
+        let backend = VotingRustBackend()
+        XCTAssertThrowsError(try backend.getRoundState(roundId: "r")) { error in
+            guard case VotingRustBackendError.databaseNotOpen = error else {
+                XCTFail("expected .databaseNotOpen, got \(error)")
+                return
+            }
+        }
+    }
+
+    func test_setupBundles_beforeOpen_throwsDatabaseNotOpen() {
+        let backend = VotingRustBackend()
+        XCTAssertThrowsError(try backend.setupBundles(roundId: "r", notes: [])) { error in
+            guard case VotingRustBackendError.databaseNotOpen = error else {
+                XCTFail("expected .databaseNotOpen, got \(error)")
+                return
+            }
+        }
+    }
+
+    func test_storeVanPosition_beforeOpen_throwsDatabaseNotOpen() {
+        let backend = VotingRustBackend()
+        XCTAssertThrowsError(
+            try backend.storeVanPosition(roundId: "r", bundleIndex: 0, position: 0)
         ) { error in
             guard case VotingRustBackendError.databaseNotOpen = error else {
                 XCTFail("expected .databaseNotOpen, got \(error)")
@@ -210,6 +731,48 @@ final class VotingRustBackendTests: XCTestCase {
                 roundId: "round1",
                 bundleIndex: 0,
                 notes: [],
+                pirEndpoints: ["https://stub"],
+                expectedSnapshotHeight: 0,
+                networkId: 1,
+                pirResolver: PirSnapshotResolver(probe: FailingProbe())
+            )
+            XCTFail("expected .databaseNotOpen")
+        } catch let error as VotingRustBackendError {
+            guard case .databaseNotOpen = error else {
+                XCTFail("expected .databaseNotOpen, got \(error)")
+                return
+            }
+        } catch {
+            XCTFail("unexpected error: \(error)")
+        }
+    }
+
+    func test_storeKeystoneSignature_beforeOpen_throwsDatabaseNotOpen() {
+        let backend = VotingRustBackend()
+        XCTAssertThrowsError(
+            try backend.storeKeystoneSignature(
+                roundId: "r",
+                bundleIndex: 0,
+                sig: [UInt8](repeating: 0, count: 64),
+                sighash: [UInt8](repeating: 0, count: 32),
+                randomizedKey: [UInt8](repeating: 0, count: 32)
+            )
+        ) { error in
+            guard case VotingRustBackendError.databaseNotOpen = error else {
+                XCTFail("expected .databaseNotOpen, got \(error)")
+                return
+            }
+        }
+    }
+
+    func test_buildAndProveDelegation_beforeOpen_throwsDatabaseNotOpen() async {
+        let backend = VotingRustBackend()
+        do {
+            _ = try await backend.buildAndProveDelegation(
+                roundId: "r",
+                bundleIndex: 0,
+                notes: [],
+                hotkeyRawAddress: [UInt8](repeating: 0, count: 43),
                 pirEndpoints: ["https://stub"],
                 expectedSnapshotHeight: 0,
                 networkId: 1,
@@ -277,10 +840,17 @@ final class VotingRustBackendTests: XCTestCase {
     // MARK: - Helpers
 
     private func makeTempDbPath() -> String {
-        let path = NSTemporaryDirectory()
-            + "VotingRustBackendTests-\(ProcessInfo.processInfo.globallyUniqueString).sqlite"
+        let unique = ProcessInfo.processInfo.globallyUniqueString
+        let path = "\(NSTemporaryDirectory())VotingRustBackendTests-\(unique).sqlite"
         dbPath = path
         return path
+    }
+
+    private func makeReadyBackend(walletId: String = "test-wallet") throws -> VotingRustBackend {
+        let backend = VotingRustBackend()
+        try backend.open(path: makeTempDbPath())
+        try backend.setWalletId(walletId)
+        return backend
     }
 }
 

--- a/Tests/OfflineTests/VotingRustBackendTests.swift
+++ b/Tests/OfflineTests/VotingRustBackendTests.swift
@@ -38,7 +38,7 @@ final class VotingRustBackendTests: XCTestCase {
         static let keystoneSignature = [UInt8](repeating: 0x01, count: keystoneSignatureByteCount)
         static let pcztSighash = [UInt8](repeating: 0x02, count: fieldElementByteCount)
         static let randomizedKey = [UInt8](repeating: 0x03, count: fieldElementByteCount)
-        static let shareNullifier = [UInt8](repeating: 0xDD, count: fieldElementByteCount)
+        static let shareNullifier = String(repeating: "dd", count: fieldElementByteCount)
         static let voteCommitment = [UInt8](repeating: 0xAA, count: fieldElementByteCount)
     }
 
@@ -704,7 +704,7 @@ final class VotingRustBackendTests: XCTestCase {
 
     // MARK: - Share delegation tracking
 
-    func test_shareDelegationLifecycle_roundTripsRawNullifierBytes() throws {
+    func test_shareDelegationLifecycle_roundTripsHexNullifier() throws {
         let backend = try makeReadyBackend()
         defer { backend.close() }
 
@@ -765,7 +765,7 @@ final class VotingRustBackendTests: XCTestCase {
         let backend = try makeReadyBackend()
         defer { backend.close() }
 
-        let bad = [UInt8](repeating: 0xAA, count: 31)
+        let bad = String(repeating: "aa", count: 31)
         XCTAssertThrowsError(
             try backend.recordShareDelegation(
                 roundId: "round",

--- a/Tests/OfflineTests/VotingRustBackendTests.swift
+++ b/Tests/OfflineTests/VotingRustBackendTests.swift
@@ -7,40 +7,39 @@ import XCTest
 import SQLite3
 @testable import ZcashLightClientKit
 
+// Shared fixtures for tests that round-trip persisted voting recovery state
+// through the Rust voting database.
+private let roundTripWalletId = "test-wallet"
+private let roundTripRoundId = "round"
+private let roundTripBundleIndex: UInt32 = 0
+private let roundTripProposalId: UInt32 = 1
+private let roundTripShareIndex0: UInt32 = 0
+private let roundTripShareIndex1: UInt32 = 1
+private let roundTripSnapshotHeight: UInt64 = 1
+private let roundTripVoteCommitmentTreePosition: UInt64 = 42
+private let roundTripDelegationTxHash = "delegation-tx-hash"
+private let roundTripVoteTxHash = "vote-tx-hash"
+private let roundTripCommitmentBundleJson = #"{"vote_commitment":[1,2,3],"proposal_id":1}"#
+private let roundTripHelperAURL = "https://helper-a.example"
+private let roundTripHelperBURL = "https://helper-b.example"
+private let roundTripFirstSubmitAt: UInt64 = 1000
+private let roundTripSecondSubmitAt: UInt64 = 2000
+private let roundTripCreatedAt: Int64 = 1_000
+private let roundTripFieldElementByteCount = 32
+private let roundTripKeystoneSignatureByteCount = 64
+private let roundTripDiversifierByteCount = 11
+private let roundTripEligibleNoteValue: UInt64 = 13_000_000
+private let roundTripSQLiteSuccessCode = SQLITE_OK
+private let roundTripSQLiteDoneCode = SQLITE_DONE
+private let roundTripRoundParameter = [UInt8](repeating: 0x07, count: roundTripFieldElementByteCount)
+private let roundTripKeystoneSignature = [UInt8](repeating: 0x01, count: roundTripKeystoneSignatureByteCount)
+private let roundTripPcztSighash = [UInt8](repeating: 0x02, count: roundTripFieldElementByteCount)
+private let roundTripRandomizedKey = [UInt8](repeating: 0x03, count: roundTripFieldElementByteCount)
+private let roundTripShareNullifier = String(repeating: "dd", count: roundTripFieldElementByteCount)
+private let roundTripVoteCommitment = [UInt8](repeating: 0xAA, count: roundTripFieldElementByteCount)
+
 final class VotingRustBackendTests: XCTestCase {
     private var dbPath: String?
-
-    private enum RoundTripFixture {
-        static let walletId = "test-wallet"
-        static let roundId = "round"
-        static let bundleIndex: UInt32 = 0
-        static let proposalId: UInt32 = 1
-        static let shareIndex0: UInt32 = 0
-        static let shareIndex1: UInt32 = 1
-        static let snapshotHeight: UInt64 = 1
-        static let voteCommitmentTreePosition: UInt64 = 42
-        static let delegationTxHash = "delegation-tx-hash"
-        static let voteTxHash = "vote-tx-hash"
-        static let commitmentBundleJson = #"{"vote_commitment":[1,2,3],"proposal_id":1}"#
-        static let helperAURL = "https://helper-a.example"
-        static let helperBURL = "https://helper-b.example"
-        static let firstSubmitAt: UInt64 = 1000
-        static let secondSubmitAt: UInt64 = 2000
-        static let createdAt: Int64 = 1_000
-        static let fieldElementByteCount = 32
-        static let keystoneSignatureByteCount = 64
-        static let diversifierByteCount = 11
-        static let eligibleNoteValue: UInt64 = 13_000_000
-        static let sqliteSuccessCode = SQLITE_OK
-        static let sqliteDoneCode = SQLITE_DONE
-
-        static let roundParameter = [UInt8](repeating: 0x07, count: fieldElementByteCount)
-        static let keystoneSignature = [UInt8](repeating: 0x01, count: keystoneSignatureByteCount)
-        static let pcztSighash = [UInt8](repeating: 0x02, count: fieldElementByteCount)
-        static let randomizedKey = [UInt8](repeating: 0x03, count: fieldElementByteCount)
-        static let shareNullifier = String(repeating: "dd", count: fieldElementByteCount)
-        static let voteCommitment = [UInt8](repeating: 0xAA, count: fieldElementByteCount)
-    }
 
     override func tearDown() {
         if let dbPath {
@@ -499,27 +498,27 @@ final class VotingRustBackendTests: XCTestCase {
         let backend = try makeReadyBackend()
         defer { backend.close() }
 
-        try createRoundWithBundle(backend, roundId: RoundTripFixture.roundId)
+        try createRoundWithBundle(backend, roundId: roundTripRoundId)
 
         XCTAssertNil(
             try backend.getDelegationTxHash(
-                roundId: RoundTripFixture.roundId,
-                bundleIndex: RoundTripFixture.bundleIndex
+                roundId: roundTripRoundId,
+                bundleIndex: roundTripBundleIndex
             )
         )
 
         try backend.storeDelegationTxHash(
-            roundId: RoundTripFixture.roundId,
-            bundleIndex: RoundTripFixture.bundleIndex,
-            txHash: RoundTripFixture.delegationTxHash
+            roundId: roundTripRoundId,
+            bundleIndex: roundTripBundleIndex,
+            txHash: roundTripDelegationTxHash
         )
 
         XCTAssertEqual(
             try backend.getDelegationTxHash(
-                roundId: RoundTripFixture.roundId,
-                bundleIndex: RoundTripFixture.bundleIndex
+                roundId: roundTripRoundId,
+                bundleIndex: roundTripBundleIndex
             ),
-            RoundTripFixture.delegationTxHash
+            roundTripDelegationTxHash
         )
     }
 
@@ -538,103 +537,103 @@ final class VotingRustBackendTests: XCTestCase {
     }
 
     func test_voteTxHash_roundTrips() throws {
-        let backend = try makeReadyBackend(walletId: RoundTripFixture.walletId)
+        let backend = try makeReadyBackend(walletId: roundTripWalletId)
         defer { backend.close() }
 
-        try createRoundWithBundle(backend, roundId: RoundTripFixture.roundId)
+        try createRoundWithBundle(backend, roundId: roundTripRoundId)
         try insertVoteRow(
-            roundId: RoundTripFixture.roundId,
-            walletId: RoundTripFixture.walletId,
-            bundleIndex: RoundTripFixture.bundleIndex,
-            proposalId: RoundTripFixture.proposalId
+            roundId: roundTripRoundId,
+            walletId: roundTripWalletId,
+            bundleIndex: roundTripBundleIndex,
+            proposalId: roundTripProposalId
         )
 
         XCTAssertNil(
             try backend.getVoteTxHash(
-                roundId: RoundTripFixture.roundId,
-                bundleIndex: RoundTripFixture.bundleIndex,
-                proposalId: RoundTripFixture.proposalId
+                roundId: roundTripRoundId,
+                bundleIndex: roundTripBundleIndex,
+                proposalId: roundTripProposalId
             )
         )
 
         try backend.storeVoteTxHash(
-            roundId: RoundTripFixture.roundId,
-            bundleIndex: RoundTripFixture.bundleIndex,
-            proposalId: RoundTripFixture.proposalId,
-            txHash: RoundTripFixture.voteTxHash
+            roundId: roundTripRoundId,
+            bundleIndex: roundTripBundleIndex,
+            proposalId: roundTripProposalId,
+            txHash: roundTripVoteTxHash
         )
 
         XCTAssertEqual(
             try backend.getVoteTxHash(
-                roundId: RoundTripFixture.roundId,
-                bundleIndex: RoundTripFixture.bundleIndex,
-                proposalId: RoundTripFixture.proposalId
+                roundId: roundTripRoundId,
+                bundleIndex: roundTripBundleIndex,
+                proposalId: roundTripProposalId
             ),
-            RoundTripFixture.voteTxHash
+            roundTripVoteTxHash
         )
     }
 
     func test_commitmentBundle_roundTrips() throws {
-        let backend = try makeReadyBackend(walletId: RoundTripFixture.walletId)
+        let backend = try makeReadyBackend(walletId: roundTripWalletId)
         defer { backend.close() }
 
-        try createRoundWithBundle(backend, roundId: RoundTripFixture.roundId)
+        try createRoundWithBundle(backend, roundId: roundTripRoundId)
         try insertVoteRow(
-            roundId: RoundTripFixture.roundId,
-            walletId: RoundTripFixture.walletId,
-            bundleIndex: RoundTripFixture.bundleIndex,
-            proposalId: RoundTripFixture.proposalId
+            roundId: roundTripRoundId,
+            walletId: roundTripWalletId,
+            bundleIndex: roundTripBundleIndex,
+            proposalId: roundTripProposalId
         )
 
         XCTAssertNil(
             try backend.getCommitmentBundle(
-                roundId: RoundTripFixture.roundId,
-                bundleIndex: RoundTripFixture.bundleIndex,
-                proposalId: RoundTripFixture.proposalId
+                roundId: roundTripRoundId,
+                bundleIndex: roundTripBundleIndex,
+                proposalId: roundTripProposalId
             )
         )
 
         try backend.storeCommitmentBundle(
-            roundId: RoundTripFixture.roundId,
-            bundleIndex: RoundTripFixture.bundleIndex,
-            proposalId: RoundTripFixture.proposalId,
-            bundleJson: RoundTripFixture.commitmentBundleJson,
-            voteCommitmentTreePosition: RoundTripFixture.voteCommitmentTreePosition
+            roundId: roundTripRoundId,
+            bundleIndex: roundTripBundleIndex,
+            proposalId: roundTripProposalId,
+            bundleJson: roundTripCommitmentBundleJson,
+            voteCommitmentTreePosition: roundTripVoteCommitmentTreePosition
         )
 
         let stored = try XCTUnwrap(
             backend.getCommitmentBundle(
-                roundId: RoundTripFixture.roundId,
-                bundleIndex: RoundTripFixture.bundleIndex,
-                proposalId: RoundTripFixture.proposalId
+                roundId: roundTripRoundId,
+                bundleIndex: roundTripBundleIndex,
+                proposalId: roundTripProposalId
             )
         )
-        XCTAssertEqual(stored.bundleJson, RoundTripFixture.commitmentBundleJson)
-        XCTAssertEqual(stored.voteCommitmentTreePosition, RoundTripFixture.voteCommitmentTreePosition)
+        XCTAssertEqual(stored.bundleJson, roundTripCommitmentBundleJson)
+        XCTAssertEqual(stored.voteCommitmentTreePosition, roundTripVoteCommitmentTreePosition)
     }
 
     func test_keystoneSignature_roundTrips() throws {
         let backend = try makeReadyBackend()
         defer { backend.close() }
 
-        try createRoundWithBundle(backend, roundId: RoundTripFixture.roundId)
+        try createRoundWithBundle(backend, roundId: roundTripRoundId)
 
         try backend.storeKeystoneSignature(
-            roundId: RoundTripFixture.roundId,
-            bundleIndex: RoundTripFixture.bundleIndex,
-            sig: RoundTripFixture.keystoneSignature,
-            sighash: RoundTripFixture.pcztSighash,
-            randomizedKey: RoundTripFixture.randomizedKey
+            roundId: roundTripRoundId,
+            bundleIndex: roundTripBundleIndex,
+            sig: roundTripKeystoneSignature,
+            sighash: roundTripPcztSighash,
+            randomizedKey: roundTripRandomizedKey
         )
 
         XCTAssertEqual(
-            try backend.getKeystoneSignatures(roundId: RoundTripFixture.roundId),
+            try backend.getKeystoneSignatures(roundId: roundTripRoundId),
             [
                 VotingKeystoneSignatureRecord(
-                    bundleIndex: RoundTripFixture.bundleIndex,
-                    sig: RoundTripFixture.keystoneSignature,
-                    sighash: RoundTripFixture.pcztSighash,
-                    randomizedKey: RoundTripFixture.randomizedKey
+                    bundleIndex: roundTripBundleIndex,
+                    sig: roundTripKeystoneSignature,
+                    sighash: roundTripPcztSighash,
+                    randomizedKey: roundTripRandomizedKey
                 )
             ]
         )
@@ -708,57 +707,57 @@ final class VotingRustBackendTests: XCTestCase {
         let backend = try makeReadyBackend()
         defer { backend.close() }
 
-        try createRoundWithBundle(backend, roundId: RoundTripFixture.roundId)
+        try createRoundWithBundle(backend, roundId: roundTripRoundId)
 
         try backend.recordShareDelegation(
-            roundId: RoundTripFixture.roundId,
-            bundleIndex: RoundTripFixture.bundleIndex,
-            proposalId: RoundTripFixture.proposalId,
-            shareIndex: RoundTripFixture.shareIndex0,
-            sentToURLs: [RoundTripFixture.helperAURL],
-            nullifier: RoundTripFixture.shareNullifier,
-            submitAt: RoundTripFixture.firstSubmitAt
+            roundId: roundTripRoundId,
+            bundleIndex: roundTripBundleIndex,
+            proposalId: roundTripProposalId,
+            shareIndex: roundTripShareIndex0,
+            sentToURLs: [roundTripHelperAURL],
+            nullifier: roundTripShareNullifier,
+            submitAt: roundTripFirstSubmitAt
         )
         try backend.recordShareDelegation(
-            roundId: RoundTripFixture.roundId,
-            bundleIndex: RoundTripFixture.bundleIndex,
-            proposalId: RoundTripFixture.proposalId,
-            shareIndex: RoundTripFixture.shareIndex1,
-            sentToURLs: [RoundTripFixture.helperBURL],
-            nullifier: RoundTripFixture.shareNullifier,
-            submitAt: RoundTripFixture.secondSubmitAt
+            roundId: roundTripRoundId,
+            bundleIndex: roundTripBundleIndex,
+            proposalId: roundTripProposalId,
+            shareIndex: roundTripShareIndex1,
+            sentToURLs: [roundTripHelperBURL],
+            nullifier: roundTripShareNullifier,
+            submitAt: roundTripSecondSubmitAt
         )
 
-        let all = try backend.getShareDelegations(roundId: RoundTripFixture.roundId)
+        let all = try backend.getShareDelegations(roundId: roundTripRoundId)
         XCTAssertEqual(all.count, 2)
 
-        let share0 = try XCTUnwrap(all.first { $0.shareIndex == RoundTripFixture.shareIndex0 })
-        XCTAssertEqual(share0.roundId, RoundTripFixture.roundId)
-        XCTAssertEqual(share0.bundleIndex, RoundTripFixture.bundleIndex)
-        XCTAssertEqual(share0.proposalId, RoundTripFixture.proposalId)
-        XCTAssertEqual(share0.sentToURLs, [RoundTripFixture.helperAURL])
-        XCTAssertEqual(share0.nullifier, RoundTripFixture.shareNullifier)
+        let share0 = try XCTUnwrap(all.first { $0.shareIndex == roundTripShareIndex0 })
+        XCTAssertEqual(share0.roundId, roundTripRoundId)
+        XCTAssertEqual(share0.bundleIndex, roundTripBundleIndex)
+        XCTAssertEqual(share0.proposalId, roundTripProposalId)
+        XCTAssertEqual(share0.sentToURLs, [roundTripHelperAURL])
+        XCTAssertEqual(share0.nullifier, roundTripShareNullifier)
         XCTAssertFalse(share0.confirmed)
-        XCTAssertEqual(share0.submitAt, RoundTripFixture.firstSubmitAt)
+        XCTAssertEqual(share0.submitAt, roundTripFirstSubmitAt)
 
-        XCTAssertEqual(try backend.getUnconfirmedDelegations(roundId: RoundTripFixture.roundId).count, 2)
+        XCTAssertEqual(try backend.getUnconfirmedDelegations(roundId: roundTripRoundId).count, 2)
 
         try backend.markShareConfirmed(
-            roundId: RoundTripFixture.roundId,
-            bundleIndex: RoundTripFixture.bundleIndex,
-            proposalId: RoundTripFixture.proposalId,
-            shareIndex: RoundTripFixture.shareIndex0
+            roundId: roundTripRoundId,
+            bundleIndex: roundTripBundleIndex,
+            proposalId: roundTripProposalId,
+            shareIndex: roundTripShareIndex0
         )
 
         let confirmedShare = try XCTUnwrap(
-            backend.getShareDelegations(roundId: RoundTripFixture.roundId)
-                .first { $0.shareIndex == RoundTripFixture.shareIndex0 }
+            backend.getShareDelegations(roundId: roundTripRoundId)
+                .first { $0.shareIndex == roundTripShareIndex0 }
         )
         XCTAssertTrue(confirmedShare.confirmed)
 
-        let unconfirmed = try backend.getUnconfirmedDelegations(roundId: RoundTripFixture.roundId)
+        let unconfirmed = try backend.getUnconfirmedDelegations(roundId: roundTripRoundId)
         XCTAssertEqual(unconfirmed.count, 1)
-        XCTAssertEqual(unconfirmed[0].shareIndex, RoundTripFixture.shareIndex1)
+        XCTAssertEqual(unconfirmed[0].shareIndex, roundTripShareIndex1)
     }
 
     func test_recordShareDelegation_rejectsInvalidNullifierLength() throws {
@@ -1067,7 +1066,7 @@ final class VotingRustBackendTests: XCTestCase {
         return path
     }
 
-    private func makeReadyBackend(walletId: String = RoundTripFixture.walletId) throws -> VotingRustBackend {
+    private func makeReadyBackend(walletId: String = roundTripWalletId) throws -> VotingRustBackend {
         let backend = VotingRustBackend()
         try backend.open(path: makeTempDbPath())
         try backend.setWalletId(walletId)
@@ -1080,10 +1079,10 @@ final class VotingRustBackendTests: XCTestCase {
     ) throws {
         try backend.initRound(
             roundId: roundId,
-            snapshotHeight: RoundTripFixture.snapshotHeight,
-            eaPublicKey: RoundTripFixture.roundParameter,
-            ncRoot: RoundTripFixture.roundParameter,
-            nullifierImtRoot: RoundTripFixture.roundParameter
+            snapshotHeight: roundTripSnapshotHeight,
+            eaPublicKey: roundTripRoundParameter,
+            ncRoot: roundTripRoundParameter,
+            nullifierImtRoot: roundTripRoundParameter
         )
 
         let result = try backend.setupBundles(
@@ -1095,13 +1094,13 @@ final class VotingRustBackendTests: XCTestCase {
 
     private func makeEligibleNote() -> VotingNoteInfo {
         VotingNoteInfo(
-            commitment: [UInt8](repeating: 0x01, count: RoundTripFixture.fieldElementByteCount),
-            nullifier: [UInt8](repeating: 0x02, count: RoundTripFixture.fieldElementByteCount),
-            value: RoundTripFixture.eligibleNoteValue,
+            commitment: [UInt8](repeating: 0x01, count: roundTripFieldElementByteCount),
+            nullifier: [UInt8](repeating: 0x02, count: roundTripFieldElementByteCount),
+            value: roundTripEligibleNoteValue,
             position: 0,
-            diversifier: [UInt8](repeating: 0, count: RoundTripFixture.diversifierByteCount),
-            rho: [UInt8](repeating: 0, count: RoundTripFixture.fieldElementByteCount),
-            rseed: [UInt8](repeating: 0, count: RoundTripFixture.fieldElementByteCount),
+            diversifier: [UInt8](repeating: 0, count: roundTripDiversifierByteCount),
+            rho: [UInt8](repeating: 0, count: roundTripFieldElementByteCount),
+            rseed: [UInt8](repeating: 0, count: roundTripFieldElementByteCount),
             scope: 0,
             ufvkStr: ""
         )
@@ -1142,7 +1141,7 @@ final class VotingRustBackendTests: XCTestCase {
         defer { sqlite3_finalize(statement) }
 
         let sqliteTransient = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
-        let commitment = RoundTripFixture.voteCommitment
+        let commitment = roundTripVoteCommitment
 
         try roundId.withCString { roundIdPointer in
             try requireSQLite(
@@ -1181,7 +1180,7 @@ final class VotingRustBackendTests: XCTestCase {
             )
         }
         try requireSQLite(
-            sqlite3_bind_int64(statement, 7, sqlite3_int64(RoundTripFixture.createdAt)),
+            sqlite3_bind_int64(statement, 7, sqlite3_int64(roundTripCreatedAt)),
             db,
             message: "bind created_at"
         )
@@ -1189,7 +1188,7 @@ final class VotingRustBackendTests: XCTestCase {
         try requireSQLite(
             sqlite3_step(statement),
             db,
-            expected: RoundTripFixture.sqliteDoneCode,
+            expected: roundTripSQLiteDoneCode,
             message: "insert vote row"
         )
     }
@@ -1197,7 +1196,7 @@ final class VotingRustBackendTests: XCTestCase {
     private func requireSQLite(
         _ code: Int32,
         _ db: OpaquePointer?,
-        expected: Int32 = RoundTripFixture.sqliteSuccessCode,
+        expected: Int32 = roundTripSQLiteSuccessCode,
         message: String
     ) throws {
         guard code == expected else {

--- a/rust/src/voting/delegation.rs
+++ b/rust/src/voting/delegation.rs
@@ -671,7 +671,7 @@ const PATH_BYTES: usize = NUM_PATH_ELEMENTS * 32;
 /// pallas::Base values for the root and the three nf_bounds, a u32 leaf
 /// position, and 29 32-byte path siblings.
 ///
-/// Returns 0 if the proof is valid, 1 if it is well-formed but invalid, and -1
+/// Returns 1 if the proof is valid, 0 if it is well-formed but invalid, and -1
 /// if inputs are malformed or a panic occurs.
 ///
 /// # Safety
@@ -721,8 +721,8 @@ pub unsafe extern "C" fn zcashlc_voting_validate_pir_proof(
         let expected_root = parse_base(&expected_root_bytes, "expected_root")?;
 
         match zkp1::validate_and_convert_pir_proof(proof, nullifier, expected_root) {
-            Ok(_) => Ok(0),
-            Err(_) => Ok(1),
+            Ok(_) => Ok(1),
+            Err(_) => Ok(0),
         }
     });
     unwrap_exc_or(res, -1)
@@ -1457,7 +1457,7 @@ mod tests {
                 &nullifier,
                 &expected_root
             ),
-            0
+            1
         );
     }
 
@@ -1479,7 +1479,7 @@ mod tests {
                 &nullifier,
                 &expected_root
             ),
-            1
+            0
         );
     }
 
@@ -1501,7 +1501,7 @@ mod tests {
                 &nullifier,
                 &expected_root
             ),
-            1
+            0
         );
     }
 

--- a/rust/src/voting/recovery.rs
+++ b/rust/src/voting/recovery.rs
@@ -52,6 +52,11 @@ pub unsafe extern "C" fn zcashlc_voting_store_delegation_tx_hash(
             unsafe { db.as_ref() }.ok_or_else(|| anyhow!("VotingDatabaseHandle is null"))?;
         let round_id_str = unsafe { str_from_ptr(round_id, round_id_len) }?;
         let tx_hash_str = unsafe { str_from_ptr(tx_hash, tx_hash_len) }?;
+        // Check if the bundle exists
+        handle
+            .db
+            .get_delegation_tx_hash(&round_id_str, bundle_index)
+            .map_err(|e| anyhow!("store_delegation_tx_hash failed: {}", e))?;
         handle
             .db
             .store_delegation_tx_hash(&round_id_str, bundle_index, &tx_hash_str)
@@ -390,6 +395,27 @@ mod tests {
         };
         let actual: Option<String> = decode_boxed_json(result);
         assert_eq!(actual.as_deref(), Some("delegation-tx"));
+
+        unsafe { zcashlc_voting_db_free(db) };
+    }
+
+    #[test]
+    fn store_delegation_tx_hash_rejects_missing_bundle() {
+        let db = open_memory_db();
+        let round_id = b"missing";
+        let tx_hash = b"delegation-tx";
+
+        let code = unsafe {
+            zcashlc_voting_store_delegation_tx_hash(
+                db,
+                round_id.as_ptr(),
+                round_id.len(),
+                0,
+                tx_hash.as_ptr(),
+                tx_hash.len(),
+            )
+        };
+        assert_eq!(code, -1);
 
         unsafe { zcashlc_voting_db_free(db) };
     }


### PR DESCRIPTION
## Summary

Tracks zcash#1661. Stacks on top of #1723 ("Add voting delegation workflow FFI").

The Rust side already exposes the full database-bound voting surface (round lifecycle, recovery state, share-delegation tracking, and the delegation workflow including the long-running prove call). This PR adds the matching Swift wrappers in `VotingRustBackend.swift` so wallet clients can drive the voting workflow end-to-end without dropping to `libzcashlc` directly.

Note: there is minor helper overlap with https://github.com/zcash/zcash-swift-wallet-sdk/pull/1719

The previously-shipped static `computeShareNullifier` is preserved unchanged. All new wrappers fall into one of two patterns.

### Pure-function FFI (no handle)

| Swift | FFI |
|-------|-----|
| `warmProvingCaches()` | `zcashlc_voting_warm_proving_caches` |
| `decomposeWeight(_:)` | `zcashlc_voting_decompose_weight` |
| `generateDelegationInputs(senderSeed:hotkeySeed:networkId:accountIndex:)` | `zcashlc_voting_generate_delegation_inputs` |
| `generateDelegationInputs(senderFvk:hotkeySeed:networkId:seedFingerprint:)` | `zcashlc_voting_generate_delegation_inputs_with_fvk` |
| `extractPcztSighash(pczt:)` | `zcashlc_voting_extract_pczt_sighash` |
| `extractSpendAuthSig(signedPczt:actionIndex:)` | `zcashlc_voting_extract_spend_auth_sig` |
| `extractOrchardFvk(ufvk:networkId:)` | `zcashlc_voting_extract_orchard_fvk_from_ufvk` |
| `extractNcRoot(treeState:)` | `zcashlc_voting_extract_nc_root` |
| `verifyWitness(_:)` | `zcashlc_voting_verify_witness` |
| `validatePirProof(_:)` | `zcashlc_voting_validate_pir_proof` |

### Database-bound FFI (require open handle)

- **Round lifecycle** — `initRound`, `getRoundState`, `listRounds`, `getVotes`, `clearRound`, `deleteSkippedBundles`
- **Wallet notes** — `getWalletNotes`
- **Recovery state** — `storeDelegationTxHash`/`getDelegationTxHash`, `storeVoteTxHash`/`getVoteTxHash`, `storeCommitmentBundle`/`getCommitmentBundle`, `storeKeystoneSignature`/`getKeystoneSignatures`, `clearRecoveryState`
- **Share-delegation tracking** — `recordShareDelegation`, `getShareDelegations`, `getUnconfirmedDelegations`, `markShareConfirmed`, `addSentServers`
- **Delegation workflow** — `generateHotkey`, `setupBundles`, `getBundleCount`, `buildPczt(_:)` (params via `VotingBuildPcztParams`), `storeTreeState`, two `getDelegationSubmission` overloads (seed-derived and Keystone-signed), `storeVanPosition`, and the long-running `async` `buildAndProveDelegation`

No public API changes beyond the new symbols listed in `CHANGELOG.md`.