### PR TITLE
[#1661] Add Swift voting cast-vote wrappers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,9 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Database lifecycle: `init()`, `open(path:)`, `close()` (idempotent), and `deinit` cleanup, over `zcashlc_voting_db_open` / `zcashlc_voting_db_free`.
   - `setWalletId(_:)` over `zcashlc_voting_set_wallet_id`.
   - `precomputeDelegationPir(roundId:bundleIndex:notes:pirEndpoints:expectedSnapshotHeight:networkId:pirResolver:)` over `zcashlc_voting_precompute_delegation_pir`, with `PirSnapshotResolver`-driven endpoint selection.
+  - `generateNoteWitnesses(roundId:bundleIndex:walletDbPath:notes:networkId:)` over `zcashlc_voting_generate_note_witnesses`.
   - Vote-tree sync: `syncVoteTree(roundId:nodeUrl:)`, `generateVanWitness(roundId:bundleIndex:anchorHeight:)`, and `resetTreeClient(roundId:)` over the corresponding `zcashlc_voting_sync_vote_tree` / `_generate_van_witness` / `_reset_tree_client` FFI.
+  - Vote casting: `encryptShares(roundId:shares:)`, `buildVoteCommitment(roundId:bundleIndex:hotkeySeed:networkId:proposalId:choice:numOptions:vanWitness:singleShare:progress:)`, `buildSharePayloads(commitment:voteDecision:numOptions:voteCommitmentTreePosition:singleShare:)`, `markVoteSubmitted(roundId:bundleIndex:proposalId:)`, and `signCastVote(hotkeySeed:networkId:commitment:)`.
   - The static `computeShareNullifier(voteCommitment:shareIndex:primaryBlind:)` over `zcashlc_voting_compute_share_nullifier`, with 32-byte input validation.
   - `VotingRustBackendError` cases `databaseAlreadyOpen` / `databaseNotOpen` for handle-state errors, alongside the existing `rustError` and `invalidData`.
 - Extends `VotingRustBackend` with additional FFI wrappers and their FFI mappings:

--- a/Sources/ZcashLightClientKit/Rust/Voting/VotingRustBackend.swift
+++ b/Sources/ZcashLightClientKit/Rust/Voting/VotingRustBackend.swift
@@ -344,8 +344,11 @@ extension VotingRustBackend {
     /// Build a vote commitment proof for a proposal.
     ///
     /// The proof callback may be invoked from Rust worker threads. Do not call
-    /// back into this backend from `progress`, because the database handle lock
-    /// is held while the FFI call is active.
+    /// back into this backend from `progress`: the database handle lock is held
+    /// while the FFI call is active, so re-entering the backend will deadlock.
+    ///
+    /// Safety: keep `progress` thread-safe, non-blocking, and limited to
+    /// reporting state outside this backend.
     // swiftlint:disable:next function_parameter_count
     public func buildVoteCommitment(
         roundId: String,

--- a/Sources/ZcashLightClientKit/Rust/Voting/VotingRustBackend.swift
+++ b/Sources/ZcashLightClientKit/Rust/Voting/VotingRustBackend.swift
@@ -262,6 +262,232 @@ extension VotingRustBackend {
     }
 }
 
+// MARK: - Delegation witnesses
+
+extension VotingRustBackend {
+    /// Generate Merkle inclusion witnesses for a bundle's notes and cache them
+    /// in the voting database.
+    public func generateNoteWitnesses(
+        roundId: String,
+        bundleIndex: UInt32,
+        walletDbPath: String,
+        notes: [VotingNoteInfo],
+        networkId: UInt32
+    ) throws -> [VotingWitnessData] {
+        let roundIdBytes = [UInt8](roundId.utf8)
+        let walletPathBytes = [UInt8](walletDbPath.utf8)
+        let notesJson = try JSONEncoder().encode(notes)
+        let notesBytes = [UInt8](notesJson)
+
+        let ptr: UnsafeMutablePointer<FfiBoxedSlice> = try withHandle { dbh in
+            let ptr: UnsafeMutablePointer<FfiBoxedSlice>? = roundIdBytes.withUnsafeBufferPointer { ridBuf in
+                walletPathBytes.withUnsafeBufferPointer { pathBuf in
+                    notesBytes.withUnsafeBufferPointer { notesBuf in
+                        zcashlc_voting_generate_note_witnesses(
+                            dbh,
+                            ridBuf.baseAddress,
+                            UInt(ridBuf.count),
+                            bundleIndex,
+                            pathBuf.baseAddress,
+                            UInt(pathBuf.count),
+                            notesBuf.baseAddress,
+                            UInt(notesBuf.count),
+                            networkId
+                        )
+                    }
+                }
+            }
+
+            guard let ptr else {
+                throw VotingRustBackendError.rustError(
+                    lastErrorMessage(fallback: "`generate_note_witnesses` failed")
+                )
+            }
+            return ptr
+        }
+        defer { zcashlc_free_boxed_slice(ptr) }
+        return try decodeJSON(from: ptr)
+    }
+}
+
+// MARK: - Vote casting
+
+extension VotingRustBackend {
+    /// Encrypt voting shares for a round.
+    public func encryptShares(roundId: String, shares: [UInt64]) throws -> [VotingWireEncryptedShare] {
+        let roundIdBytes = [UInt8](roundId.utf8)
+        let sharesJson = try JSONEncoder().encode(shares)
+        let sharesBytes = [UInt8](sharesJson)
+
+        let ptr: UnsafeMutablePointer<FfiBoxedSlice> = try withHandle { dbh in
+            let ptr: UnsafeMutablePointer<FfiBoxedSlice>? = roundIdBytes.withUnsafeBufferPointer { ridBuf in
+                sharesBytes.withUnsafeBufferPointer { sharesBuf in
+                    zcashlc_voting_encrypt_shares(
+                        dbh,
+                        ridBuf.baseAddress,
+                        UInt(ridBuf.count),
+                        sharesBuf.baseAddress,
+                        UInt(sharesBuf.count)
+                    )
+                }
+            }
+
+            guard let ptr else {
+                throw VotingRustBackendError.rustError(lastErrorMessage(fallback: "`encrypt_shares` failed"))
+            }
+            return ptr
+        }
+        defer { zcashlc_free_boxed_slice(ptr) }
+        return try decodeJSON(from: ptr)
+    }
+
+    /// Build a vote commitment proof for a proposal.
+    ///
+    /// The proof callback may be invoked from Rust worker threads. Do not call
+    /// back into this backend from `progress`, because the database handle lock
+    /// is held while the FFI call is active.
+    // swiftlint:disable:next function_parameter_count
+    public func buildVoteCommitment(
+        roundId: String,
+        bundleIndex: UInt32,
+        hotkeySeed: [UInt8],
+        networkId: UInt32,
+        proposalId: UInt32,
+        choice: UInt32,
+        numOptions: UInt32,
+        vanWitness: VotingVanWitness,
+        singleShare: Bool,
+        progress: (@Sendable (Double) -> Void)? = nil
+    ) async throws -> VotingVoteCommitmentBundle {
+        try requireOpenDatabase()
+
+        return try await Task.detached { [self] in
+            try syncBuildVoteCommitment(
+                roundId: roundId,
+                bundleIndex: bundleIndex,
+                hotkeySeed: hotkeySeed,
+                networkId: networkId,
+                proposalId: proposalId,
+                choice: choice,
+                numOptions: numOptions,
+                vanWitness: vanWitness,
+                singleShare: singleShare,
+                progress: progress
+            )
+        }.value
+    }
+
+    /// Build delegated share-submission payloads from a vote commitment bundle.
+    public func buildSharePayloads(
+        commitment: VotingVoteCommitmentBundle,
+        voteDecision: UInt32,
+        numOptions: UInt32,
+        voteCommitmentTreePosition: UInt64,
+        singleShare: Bool
+    ) throws -> [VotingSharePayload] {
+        let commitmentJson = try JSONEncoder().encode(commitment)
+        let commitmentBytes = [UInt8](commitmentJson)
+
+        let ptr: UnsafeMutablePointer<FfiBoxedSlice> = try withHandle { dbh in
+            let ptr: UnsafeMutablePointer<FfiBoxedSlice>? = commitmentBytes.withUnsafeBufferPointer { commitmentBuf in
+                zcashlc_voting_build_share_payloads(
+                    dbh,
+                    commitmentBuf.baseAddress,
+                    UInt(commitmentBuf.count),
+                    voteDecision,
+                    numOptions,
+                    voteCommitmentTreePosition,
+                    singleShare ? 1 : 0
+                )
+            }
+
+            guard let ptr else {
+                throw VotingRustBackendError.rustError(
+                    lastErrorMessage(fallback: "`build_share_payloads` failed")
+                )
+            }
+            return ptr
+        }
+        defer { zcashlc_free_boxed_slice(ptr) }
+        return try decodeJSON(from: ptr)
+    }
+
+    /// Mark a vote as submitted for a specific proposal and bundle.
+    public func markVoteSubmitted(
+        roundId: String,
+        bundleIndex: UInt32,
+        proposalId: UInt32
+    ) throws {
+        let roundIdBytes = [UInt8](roundId.utf8)
+
+        try withHandle { dbh in
+            let result = roundIdBytes.withUnsafeBufferPointer { buf in
+                zcashlc_voting_mark_vote_submitted(
+                    dbh,
+                    buf.baseAddress,
+                    UInt(buf.count),
+                    bundleIndex,
+                    proposalId
+                )
+            }
+
+            guard result == 0 else {
+                throw VotingRustBackendError.rustError(lastErrorMessage(fallback: "`mark_vote_submitted` failed"))
+            }
+        }
+    }
+
+    /// Sign a cast-vote transaction using fields from a vote commitment bundle.
+    public static func signCastVote(
+        hotkeySeed: [UInt8],
+        networkId: UInt32,
+        commitment: VotingVoteCommitmentBundle
+    ) throws -> VotingCastVoteSignature {
+        let roundIdBytes = [UInt8](commitment.voteRoundId.utf8)
+
+        let ptr: UnsafeMutablePointer<FfiBoxedSlice>? = hotkeySeed.withUnsafeBufferPointer { seedBuf in
+            roundIdBytes.withUnsafeBufferPointer { roundBuf in
+                commitment.rVpkBytes.withUnsafeBufferPointer { rVpkBuf in
+                    commitment.vanNullifier.withUnsafeBufferPointer { vanNullifierBuf in
+                        commitment.voteAuthorityNoteNew.withUnsafeBufferPointer { vanNewBuf in
+                            commitment.voteCommitment.withUnsafeBufferPointer { voteCommitmentBuf in
+                                commitment.alphaV.withUnsafeBufferPointer { alphaBuf in
+                                    zcashlc_voting_sign_cast_vote(
+                                        seedBuf.baseAddress,
+                                        UInt(seedBuf.count),
+                                        networkId,
+                                        roundBuf.baseAddress,
+                                        UInt(roundBuf.count),
+                                        rVpkBuf.baseAddress,
+                                        UInt(rVpkBuf.count),
+                                        vanNullifierBuf.baseAddress,
+                                        UInt(vanNullifierBuf.count),
+                                        vanNewBuf.baseAddress,
+                                        UInt(vanNewBuf.count),
+                                        voteCommitmentBuf.baseAddress,
+                                        UInt(voteCommitmentBuf.count),
+                                        commitment.proposalId,
+                                        commitment.anchorHeight,
+                                        alphaBuf.baseAddress,
+                                        UInt(alphaBuf.count)
+                                    )
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        guard let ptr else {
+            throw VotingRustBackendError.rustError(staticLastErrorMessage(fallback: "`sign_cast_vote` failed"))
+        }
+        defer { zcashlc_free_boxed_slice(ptr) }
+        let data = Data(bytes: ptr.pointee.ptr, count: Int(ptr.pointee.len))
+        return try JSONDecoder().decode(VotingCastVoteSignature.self, from: data)
+    }
+}
+
 // MARK: - Share tracking (static)
 
 extension VotingRustBackend {
@@ -1578,6 +1804,72 @@ private extension VotingRustBackend {
     func decodeJSON<T: Decodable>(from ptr: UnsafeMutablePointer<FfiBoxedSlice>) throws -> T {
         let data = Data(bytes: ptr.pointee.ptr, count: Int(ptr.pointee.len))
         return try JSONDecoder().decode(T.self, from: data)
+    }
+
+    /// Synchronous body of `buildVoteCommitment`. Runs inside `Task.detached`
+    /// so proving does not block the caller's executor.
+    // swiftlint:disable:next function_parameter_count
+    func syncBuildVoteCommitment(
+        roundId: String,
+        bundleIndex: UInt32,
+        hotkeySeed: [UInt8],
+        networkId: UInt32,
+        proposalId: UInt32,
+        choice: UInt32,
+        numOptions: UInt32,
+        vanWitness: VotingVanWitness,
+        singleShare: Bool,
+        progress: (@Sendable (Double) -> Void)?
+    ) throws -> VotingVoteCommitmentBundle {
+        let roundIdBytes = [UInt8](roundId.utf8)
+        let authPathJson = try JSONEncoder().encode(vanWitness.authPath)
+        let authPathBytes = [UInt8](authPathJson)
+
+        let progressBox = progress.map(VotingProgressBox.init(report:))
+        let progressContext = progressBox.map { Unmanaged.passRetained($0).toOpaque() }
+        defer {
+            if let progressContext {
+                Unmanaged<VotingProgressBox>.fromOpaque(progressContext).release()
+            }
+        }
+        let trampoline: VotingProgressCallback? = progressBox == nil ? nil : votingProgressCallbackTrampoline
+
+        let ptr: UnsafeMutablePointer<FfiBoxedSlice> = try withHandle { dbh in
+            let ptr: UnsafeMutablePointer<FfiBoxedSlice>? = roundIdBytes.withUnsafeBufferPointer { ridBuf in
+                hotkeySeed.withUnsafeBufferPointer { seedBuf in
+                    authPathBytes.withUnsafeBufferPointer { pathBuf in
+                        zcashlc_voting_build_vote_commitment(
+                            dbh,
+                            ridBuf.baseAddress,
+                            UInt(ridBuf.count),
+                            bundleIndex,
+                            seedBuf.baseAddress,
+                            UInt(seedBuf.count),
+                            networkId,
+                            proposalId,
+                            choice,
+                            numOptions,
+                            pathBuf.baseAddress,
+                            UInt(pathBuf.count),
+                            vanWitness.position,
+                            vanWitness.anchorHeight,
+                            trampoline,
+                            progressContext,
+                            singleShare ? 1 : 0
+                        )
+                    }
+                }
+            }
+
+            guard let ptr else {
+                throw VotingRustBackendError.rustError(
+                    lastErrorMessage(fallback: "`build_vote_commitment` failed")
+                )
+            }
+            return ptr
+        }
+        defer { zcashlc_free_boxed_slice(ptr) }
+        return try decodeJSON(from: ptr)
     }
 
     /// Reads the last error recorded by `libzcashlc` and clears it as a side

--- a/Sources/ZcashLightClientKit/Rust/Voting/VotingRustBackend.swift
+++ b/Sources/ZcashLightClientKit/Rust/Voting/VotingRustBackend.swift
@@ -123,7 +123,7 @@ extension VotingRustBackend {
     /// needed for the delegation ZKP, and cache them in the voting database.
     ///
     /// This performs the network PIR lookup only, proof construction happens
-    //  elsewhere.
+    ///  elsewhere.
     ///
     /// `pirEndpoints` are probed in parallel via `pirResolver`. The first
     /// endpoint whose served snapshot height equals `expectedSnapshotHeight`

--- a/Tests/OfflineTests/VotingRustBackendTests.swift
+++ b/Tests/OfflineTests/VotingRustBackendTests.swift
@@ -985,6 +985,24 @@ final class VotingRustBackendTests: XCTestCase {
         }
     }
 
+    func test_generateNoteWitnesses_beforeOpen_throwsDatabaseNotOpen() {
+        let backend = VotingRustBackend()
+        XCTAssertThrowsError(
+            try backend.generateNoteWitnesses(
+                roundId: "round1",
+                bundleIndex: 0,
+                walletDbPath: "/tmp/wallet.sqlite",
+                notes: [],
+                networkId: 1
+            )
+        ) { error in
+            guard case VotingRustBackendError.databaseNotOpen = error else {
+                XCTFail("expected .databaseNotOpen, got \(error)")
+                return
+            }
+        }
+    }
+
     func test_buildAndProveDelegation_beforeOpen_throwsDatabaseNotOpen() async {
         let backend = VotingRustBackend()
         do {
@@ -1007,6 +1025,334 @@ final class VotingRustBackendTests: XCTestCase {
         } catch {
             XCTFail("unexpected error: \(error)")
         }
+    }
+
+    func test_generateNoteWitnesses_afterOpen_forwardsNetworkIdAndPropagatesRustError() throws {
+        let backend = try makeOpenBackend()
+        defer { backend.close() }
+
+        XCTAssertThrowsError(
+            try backend.generateNoteWitnesses(
+                roundId: "round1",
+                bundleIndex: 0,
+                walletDbPath: "/tmp/nonexistent-wallet.sqlite",
+                notes: [],
+                networkId: 99
+            )
+        ) { error in
+            guard case VotingRustBackendError.rustError(let message) = error else {
+                XCTFail("expected .rustError, got \(error)")
+                return
+            }
+            XCTAssertTrue(message.contains("Invalid network type"), "unexpected message: \(message)")
+        }
+    }
+
+    func test_encryptShares_beforeOpen_throwsDatabaseNotOpen() {
+        let backend = VotingRustBackend()
+        XCTAssertThrowsError(try backend.encryptShares(roundId: "round1", shares: [1])) { error in
+            guard case VotingRustBackendError.databaseNotOpen = error else {
+                XCTFail("expected .databaseNotOpen, got \(error)")
+                return
+            }
+        }
+    }
+
+    func test_encryptShares_afterOpen_propagatesRustError() throws {
+        let backend = try makeOpenBackend()
+        defer { backend.close() }
+
+        XCTAssertThrowsError(try backend.encryptShares(roundId: "missing-round", shares: [1, 2])) { error in
+            guard case VotingRustBackendError.rustError(let message) = error else {
+                XCTFail("expected .rustError, got \(error)")
+                return
+            }
+            XCTAssertTrue(message.contains("encrypt_shares failed"), "unexpected message: \(message)")
+        }
+    }
+
+    func test_buildVoteCommitment_beforeOpen_throwsDatabaseNotOpen() async {
+        let backend = VotingRustBackend()
+
+        do {
+            _ = try await backend.buildVoteCommitment(
+                roundId: "round1",
+                bundleIndex: 0,
+                hotkeySeed: [UInt8](repeating: 1, count: 32),
+                networkId: 1,
+                proposalId: 0,
+                choice: 0,
+                numOptions: 2,
+                vanWitness: VotingVanWitness(
+                    authPath: [[UInt8](repeating: 1, count: 32)],
+                    position: 0,
+                    anchorHeight: 0
+                ),
+                singleShare: false
+            )
+            XCTFail("expected .databaseNotOpen")
+        } catch let error as VotingRustBackendError {
+            guard case .databaseNotOpen = error else {
+                XCTFail("expected .databaseNotOpen, got \(error)")
+                return
+            }
+        } catch {
+            XCTFail("unexpected error: \(error)")
+        }
+    }
+
+    func test_buildVoteCommitment_afterOpen_rejectsShortSeedAndDoesNotReportProgress() async throws {
+        let backend = try makeOpenBackend()
+        defer { backend.close() }
+        let progressReported = expectation(description: "progress must not be reported before seed validation")
+        progressReported.isInverted = true
+
+        do {
+            _ = try await backend.buildVoteCommitment(
+                roundId: "round1",
+                bundleIndex: 0,
+                hotkeySeed: [UInt8](repeating: 1, count: 31),
+                networkId: 1,
+                proposalId: 0,
+                choice: 0,
+                numOptions: 2,
+                vanWitness: VotingVanWitness(
+                    authPath: [],
+                    position: 0,
+                    anchorHeight: 0
+                ),
+                singleShare: false,
+                progress: { _ in progressReported.fulfill() }
+            )
+            XCTFail("expected .rustError")
+        } catch let error as VotingRustBackendError {
+            guard case .rustError(let message) = error else {
+                XCTFail("expected .rustError, got \(error)")
+                return
+            }
+            XCTAssertTrue(message.contains("hotkey_seed must be at least"), "unexpected message: \(message)")
+        } catch {
+            XCTFail("unexpected error: \(error)")
+        }
+
+        await fulfillment(of: [progressReported], timeout: 0.1)
+    }
+
+    func test_buildSharePayloads_beforeOpen_throwsDatabaseNotOpen() {
+        let backend = VotingRustBackend()
+        XCTAssertThrowsError(
+            try backend.buildSharePayloads(
+                commitment: makeVoteCommitmentBundle(),
+                voteDecision: 0,
+                numOptions: 2,
+                voteCommitmentTreePosition: 0,
+                singleShare: false
+            )
+        ) { error in
+            guard case VotingRustBackendError.databaseNotOpen = error else {
+                XCTFail("expected .databaseNotOpen, got \(error)")
+                return
+            }
+        }
+    }
+
+    func test_buildSharePayloads_afterOpen_rejectsCommitmentWithoutEncryptedShares() throws {
+        let backend = try makeOpenBackend()
+        defer { backend.close() }
+
+        XCTAssertThrowsError(
+            try backend.buildSharePayloads(
+                commitment: makeVoteCommitmentBundle(encShares: []),
+                voteDecision: 0,
+                numOptions: 2,
+                voteCommitmentTreePosition: 0,
+                singleShare: false
+            )
+        ) { error in
+            guard case VotingRustBackendError.rustError(let message) = error else {
+                XCTFail("expected .rustError, got \(error)")
+                return
+            }
+            XCTAssertTrue(message.contains("enc_shares must not be empty"), "unexpected message: \(message)")
+        }
+    }
+
+    func test_voteSubmissionHelpers_afterOpen_buildPayloadsSignAndMarkSubmitted() throws {
+        let backend = try makeOpenBackend()
+        defer { backend.close() }
+        let commitment = makeVoteCommitmentBundle(proposalId: 7)
+
+        let payloads = try backend.buildSharePayloads(
+            commitment: commitment,
+            voteDecision: 1,
+            numOptions: 2,
+            voteCommitmentTreePosition: 42,
+            singleShare: false
+        )
+
+        XCTAssertEqual(payloads.count, commitment.encShares.count)
+        XCTAssertEqual(payloads[0].sharesHash, commitment.sharesHash)
+        XCTAssertEqual(payloads[0].proposalId, commitment.proposalId)
+        XCTAssertEqual(payloads[0].voteDecision, 1)
+        XCTAssertEqual(payloads[0].treePosition, 42)
+        XCTAssertEqual(payloads[0].encShare.shareIndex, commitment.encShares[0].shareIndex)
+        XCTAssertEqual(payloads[0].allEncShares.count, commitment.encShares.count)
+        XCTAssertEqual(payloads[0].shareComms, commitment.shareComms)
+        XCTAssertEqual(payloads[0].primaryBlind, commitment.shareBlinds[0])
+
+        let nullifier = try VotingRustBackend.computeShareNullifier(
+            voteCommitment: commitment.voteCommitment,
+            shareIndex: payloads[0].encShare.shareIndex,
+            primaryBlind: payloads[0].primaryBlind
+        )
+        XCTAssertEqual(nullifier.count, 64)
+
+        let signature = try VotingRustBackend.signCastVote(
+            hotkeySeed: [UInt8](repeating: 1, count: 32),
+            networkId: 1,
+            commitment: commitment
+        )
+        XCTAssertFalse(signature.voteAuthSig.isEmpty)
+
+        try createRoundWithBundle(backend, roundId: commitment.voteRoundId)
+        try insertVoteRow(
+            roundId: commitment.voteRoundId,
+            walletId: "wallet",
+            bundleIndex: 0,
+            proposalId: commitment.proposalId
+        )
+        XCTAssertNoThrow(
+            try backend.markVoteSubmitted(
+                roundId: commitment.voteRoundId,
+                bundleIndex: 0,
+                proposalId: commitment.proposalId
+            )
+        )
+    }
+
+    func test_markVoteSubmitted_beforeOpen_throwsDatabaseNotOpen() {
+        let backend = VotingRustBackend()
+        XCTAssertThrowsError(
+            try backend.markVoteSubmitted(roundId: "round1", bundleIndex: 0, proposalId: 0)
+        ) { error in
+            guard case VotingRustBackendError.databaseNotOpen = error else {
+                XCTFail("expected .databaseNotOpen, got \(error)")
+                return
+            }
+        }
+    }
+
+    func test_markVoteSubmitted_afterOpen_marksExistingVote() throws {
+        let backend = try makeOpenBackend()
+        defer { backend.close() }
+
+        try createRoundWithBundle(backend, roundId: roundTripRoundId)
+        try insertVoteRow(
+            roundId: roundTripRoundId,
+            walletId: "wallet",
+            bundleIndex: roundTripBundleIndex,
+            proposalId: roundTripProposalId
+        )
+        XCTAssertNoThrow(
+            try backend.markVoteSubmitted(
+                roundId: roundTripRoundId,
+                bundleIndex: roundTripBundleIndex,
+                proposalId: roundTripProposalId
+            )
+        )
+    }
+
+    func test_signCastVote_invalidCommitment_throwsRustError() {
+        XCTAssertThrowsError(
+            try VotingRustBackend.signCastVote(
+                hotkeySeed: [UInt8](repeating: 1, count: 32),
+                networkId: 1,
+                commitment: makeVoteCommitmentBundle(voteRoundId: "too-short")
+            )
+        ) { error in
+            guard case VotingRustBackendError.rustError = error else {
+                XCTFail("expected .rustError, got \(error)")
+                return
+            }
+        }
+    }
+
+    func test_signCastVote_rejectsShortSeed() {
+        XCTAssertThrowsError(
+            try VotingRustBackend.signCastVote(
+                hotkeySeed: [UInt8](repeating: 1, count: 31),
+                networkId: 1,
+                commitment: makeVoteCommitmentBundle()
+            )
+        ) { error in
+            guard case VotingRustBackendError.rustError(let message) = error else {
+                XCTFail("expected .rustError, got \(error)")
+                return
+            }
+            XCTAssertTrue(message.contains("hotkey_seed must be at least"), "unexpected message: \(message)")
+        }
+    }
+
+    func test_signCastVote_rejectsWrongSizedCanonicalFields() {
+        let short = [UInt8](repeating: 1, count: 31)
+
+        let cases: [(String, VotingVoteCommitmentBundle, String)] = [
+            (
+                "rVpkBytes",
+                makeVoteCommitmentBundle(rVpkBytes: short),
+                "r_vpk_bytes must be 32 bytes"
+            ),
+            (
+                "vanNullifier",
+                makeVoteCommitmentBundle(vanNullifier: short),
+                "van_nullifier must be 32 bytes"
+            ),
+            (
+                "voteAuthorityNoteNew",
+                makeVoteCommitmentBundle(voteAuthorityNoteNew: short),
+                "vote_authority_note_new must be 32 bytes"
+            ),
+            (
+                "voteCommitment",
+                makeVoteCommitmentBundle(voteCommitment: short),
+                "vote_commitment must be 32 bytes"
+            ),
+            (
+                "alphaV",
+                makeVoteCommitmentBundle(alphaV: short),
+                "alpha_v must be 32 bytes"
+            )
+        ]
+
+        for (label, commitment, expectedMessage) in cases {
+            XCTAssertThrowsError(
+                try VotingRustBackend.signCastVote(
+                    hotkeySeed: [UInt8](repeating: 1, count: 32),
+                    networkId: 1,
+                    commitment: commitment
+                ),
+                label
+            ) { error in
+                guard case VotingRustBackendError.rustError(let message) = error else {
+                    XCTFail("\(label): expected .rustError, got \(error)")
+                    return
+                }
+                XCTAssertTrue(
+                    message.contains(expectedMessage),
+                    "\(label): unexpected message: \(message)"
+                )
+            }
+        }
+    }
+
+    func test_signCastVote_validFixture_returnsSignature() throws {
+        let signature = try VotingRustBackend.signCastVote(
+            hotkeySeed: [UInt8](repeating: 1, count: 32),
+            networkId: 1,
+            commitment: makeVoteCommitmentBundle()
+        )
+
+        XCTAssertFalse(signature.voteAuthSig.isEmpty)
     }
 
     // MARK: - setWalletId
@@ -1210,6 +1556,46 @@ final class VotingRustBackendTests: XCTestCase {
                 userInfo: [NSLocalizedDescriptionKey: "\(message): \(details)"]
             )
         }
+    }
+
+    private func makeOpenBackend() throws -> VotingRustBackend {
+        let backend = VotingRustBackend()
+        try backend.open(path: makeTempDbPath())
+        try backend.setWalletId("wallet")
+        return backend
+    }
+
+    private func makeVoteCommitmentBundle(
+        voteRoundId: String = String(repeating: "a", count: 64),
+        vanNullifier: [UInt8] = [UInt8](repeating: 1, count: 32),
+        voteAuthorityNoteNew: [UInt8] = [UInt8](repeating: 2, count: 32),
+        voteCommitment: [UInt8] = [UInt8](repeating: 3, count: 32),
+        proposalId: UInt32 = 0,
+        encShares: [VotingWireEncryptedShare] = [
+            VotingWireEncryptedShare(
+                ciphertext1: [UInt8](repeating: 5, count: 32),
+                ciphertext2: [UInt8](repeating: 6, count: 32),
+                shareIndex: 0
+            )
+        ],
+        rVpkBytes: [UInt8] = [UInt8](repeating: 10, count: 32),
+        alphaV: [UInt8] = [UInt8](repeating: 11, count: 32)
+    ) -> VotingVoteCommitmentBundle {
+        VotingVoteCommitmentBundle(
+            vanNullifier: vanNullifier,
+            voteAuthorityNoteNew: voteAuthorityNoteNew,
+            voteCommitment: voteCommitment,
+            proposalId: proposalId,
+            proof: [4],
+            encShares: encShares,
+            anchorHeight: 1,
+            voteRoundId: voteRoundId,
+            sharesHash: [7],
+            shareBlinds: [[UInt8](repeating: 8, count: 32)],
+            shareComms: [[UInt8](repeating: 9, count: 32)],
+            rVpkBytes: rVpkBytes,
+            alphaV: alphaV
+        )
     }
 }
 

--- a/Tests/OfflineTests/VotingRustBackendTests.swift
+++ b/Tests/OfflineTests/VotingRustBackendTests.swift
@@ -1177,7 +1177,7 @@ final class VotingRustBackendTests: XCTestCase {
         }
     }
 
-    func test_voteSubmissionHelpers_afterOpen_buildPayloadsSignAndMarkSubmitted() throws {
+    func test_voteSubmissionHelpers_afterOpen_buildPayloadsAndSignWithSyntheticCommitment() throws {
         let backend = try makeOpenBackend()
         defer { backend.close() }
         let commitment = makeVoteCommitmentBundle(proposalId: 7)
@@ -1213,21 +1213,6 @@ final class VotingRustBackendTests: XCTestCase {
             commitment: commitment
         )
         XCTAssertFalse(signature.voteAuthSig.isEmpty)
-
-        try createRoundWithBundle(backend, roundId: commitment.voteRoundId)
-        try insertVoteRow(
-            roundId: commitment.voteRoundId,
-            walletId: "wallet",
-            bundleIndex: 0,
-            proposalId: commitment.proposalId
-        )
-        XCTAssertNoThrow(
-            try backend.markVoteSubmitted(
-                roundId: commitment.voteRoundId,
-                bundleIndex: 0,
-                proposalId: commitment.proposalId
-            )
-        )
     }
 
     func test_markVoteSubmitted_beforeOpen_throwsDatabaseNotOpen() {
@@ -1242,24 +1227,15 @@ final class VotingRustBackendTests: XCTestCase {
         }
     }
 
-    func test_markVoteSubmitted_afterOpen_marksExistingVote() throws {
+    func test_markVoteSubmitted_afterOpen_missingVote_throwsRustError() throws {
         let backend = try makeOpenBackend()
         defer { backend.close() }
 
-        try createRoundWithBundle(backend, roundId: roundTripRoundId)
-        try insertVoteRow(
-            roundId: roundTripRoundId,
-            walletId: "wallet",
-            bundleIndex: roundTripBundleIndex,
-            proposalId: roundTripProposalId
-        )
-        XCTAssertNoThrow(
-            try backend.markVoteSubmitted(
-                roundId: roundTripRoundId,
-                bundleIndex: roundTripBundleIndex,
-                proposalId: roundTripProposalId
-            )
-        )
+        XCTAssertThrowsError(
+            try backend.markVoteSubmitted(roundId: "missing-round", bundleIndex: 0, proposalId: 0)
+        ) { error in
+            assertNoVoteFound(error)
+        }
     }
 
     func test_signCastVote_invalidCommitment_throwsRustError() {
@@ -1563,6 +1539,18 @@ final class VotingRustBackendTests: XCTestCase {
         try backend.open(path: makeTempDbPath())
         try backend.setWalletId("wallet")
         return backend
+    }
+
+    private func assertNoVoteFound(
+        _ error: Error,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        guard case VotingRustBackendError.rustError(let message) = error else {
+            XCTFail("expected .rustError, got \(error)", file: file, line: line)
+            return
+        }
+        XCTAssertTrue(message.contains("no vote found"), "unexpected message: \(message)", file: file, line: line)
     }
 
     private func makeVoteCommitmentBundle(


### PR DESCRIPTION
## Summary
- Expose Swift wrappers for vote witness generation and cast-vote FFI helpers.
- Add offline coverage for handle gating, Rust error propagation, payload construction, signing validation, and vote submission marking.
- Update the unreleased changelog entry for the new voting APIs.

## Note on Testing


Swift-side tests don’t exercise a full successful `buildVoteCommitment` or `generateNoteWitnesses` path with realistic fixture data. That's by choice as those are already covered more deeply in Rust.

## Test plan
- `swift test --filter VotingRustBackendTests`