### PR TITLE
Pin FFI binary release for 2.6.0-alpha.1

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -30,8 +30,8 @@ if useLocalFFI {
     targets.append(
         .binaryTarget(
             name: "libzcashlc",
-            url: "https://github.com/zcash/zcash-swift-wallet-sdk/releases/download/2.5.0/libzcashlc.xcframework.zip",
-            checksum: "1a38e5675f1015bb47006b17db33acbdc112549c9d8622e7b7918cec6152c2c8"
+            url: "https://github.com/zcash/zcash-swift-wallet-sdk/releases/download/2.6.0-alpha.1/libzcashlc.xcframework.zip",
+            checksum: "215e2c97cc2bfb11b0a8d15530431b5959ad44ab112e2df08699f9bfb463d4a1"
         )
     )
     sdkDependencies.append("libzcashlc")


### PR DESCRIPTION
## Summary
- Pin `Package.swift` to the `libzcashlc.xcframework.zip` asset generated by the successful Build FFI XCFramework workflow run.
- Use the workflow-provided SHA-256 checksum for the 2.6.0-alpha.1 FFI binary.

## Verification
- `swift package dump-package`

## Notes
- Source workflow job: https://github.com/zcash/zcash-swift-wallet-sdk/actions/runs/25747980235/job/75616331927