### PR TITLE
DRAFT: Exclude Broadcaster transactions from automatic resubmission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
+## Fixed
+- Prevent transactions created through `Broadcaster` from being automatically resubmitted by the SDK.
+
 # 2.5.0 - 2026-05-11
 
 ## Added

--- a/Sources/ZcashLightClientKit/Block/Actions/TxResubmissionAction.swift
+++ b/Sources/ZcashLightClientKit/Block/Actions/TxResubmissionAction.swift
@@ -16,11 +16,13 @@ final class TxResubmissionAction {
     let transactionRepository: TransactionRepository
     var transactionEncoder: TransactionEncoder
     let logger: Logger
+    let automaticTxResubmissionGuard: AutomaticTxResubmissionGuard
 
     init(container: DIContainer) {
         transactionRepository = container.resolve(TransactionRepository.self)
         transactionEncoder = container.resolve(TransactionEncoder.self)
         logger = container.resolve(Logger.self)
+        automaticTxResubmissionGuard = container.resolve(AutomaticTxResubmissionGuard.self)
     }
 }
 
@@ -33,7 +35,8 @@ extension TxResubmissionAction: Action {
         // find all candidates for the resubmission
         do {
             logger.info("TxResubmissionAction check started at \(latestBlockHeight) height.")
-            let transactions = try await transactionRepository.findForResubmission(upTo: latestBlockHeight)
+            let candidates = try await transactionRepository.findForResubmission(upTo: latestBlockHeight)
+            let transactions = await automaticTxResubmissionGuard.filterAutomaticallyResubmittable(candidates)
 
             // no candidates, update the time and continue with the next action
             if transactions.isEmpty {

--- a/Sources/ZcashLightClientKit/Broadcaster.swift
+++ b/Sources/ZcashLightClientKit/Broadcaster.swift
@@ -16,6 +16,10 @@ import Foundation
 /// strategies such as submitting to multiple lightwalletd servers
 /// in parallel.
 ///
+/// Transactions created through this API are caller-managed. The SDK
+/// stores them in the wallet database, but it will not automatically
+/// resubmit them; callers own submission and retry behavior.
+///
 /// Typical usage:
 /// ```swift
 /// // 1. Create the transaction(s)
@@ -39,6 +43,9 @@ public protocol Broadcaster: AnyObject {
     ///   property contains the serialized transaction bytes suitable for
     ///   later submission via ``submit(_:to:)``.
     ///
+    /// Transactions returned by this method are not automatically resubmitted
+    /// by the SDK.
+    ///
     /// If `prepare()` hasn't already been called since creation of the
     /// synchronizer instance or since the last wipe then this method throws
     /// `ZcashError.synchronizerNotPrepared`.
@@ -54,6 +61,9 @@ public protocol Broadcaster: AnyObject {
     /// - Parameter pcztWithProofs: the PCZT with proofs added.
     /// - Parameter pcztWithSigs: the PCZT with signatures added.
     /// - Returns: An array of transaction overviews with `raw` bytes.
+    ///
+    /// Transactions returned by this method are not automatically resubmitted
+    /// by the SDK.
     ///
     /// If `prepare()` hasn't already been called since creation of the
     /// synchronizer instance or since the last wipe then this method throws

--- a/Sources/ZcashLightClientKit/Synchronizer/Dependencies.swift
+++ b/Sources/ZcashLightClientKit/Synchronizer/Dependencies.swift
@@ -144,6 +144,15 @@ enum Dependencies {
         container.register(type: SyncSessionIDGenerator.self, isSingleton: false) { _ in
             UniqueSyncSessionIDGenerator()
         }
+
+        container.register(type: AutomaticTxResubmissionGuard.self, isSingleton: true) { di in
+            let logger = di.resolve(Logger.self)
+
+            return AutomaticTxResubmissionGuard(
+                storageURL: urls.generalStorageURL,
+                logger: logger
+            )
+        }
         
         container.register(type: ZcashFileManager.self, isSingleton: true) { _ in
             FileManager.default

--- a/Sources/ZcashLightClientKit/Synchronizer/SDKBroadcaster.swift
+++ b/Sources/ZcashLightClientKit/Synchronizer/SDKBroadcaster.swift
@@ -14,6 +14,7 @@ class SDKBroadcaster: Broadcaster {
     private let sdkFlags: SDKFlags
     private let logger: Logger
     private let eventSubject: PassthroughSubject<SynchronizerEvent, Never>
+    private let automaticTxResubmissionGuard: AutomaticTxResubmissionGuard
     private let statusCheck: () throws -> Void
 
     init(
@@ -22,6 +23,7 @@ class SDKBroadcaster: Broadcaster {
         sdkFlags: SDKFlags,
         logger: Logger,
         eventSubject: PassthroughSubject<SynchronizerEvent, Never>,
+        automaticTxResubmissionGuard: AutomaticTxResubmissionGuard,
         statusCheck: @escaping () throws -> Void
     ) {
         self.transactionEncoder = transactionEncoder
@@ -29,12 +31,58 @@ class SDKBroadcaster: Broadcaster {
         self.sdkFlags = sdkFlags
         self.logger = logger
         self.eventSubject = eventSubject
+        self.automaticTxResubmissionGuard = automaticTxResubmissionGuard
         self.statusCheck = statusCheck
     }
 
     func createProposedTransactions(
         proposal: Proposal,
         spendingKey: UnifiedSpendingKey
+    ) async throws -> [ZcashTransaction.Overview] {
+        try await createProposedTransactions(
+            proposal: proposal,
+            spendingKey: spendingKey,
+            excludeFromAutomaticResubmission: true
+        )
+    }
+
+    func createProposedTransactionsForSDKSubmission(
+        proposal: Proposal,
+        spendingKey: UnifiedSpendingKey
+    ) async throws -> [ZcashTransaction.Overview] {
+        try await createProposedTransactions(
+            proposal: proposal,
+            spendingKey: spendingKey,
+            excludeFromAutomaticResubmission: false
+        )
+    }
+
+    func createTransactionFromPCZT(
+        pcztWithProofs: Pczt,
+        pcztWithSigs: Pczt
+    ) async throws -> [ZcashTransaction.Overview] {
+        try await createTransactionFromPCZT(
+            pcztWithProofs: pcztWithProofs,
+            pcztWithSigs: pcztWithSigs,
+            excludeFromAutomaticResubmission: true
+        )
+    }
+
+    func createTransactionFromPCZTForSDKSubmission(
+        pcztWithProofs: Pczt,
+        pcztWithSigs: Pczt
+    ) async throws -> [ZcashTransaction.Overview] {
+        try await createTransactionFromPCZT(
+            pcztWithProofs: pcztWithProofs,
+            pcztWithSigs: pcztWithSigs,
+            excludeFromAutomaticResubmission: false
+        )
+    }
+
+    private func createProposedTransactions(
+        proposal: Proposal,
+        spendingKey: UnifiedSpendingKey,
+        excludeFromAutomaticResubmission: Bool
     ) async throws -> [ZcashTransaction.Overview] {
         try statusCheck()
 
@@ -51,16 +99,18 @@ class SDKBroadcaster: Broadcaster {
             spendingKey: spendingKey
         )
 
-        if !transactions.isEmpty {
-            eventSubject.send(.foundTransactions(transactions, nil))
-        }
+        await finishTransactionCreation(
+            transactions,
+            excludeFromAutomaticResubmission: excludeFromAutomaticResubmission
+        )
 
         return transactions
     }
 
-    func createTransactionFromPCZT(
+    private func createTransactionFromPCZT(
         pcztWithProofs: Pczt,
-        pcztWithSigs: Pczt
+        pcztWithSigs: Pczt,
+        excludeFromAutomaticResubmission: Bool
     ) async throws -> [ZcashTransaction.Overview] {
         try statusCheck()
 
@@ -79,11 +129,25 @@ class SDKBroadcaster: Broadcaster {
 
         let transactions = try await transactionEncoder.fetchTransactionsForTxIds([txId])
 
-        if !transactions.isEmpty {
-            eventSubject.send(.foundTransactions(transactions, nil))
-        }
+        await finishTransactionCreation(
+            transactions,
+            excludeFromAutomaticResubmission: excludeFromAutomaticResubmission
+        )
 
         return transactions
+    }
+
+    private func finishTransactionCreation(
+        _ transactions: [ZcashTransaction.Overview],
+        excludeFromAutomaticResubmission: Bool
+    ) async {
+        guard !transactions.isEmpty else { return }
+
+        if excludeFromAutomaticResubmission {
+            await automaticTxResubmissionGuard.excludeFromAutomaticResubmission(transactions)
+        }
+
+        eventSubject.send(.foundTransactions(transactions, nil))
     }
 
     func submit(

--- a/Sources/ZcashLightClientKit/Synchronizer/SDKSynchronizer.swift
+++ b/Sources/ZcashLightClientKit/Synchronizer/SDKSynchronizer.swift
@@ -55,12 +55,15 @@ public class SDKSynchronizer: Synchronizer {
     private let syncSessionTicker: SessionTicker
     var latestBlocksDataProvider: LatestBlocksDataProvider
 
-    private var broadcasterStorage: Broadcaster?
-    public var broadcaster: Broadcaster {
+    private var broadcasterStorage: SDKBroadcaster?
+    private var sdkBroadcaster: SDKBroadcaster {
         guard let broadcaster = broadcasterStorage else {
             preconditionFailure("Broadcaster accessed before initialization")
         }
         return broadcaster
+    }
+    public var broadcaster: Broadcaster {
+        sdkBroadcaster
     }
 
     /// Creates an SDKSynchronizer instance
@@ -108,6 +111,7 @@ public class SDKSynchronizer: Synchronizer {
             sdkFlags: sdkFlags,
             logger: logger,
             eventSubject: eventSubject,
+            automaticTxResubmissionGuard: initializer.container.resolve(AutomaticTxResubmissionGuard.self),
             statusCheck: { [weak self] in
                 guard let self else {
                     throw ZcashError.synchronizerNotPrepared
@@ -460,7 +464,7 @@ public class SDKSynchronizer: Synchronizer {
         proposal: Proposal,
         spendingKey: UnifiedSpendingKey
     ) async throws -> AsyncThrowingStream<TransactionSubmitResult, Error> {
-        let transactions = try await broadcaster.createProposedTransactions(
+        let transactions = try await sdkBroadcaster.createProposedTransactionsForSDKSubmission(
             proposal: proposal,
             spendingKey: spendingKey
         )
@@ -532,7 +536,7 @@ public class SDKSynchronizer: Synchronizer {
     }
     
     public func createTransactionFromPCZT(pcztWithProofs: Pczt, pcztWithSigs: Pczt) async throws -> AsyncThrowingStream<TransactionSubmitResult, Error> {
-        let transactions = try await broadcaster.createTransactionFromPCZT(
+        let transactions = try await sdkBroadcaster.createTransactionFromPCZTForSDKSubmission(
             pcztWithProofs: pcztWithProofs,
             pcztWithSigs: pcztWithSigs
         )

--- a/Sources/ZcashLightClientKit/Transaction/AutomaticTxResubmissionGuard.swift
+++ b/Sources/ZcashLightClientKit/Transaction/AutomaticTxResubmissionGuard.swift
@@ -1,0 +1,99 @@
+//
+//  AutomaticTxResubmissionGuard.swift
+//  ZcashLightClientKit
+//
+//  Created by Adam Tucker on 2026-05-11.
+//
+
+import Foundation
+
+actor AutomaticTxResubmissionGuard {
+    private enum Constants {
+        static let fileName = "automatic-resubmission-excluded-tx-ids"
+    }
+
+    private let fileManager: FileManager
+    private let fileURL: URL
+    private let logger: Logger
+
+    private var excludedTransactionIds = Set<String>()
+    private var hasLoadedFromStorage = false
+
+    init(
+        storageURL: URL,
+        fileManager: FileManager = .default,
+        logger: Logger
+    ) {
+        self.fileManager = fileManager
+        self.fileURL = storageURL.appendingPathComponent(Constants.fileName)
+        self.logger = logger
+    }
+
+    func excludeFromAutomaticResubmission(_ transactions: [ZcashTransaction.Overview]) {
+        loadFromStorageIfNeeded()
+
+        let transactionIds = Set(transactions.map(\.resubmissionGuardId))
+        guard !transactionIds.isEmpty else { return }
+
+        excludedTransactionIds.formUnion(transactionIds)
+        saveToStorage()
+    }
+
+    func filterAutomaticallyResubmittable(
+        _ transactions: [ZcashTransaction.Overview]
+    ) -> [ZcashTransaction.Overview] {
+        loadFromStorageIfNeeded()
+        retainExclusionsFor(transactions)
+
+        return transactions.filter { !excludedTransactionIds.contains($0.resubmissionGuardId) }
+    }
+
+    private func retainExclusionsFor(_ transactions: [ZcashTransaction.Overview]) {
+        let currentCandidateIds = Set(transactions.map(\.resubmissionGuardId))
+        let retainedTransactionIds = excludedTransactionIds.intersection(currentCandidateIds)
+
+        guard retainedTransactionIds != excludedTransactionIds else { return }
+
+        excludedTransactionIds = retainedTransactionIds
+        saveToStorage()
+    }
+
+    private func loadFromStorageIfNeeded() {
+        guard !hasLoadedFromStorage else { return }
+
+        defer { hasLoadedFromStorage = true }
+
+        guard fileManager.fileExists(atPath: fileURL.path) else { return }
+
+        do {
+            let contents = try String(contentsOf: fileURL, encoding: .utf8)
+            excludedTransactionIds = Set(
+                contents
+                    .components(separatedBy: .newlines)
+                    .filter { !$0.isEmpty }
+            )
+        } catch {
+            logger.warn("Failed to load automatic resubmission exclusions: \(error)")
+        }
+    }
+
+    private func saveToStorage() {
+        do {
+            try fileManager.createDirectory(
+                at: fileURL.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+
+            let contents = excludedTransactionIds.sorted().joined(separator: "\n")
+            try contents.write(to: fileURL, atomically: true, encoding: .utf8)
+        } catch {
+            logger.warn("Failed to store automatic resubmission exclusions: \(error)")
+        }
+    }
+}
+
+private extension ZcashTransaction.Overview {
+    var resubmissionGuardId: String {
+        rawID.hexEncodedString()
+    }
+}

--- a/Tests/OfflineTests/AutomaticTxResubmissionGuardTests.swift
+++ b/Tests/OfflineTests/AutomaticTxResubmissionGuardTests.swift
@@ -1,0 +1,153 @@
+//
+//  AutomaticTxResubmissionGuardTests.swift
+//  ZcashLightClientKitTests
+//
+
+import XCTest
+@testable import TestUtils
+@testable import ZcashLightClientKit
+
+final class AutomaticTxResubmissionGuardTests: ZcashTestCase {
+    func testPersistsExcludedTransactions() async throws {
+        let excludedTransaction = makeTransaction(rawID: Data(repeating: 0xAB, count: 32))
+        let resubmittableTransaction = makeTransaction(rawID: Data(repeating: 0xCD, count: 32))
+        let guardStorage = testGeneralStorageDirectory.appendingPathComponent("persisted")
+        let resubmissionGuard = AutomaticTxResubmissionGuard(storageURL: guardStorage, logger: NullLogger())
+
+        await resubmissionGuard.excludeFromAutomaticResubmission([excludedTransaction])
+
+        let reloadedGuard = AutomaticTxResubmissionGuard(storageURL: guardStorage, logger: NullLogger())
+        let transactions = await reloadedGuard.filterAutomaticallyResubmittable([
+            excludedTransaction,
+            resubmittableTransaction
+        ])
+
+        XCTAssertEqual(transactions.map(\.rawID), [resubmittableTransaction.rawID])
+    }
+
+    func testPrunesExcludedTransactionsThatAreNoLongerCandidates() async throws {
+        let retainedTransaction = makeTransaction(rawID: Data(repeating: 0xAB, count: 32))
+        let prunedTransaction = makeTransaction(rawID: Data(repeating: 0xCD, count: 32))
+        let guardStorage = testGeneralStorageDirectory.appendingPathComponent("pruned")
+        let resubmissionGuard = AutomaticTxResubmissionGuard(storageURL: guardStorage, logger: NullLogger())
+
+        await resubmissionGuard.excludeFromAutomaticResubmission([retainedTransaction, prunedTransaction])
+        _ = await resubmissionGuard.filterAutomaticallyResubmittable([retainedTransaction])
+
+        let reloadedGuard = AutomaticTxResubmissionGuard(storageURL: guardStorage, logger: NullLogger())
+        let transactions = await reloadedGuard.filterAutomaticallyResubmittable([
+            retainedTransaction,
+            prunedTransaction
+        ])
+
+        XCTAssertEqual(transactions.map(\.rawID), [prunedTransaction.rawID])
+    }
+
+    func testTxResubmissionActionSkipsExcludedTransactions() async throws {
+        let excludedTransaction = makeTransaction(rawID: Data(repeating: 0xAB, count: 32))
+        let resubmittableTransaction = makeTransaction(rawID: Data(repeating: 0xCD, count: 32))
+        let transactionRepository = TransactionRepositoryMock()
+        let transactionEncoder = RecordingTransactionEncoder()
+        let resubmissionGuard = AutomaticTxResubmissionGuard(
+            storageURL: testGeneralStorageDirectory,
+            logger: NullLogger()
+        )
+
+        transactionRepository.findForResubmissionUpToReturnValue = [
+            excludedTransaction,
+            resubmittableTransaction
+        ]
+
+        mockContainer.mock(type: TransactionRepository.self, isSingleton: true) { _ in transactionRepository }
+        mockContainer.mock(type: TransactionEncoder.self, isSingleton: true) { _ in transactionEncoder }
+        mockContainer.mock(type: Logger.self, isSingleton: true) { _ in NullLogger() }
+        mockContainer.mock(type: AutomaticTxResubmissionGuard.self, isSingleton: true) { _ in resubmissionGuard }
+
+        await resubmissionGuard.excludeFromAutomaticResubmission([excludedTransaction])
+
+        let context = ActionContextMock.default()
+        context.underlyingSyncControlData = SyncControlData(
+            latestBlockHeight: 1000,
+            latestScannedHeight: nil,
+            firstUnenhancedHeight: nil
+        )
+
+        let action = TxResubmissionAction(container: mockContainer)
+        action.latestResolvedTime = 0
+
+        _ = try await action.run(with: context) { _ in }
+
+        XCTAssertEqual(
+            transactionEncoder.submittedTransactions.map(\.transactionId),
+            [resubmittableTransaction.rawID]
+        )
+    }
+
+    private func makeTransaction(rawID: Data) -> ZcashTransaction.Overview {
+        ZcashTransaction.Overview(
+            accountUUID: TestsData.mockedAccountUUID,
+            blockTime: nil,
+            expiryHeight: 123_456,
+            fee: Zatoshi(10_000),
+            index: 0,
+            isShielding: false,
+            hasChange: false,
+            memoCount: 0,
+            minedHeight: nil,
+            raw: Data([0x01]),
+            rawID: rawID,
+            receivedNoteCount: 0,
+            sentNoteCount: 1,
+            value: Zatoshi(-1_000),
+            isExpiredUmined: false,
+            totalSpent: nil,
+            totalReceived: nil
+        )
+    }
+}
+
+private final class RecordingTransactionEncoder: TransactionEncoder {
+    private(set) var submittedTransactions: [EncodedTransaction] = []
+
+    func proposeTransfer(
+        accountUUID: AccountUUID,
+        recipient: String,
+        amount: Zatoshi,
+        memoBytes: MemoBytes?
+    ) async throws -> Proposal {
+        fatalError("Unused in test")
+    }
+
+    func proposeShielding(
+        accountUUID: AccountUUID,
+        shieldingThreshold: Zatoshi,
+        memoBytes: MemoBytes?,
+        transparentReceiver: String?
+    ) async throws -> Proposal? {
+        fatalError("Unused in test")
+    }
+
+    func createProposedTransactions(
+        proposal: Proposal,
+        spendingKey: UnifiedSpendingKey
+    ) async throws -> [ZcashTransaction.Overview] {
+        fatalError("Unused in test")
+    }
+
+    func proposeFulfillingPaymentFromURI(
+        _ uri: String,
+        accountUUID: AccountUUID
+    ) async throws -> Proposal {
+        fatalError("Unused in test")
+    }
+
+    func submit(transaction: EncodedTransaction) async throws {
+        submittedTransactions.append(transaction)
+    }
+
+    func fetchTransactionsForTxIds(_ txIds: [Data]) async throws -> [ZcashTransaction.Overview] {
+        fatalError("Unused in test")
+    }
+
+    func closeDBConnection() { }
+}

--- a/Tests/OfflineTests/BroadcasterTests.swift
+++ b/Tests/OfflineTests/BroadcasterTests.swift
@@ -58,6 +58,60 @@ final class BroadcasterTests: ZcashTestCase {
         XCTAssertEqual(transactions.map(\.rawID), createdTransactions.map(\.rawID))
         XCTAssertEqual(try transactions.map { try XCTUnwrap($0.raw) }, [rawTransaction])
 
+        let resubmissionGuard = synchronizer.initializer.container.resolve(AutomaticTxResubmissionGuard.self)
+        let resubmittableTransactions = await resubmissionGuard.filterAutomaticallyResubmittable(transactions)
+        XCTAssertTrue(resubmittableTransactions.isEmpty)
+
+        await fulfillment(of: [foundTransactionsExpectation], timeout: 1.0)
+    }
+
+    func testCreateTransactionFromPCZTExcludesFromAutomaticResubmissionAndEmitsEvent() async throws {
+        let rawID = Data(repeating: 0xCD, count: 32)
+        let rawTransaction = Data([0x05, 0x06, 0x07, 0x08])
+        let pcztWithProofs = Pczt([0x10, 0x11])
+        let pcztWithSigs = Pczt([0x12, 0x13])
+        let createdTransactions = [makeTransaction(raw: rawTransaction, rawID: rawID)]
+        let transactionEncoder = StubTransactionEncoder(createdTransactions: createdTransactions)
+        let rustBackend = ZcashRustBackendWeldingMock()
+        rustBackend.extractAndStoreTxFromPCZTPcztWithProofsPcztWithSigsReturnValue = rawID
+        let synchronizer = try makeSynchronizer(
+            transactionEncoder: transactionEncoder,
+            rustBackend: rustBackend
+        )
+        let foundTransactionsExpectation = XCTestExpectation(description: "found transactions event")
+
+        synchronizer.eventStream
+            .sink { event in
+                guard case let .foundTransactions(transactions, range) = event else { return }
+                XCTAssertNil(range)
+                XCTAssertEqual(transactions.map(\.rawID), [rawID])
+                foundTransactionsExpectation.fulfill()
+            }
+            .store(in: &cancellables)
+
+        await synchronizer.updateStatus(.stopped)
+
+        let transactions = try await synchronizer.broadcaster.createTransactionFromPCZT(
+            pcztWithProofs: pcztWithProofs,
+            pcztWithSigs: pcztWithSigs
+        )
+
+        XCTAssertEqual(
+            rustBackend.extractAndStoreTxFromPCZTPcztWithProofsPcztWithSigsReceivedArguments?.pcztWithProofs,
+            pcztWithProofs
+        )
+        XCTAssertEqual(
+            rustBackend.extractAndStoreTxFromPCZTPcztWithProofsPcztWithSigsReceivedArguments?.pcztWithSigs,
+            pcztWithSigs
+        )
+        XCTAssertEqual(transactionEncoder.receivedFetchTxIds, [rawID])
+        XCTAssertEqual(transactions.map(\.rawID), [rawID])
+        XCTAssertEqual(try transactions.map { try XCTUnwrap($0.raw) }, [rawTransaction])
+
+        let resubmissionGuard = synchronizer.initializer.container.resolve(AutomaticTxResubmissionGuard.self)
+        let resubmittableTransactions = await resubmissionGuard.filterAutomaticallyResubmittable(transactions)
+        XCTAssertTrue(resubmittableTransactions.isEmpty)
+
         await fulfillment(of: [foundTransactionsExpectation], timeout: 1.0)
     }
 
@@ -197,6 +251,10 @@ final class BroadcasterTests: ZcashTestCase {
             [EncodedTransaction(transactionId: rawID, raw: rawTransaction)]
         )
 
+        let resubmissionGuard = synchronizer.initializer.container.resolve(AutomaticTxResubmissionGuard.self)
+        let resubmittableTransactions = await resubmissionGuard.filterAutomaticallyResubmittable(createdTransactions)
+        XCTAssertEqual(resubmittableTransactions.map(\.rawID), [rawID])
+
         await fulfillment(of: [foundTransactionsExpectation], timeout: 1.0)
         XCTAssertEqual(foundTransactionsEventCount, 1)
     }
@@ -255,6 +313,10 @@ final class BroadcasterTests: ZcashTestCase {
             transactionEncoder.submittedTransactions,
             [EncodedTransaction(transactionId: rawID, raw: rawTransaction)]
         )
+
+        let resubmissionGuard = synchronizer.initializer.container.resolve(AutomaticTxResubmissionGuard.self)
+        let resubmittableTransactions = await resubmissionGuard.filterAutomaticallyResubmittable(createdTransactions)
+        XCTAssertEqual(resubmittableTransactions.map(\.rawID), [rawID])
 
         await fulfillment(of: [foundTransactionsExpectation], timeout: 1.0)
         XCTAssertEqual(foundTransactionsEventCount, 1)


### PR DESCRIPTION
This prevents transactions created through the public Broadcaster API from being retried later by the SDK's automatic resubmission path. The legacy Synchronizer create-and-submit APIs continue to use the shared creation flow without marking those transactions caller-managed, so SDK-owned submissions keep their existing retry behavior.

Validation:
- swift test --filter OfflineTests
- swiftlint lint on touched source and test files
