### PR TITLE
[MOB-1039] Retry broadcaster transactions with submit plans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
+## Changed
+- `Broadcaster` transactions now remain eligible for SDK automatic retry after submission. The SDK records the submitted endpoints privately and retries with those endpoints instead of the synchronizer's default endpoint.
+
 # 2.5.0 - 2026-05-11
 
 ## Added

--- a/Sources/ZcashLightClientKit/Block/Actions/TxResubmissionAction.swift
+++ b/Sources/ZcashLightClientKit/Block/Actions/TxResubmissionAction.swift
@@ -37,8 +37,12 @@ extension TxResubmissionAction: Action {
         // find all candidates for the resubmission
         do {
             logger.info("TxResubmissionAction check started at \(latestBlockHeight) height.")
-            let transactions = try await transactionRepository.findForResubmission(upTo: latestBlockHeight)
-            await pendingSubmitPlanStore.retainPlans(for: transactions.map(\.rawID))
+            let transactions = try await pendingSubmitPlanStore.loadTransactionsAndRetainSubmitPlans(
+                loadTransactions: {
+                    try await transactionRepository.findForResubmission(upTo: latestBlockHeight)
+                },
+                transactionId: { $0.rawID }
+            )
 
             // no candidates, update the time and continue with the next action
             if transactions.isEmpty {

--- a/Sources/ZcashLightClientKit/Block/Actions/TxResubmissionAction.swift
+++ b/Sources/ZcashLightClientKit/Block/Actions/TxResubmissionAction.swift
@@ -15,11 +15,15 @@ final class TxResubmissionAction {
     var latestResolvedTime: TimeInterval = 0
     let transactionRepository: TransactionRepository
     var transactionEncoder: TransactionEncoder
+    let pendingSubmitPlanStore: PendingSubmitPlanStore
+    let submitPlanExecutor: SubmitPlanExecutor
     let logger: Logger
 
     init(container: DIContainer) {
         transactionRepository = container.resolve(TransactionRepository.self)
         transactionEncoder = container.resolve(TransactionEncoder.self)
+        pendingSubmitPlanStore = container.resolve(PendingSubmitPlanStore.self)
+        submitPlanExecutor = container.resolve(SubmitPlanExecutor.self)
         logger = container.resolve(Logger.self)
     }
 }
@@ -34,6 +38,7 @@ extension TxResubmissionAction: Action {
         do {
             logger.info("TxResubmissionAction check started at \(latestBlockHeight) height.")
             let transactions = try await transactionRepository.findForResubmission(upTo: latestBlockHeight)
+            await pendingSubmitPlanStore.retainPlans(for: transactions.map(\.rawID))
 
             // no candidates, update the time and continue with the next action
             if transactions.isEmpty {
@@ -47,10 +52,29 @@ extension TxResubmissionAction: Action {
                     // resubmission
                     do {
                         for transaction in transactions {
+                            let submitPlan = await pendingSubmitPlanStore.getSubmitPlan(for: transaction.rawID)
+                            if case .awaitingPlan = submitPlan {
+                                logger.info(
+                                    "TxResubmissionAction skipping transaction \(transaction.rawID.toHexStringTxId()) " +
+                                    "until a submit plan is registered."
+                                )
+                                continue
+                            }
+
                             logger.info("TxResubmissionAction trying to resubmit transaction \(transaction.rawID.toHexStringTxId()).")
                             let encodedTransaction = try transaction.encodedTransaction()
                             
-                            try await transactionEncoder.submit(transaction: encodedTransaction)
+                            switch submitPlan {
+                            case .none:
+                                try await transactionEncoder.submit(transaction: encodedTransaction)
+                            case .ready(let plan):
+                                try await submitPlanExecutor.submit(
+                                    transaction: encodedTransaction,
+                                    submitPlan: plan
+                                )
+                            case .awaitingPlan:
+                                break
+                            }
                         }
                     } catch {
                         logger.error("TxResubmissionAction failed to resubmit candidates.")

--- a/Sources/ZcashLightClientKit/Broadcaster.swift
+++ b/Sources/ZcashLightClientKit/Broadcaster.swift
@@ -16,6 +16,11 @@ import Foundation
 /// strategies such as submitting to multiple lightwalletd servers
 /// in parallel.
 ///
+/// Transactions created through this API wait for the caller to submit them.
+/// Once submitted, automatic retry uses the submitted endpoints instead of the
+/// synchronizer's default endpoint. Retry tries the recorded endpoints in order
+/// until one submit succeeds.
+///
 /// Typical usage:
 /// ```swift
 /// // 1. Create the transaction(s)
@@ -68,6 +73,9 @@ public protocol Broadcaster: AnyObject {
     /// Creates an ephemeral connection to the given endpoint, submits the
     /// transaction, and tears down the connection. Respects the current
     /// Tor configuration.
+    ///
+    /// If the transaction was created through this `Broadcaster`, the endpoint
+    /// is remembered for automatic retry.
     ///
     /// - Parameter rawTransaction: the raw serialized transaction bytes.
     /// - Parameter endpoint: the `LightWalletEndpoint` to submit to.

--- a/Sources/ZcashLightClientKit/DAO/TransactionDao.swift
+++ b/Sources/ZcashLightClientKit/DAO/TransactionDao.swift
@@ -33,7 +33,7 @@ extension Connection {
     }
 }
 
-class TransactionSQLDAO: TransactionRepository {
+class TransactionSQLDAO: TransactionRepository, RawTransactionLookup {
     enum NotesTableStructure {
         static let transactionID = SQLite.Expression<Int>("tx")
         static let memo = SQLite.Expression<Blob>("memo")
@@ -141,6 +141,14 @@ class TransactionSQLDAO: TransactionRepository {
     func find(rawID: Data) async throws -> ZcashTransaction.Overview {
         let query = transactionsView
             .filter(ZcashTransaction.Overview.Column.rawID == Blob(bytes: rawID.bytes))
+            .limit(1)
+
+        return try await execute(query) { try ZcashTransaction.Overview(row: $0) }
+    }
+
+    func find(rawTransaction: Data) async throws -> ZcashTransaction.Overview {
+        let query = transactionsView
+            .filter(ZcashTransaction.Overview.Column.raw == Blob(bytes: rawTransaction.bytes))
             .limit(1)
 
         return try await execute(query) { try ZcashTransaction.Overview(row: $0) }

--- a/Sources/ZcashLightClientKit/Repository/TransactionRepository.swift
+++ b/Sources/ZcashLightClientKit/Repository/TransactionRepository.swift
@@ -29,3 +29,7 @@ protocol TransactionRepository {
     func getTransactionOutputs(for rawID: Data) async throws -> [ZcashTransaction.Output]
     func debugDatabase(sql: String) -> String
 }
+
+protocol RawTransactionLookup {
+    func find(rawTransaction: Data) async throws -> ZcashTransaction.Overview
+}

--- a/Sources/ZcashLightClientKit/Synchronizer/Dependencies.swift
+++ b/Sources/ZcashLightClientKit/Synchronizer/Dependencies.swift
@@ -168,7 +168,10 @@ enum Dependencies {
         }
 
         container.register(type: SubmitPlanExecutor.self, isSingleton: true) { di in
-            SubmitPlanExecutor(transactionSubmitter: di.resolve(TransactionSubmitter.self))
+            SubmitPlanExecutor(
+                transactionSubmitter: di.resolve(TransactionSubmitter.self),
+                logger: di.resolve(Logger.self)
+            )
         }
         
         container.register(type: TransactionEncoder.self, isSingleton: true) { di in

--- a/Sources/ZcashLightClientKit/Synchronizer/Dependencies.swift
+++ b/Sources/ZcashLightClientKit/Synchronizer/Dependencies.swift
@@ -92,6 +92,17 @@ enum Dependencies {
             TorClient(torDir: urls.torDirURL)
         }
 
+        container.register(type: PendingSubmitPlanStore.self, isSingleton: true) { di in
+            let logger = di.resolve(Logger.self)
+            return PendingSubmitPlanStore(
+                persistence: KeychainSubmitPlanPersistence(
+                    alias: alias,
+                    networkType: networkType
+                ),
+                logger: logger
+            )
+        }
+
         container.register(type: LightWalletService.self, isSingleton: true) { di in
             let torClient = di.resolve(TorClient.self)
             
@@ -147,6 +158,17 @@ enum Dependencies {
         
         container.register(type: ZcashFileManager.self, isSingleton: true) { _ in
             FileManager.default
+        }
+
+        container.register(type: TransactionSubmitter.self, isSingleton: true) { di in
+            EndpointTransactionSubmitter(
+                torClient: di.resolve(TorClient.self),
+                sdkFlags: di.resolve(SDKFlags.self)
+            )
+        }
+
+        container.register(type: SubmitPlanExecutor.self, isSingleton: true) { di in
+            SubmitPlanExecutor(transactionSubmitter: di.resolve(TransactionSubmitter.self))
         }
         
         container.register(type: TransactionEncoder.self, isSingleton: true) { di in

--- a/Sources/ZcashLightClientKit/Synchronizer/SDKBroadcaster.swift
+++ b/Sources/ZcashLightClientKit/Synchronizer/SDKBroadcaster.swift
@@ -119,16 +119,22 @@ class SDKBroadcaster: Broadcaster {
         to endpoint: LightWalletEndpoint
     ) async throws {
         // Record before submitting so transient endpoint failures keep the same retry plan.
-        if let transaction = try? await rawTransactionLookup?.find(rawTransaction: rawTransaction) {
-            await pendingSubmitPlanStore.addSubmitEndpoint(transaction: transaction, endpoint: endpoint)
-            try await transactionSubmitter.submit(
-                transaction: EncodedTransaction(transactionId: transaction.rawID, raw: rawTransaction),
-                to: endpoint
-            )
-        } else {
-            await pendingSubmitPlanStore.addSubmitEndpoint(rawTransaction: rawTransaction, endpoint: endpoint)
-            try await transactionSubmitter.submit(rawTransaction: rawTransaction, to: endpoint)
+        if let rawTransactionLookup = rawTransactionLookup {
+            do {
+                let transaction = try await rawTransactionLookup.find(rawTransaction: rawTransaction)
+                await pendingSubmitPlanStore.addSubmitEndpoint(transaction: transaction, endpoint: endpoint)
+                try await transactionSubmitter.submit(
+                    transaction: EncodedTransaction(transactionId: transaction.rawID, raw: rawTransaction),
+                    to: endpoint
+                )
+                return
+            } catch ZcashError.transactionRepositoryEntityNotFound {
+                // Fall back to raw submission for transactions that are not in the repository.
+            }
         }
+
+        await pendingSubmitPlanStore.addSubmitEndpoint(rawTransaction: rawTransaction, endpoint: endpoint)
+        try await transactionSubmitter.submit(rawTransaction: rawTransaction, to: endpoint)
     }
 
     private func createProposedTransactionsWithoutRegisteringSubmitPlan(

--- a/Sources/ZcashLightClientKit/Synchronizer/SDKBroadcaster.swift
+++ b/Sources/ZcashLightClientKit/Synchronizer/SDKBroadcaster.swift
@@ -117,6 +117,7 @@ class SDKBroadcaster: Broadcaster {
         _ rawTransaction: Data,
         to endpoint: LightWalletEndpoint
     ) async throws {
+        // Record before submitting so transient endpoint failures keep the same retry plan.
         if let transaction = try? await rawTransactionLookup?.find(rawTransaction: rawTransaction) {
             await pendingSubmitPlanStore.addSubmitEndpoint(transaction: transaction, endpoint: endpoint)
             try await transactionSubmitter.submit(

--- a/Sources/ZcashLightClientKit/Synchronizer/SDKBroadcaster.swift
+++ b/Sources/ZcashLightClientKit/Synchronizer/SDKBroadcaster.swift
@@ -11,24 +11,30 @@ import Foundation
 class SDKBroadcaster: Broadcaster {
     private let transactionEncoder: TransactionEncoder
     private let initializer: Initializer
-    private let sdkFlags: SDKFlags
     private let logger: Logger
     private let eventSubject: PassthroughSubject<SynchronizerEvent, Never>
     private let statusCheck: () throws -> Void
+    private let pendingSubmitPlanStore: PendingSubmitPlanStore
+    private let transactionSubmitter: TransactionSubmitter
+    private let rawTransactionLookup: RawTransactionLookup?
 
     init(
         transactionEncoder: TransactionEncoder,
         initializer: Initializer,
-        sdkFlags: SDKFlags,
         logger: Logger,
         eventSubject: PassthroughSubject<SynchronizerEvent, Never>,
+        pendingSubmitPlanStore: PendingSubmitPlanStore,
+        transactionSubmitter: TransactionSubmitter,
+        rawTransactionLookup: RawTransactionLookup?,
         statusCheck: @escaping () throws -> Void
     ) {
         self.transactionEncoder = transactionEncoder
         self.initializer = initializer
-        self.sdkFlags = sdkFlags
         self.logger = logger
         self.eventSubject = eventSubject
+        self.pendingSubmitPlanStore = pendingSubmitPlanStore
+        self.transactionSubmitter = transactionSubmitter
+        self.rawTransactionLookup = rawTransactionLookup
         self.statusCheck = statusCheck
     }
 
@@ -51,10 +57,21 @@ class SDKBroadcaster: Broadcaster {
             spendingKey: spendingKey
         )
 
-        if !transactions.isEmpty {
-            eventSubject.send(.foundTransactions(transactions, nil))
-        }
+        await pendingSubmitPlanStore.markAwaitingSubmitPlan(transactions)
+        sendFoundTransactionsEvent(transactions)
 
+        return transactions
+    }
+
+    func createProposedTransactionsForLegacySubmit(
+        proposal: Proposal,
+        spendingKey: UnifiedSpendingKey
+    ) async throws -> [ZcashTransaction.Overview] {
+        let transactions = try await createProposedTransactionsWithoutRegisteringSubmitPlan(
+            proposal: proposal,
+            spendingKey: spendingKey
+        )
+        sendFoundTransactionsEvent(transactions)
         return transactions
     }
 
@@ -78,11 +95,21 @@ class SDKBroadcaster: Broadcaster {
         )
 
         let transactions = try await transactionEncoder.fetchTransactionsForTxIds([txId])
+        await pendingSubmitPlanStore.markAwaitingSubmitPlan(transactions)
+        sendFoundTransactionsEvent(transactions)
 
-        if !transactions.isEmpty {
-            eventSubject.send(.foundTransactions(transactions, nil))
-        }
+        return transactions
+    }
 
+    func createTransactionFromPCZTForLegacySubmit(
+        pcztWithProofs: Pczt,
+        pcztWithSigs: Pczt
+    ) async throws -> [ZcashTransaction.Overview] {
+        let transactions = try await createTransactionFromPCZTWithoutRegisteringSubmitPlan(
+            pcztWithProofs: pcztWithProofs,
+            pcztWithSigs: pcztWithSigs
+        )
+        sendFoundTransactionsEvent(transactions)
         return transactions
     }
 
@@ -90,18 +117,63 @@ class SDKBroadcaster: Broadcaster {
         _ rawTransaction: Data,
         to endpoint: LightWalletEndpoint
     ) async throws {
-        let torClient = initializer.container.resolve(TorClient.self)
-        let service = LightWalletGRPCServiceOverTor(endpoint: endpoint, tor: torClient)
-        defer { Task { await service.closeConnections() } }
-
-        let mode: ServiceMode = await sdkFlags.torEnabled ? .uniqueTor : .direct
-        let response = try await service.submit(spendTransaction: rawTransaction, mode: mode)
-
-        guard response.errorCode >= 0 else {
-            throw TransactionEncoderError.submitError(
-                code: Int(response.errorCode),
-                message: response.errorMessage
+        if let transaction = try? await rawTransactionLookup?.find(rawTransaction: rawTransaction) {
+            await pendingSubmitPlanStore.addSubmitEndpoint(transaction: transaction, endpoint: endpoint)
+            try await transactionSubmitter.submit(
+                transaction: EncodedTransaction(transactionId: transaction.rawID, raw: rawTransaction),
+                to: endpoint
             )
+        } else {
+            await pendingSubmitPlanStore.addSubmitEndpoint(rawTransaction: rawTransaction, endpoint: endpoint)
+            try await transactionSubmitter.submit(rawTransaction: rawTransaction, to: endpoint)
+        }
+    }
+
+    private func createProposedTransactionsWithoutRegisteringSubmitPlan(
+        proposal: Proposal,
+        spendingKey: UnifiedSpendingKey
+    ) async throws -> [ZcashTransaction.Overview] {
+        try statusCheck()
+
+        try await SaplingParameterDownloader.downloadParamsIfnotPresent(
+            spendURL: initializer.spendParamsURL,
+            spendSourceURL: initializer.saplingParamsSourceURL.spendParamFileURL,
+            outputURL: initializer.outputParamsURL,
+            outputSourceURL: initializer.saplingParamsSourceURL.outputParamFileURL,
+            logger: logger
+        )
+
+        return try await transactionEncoder.createProposedTransactions(
+            proposal: proposal,
+            spendingKey: spendingKey
+        )
+    }
+
+    private func createTransactionFromPCZTWithoutRegisteringSubmitPlan(
+        pcztWithProofs: Pczt,
+        pcztWithSigs: Pczt
+    ) async throws -> [ZcashTransaction.Overview] {
+        try statusCheck()
+
+        try await SaplingParameterDownloader.downloadParamsIfnotPresent(
+            spendURL: initializer.spendParamsURL,
+            spendSourceURL: initializer.saplingParamsSourceURL.spendParamFileURL,
+            outputURL: initializer.outputParamsURL,
+            outputSourceURL: initializer.saplingParamsSourceURL.outputParamFileURL,
+            logger: logger
+        )
+
+        let txId = try await initializer.rustBackend.extractAndStoreTxFromPCZT(
+            pcztWithProofs: pcztWithProofs,
+            pcztWithSigs: pcztWithSigs
+        )
+
+        return try await transactionEncoder.fetchTransactionsForTxIds([txId])
+    }
+
+    private func sendFoundTransactionsEvent(_ transactions: [ZcashTransaction.Overview]) {
+        if !transactions.isEmpty {
+            eventSubject.send(.foundTransactions(transactions, nil))
         }
     }
 }

--- a/Sources/ZcashLightClientKit/Synchronizer/SDKBroadcaster.swift
+++ b/Sources/ZcashLightClientKit/Synchronizer/SDKBroadcaster.swift
@@ -52,12 +52,12 @@ class SDKBroadcaster: Broadcaster {
             logger: logger
         )
 
-        let transactions = try await transactionEncoder.createProposedTransactions(
-            proposal: proposal,
-            spendingKey: spendingKey
-        )
-
-        await pendingSubmitPlanStore.markAwaitingSubmitPlan(transactions)
+        let transactions = try await pendingSubmitPlanStore.createAndMarkAwaitingSubmitPlan {
+            try await transactionEncoder.createProposedTransactions(
+                proposal: proposal,
+                spendingKey: spendingKey
+            )
+        }
         sendFoundTransactionsEvent(transactions)
 
         return transactions
@@ -89,13 +89,14 @@ class SDKBroadcaster: Broadcaster {
             logger: logger
         )
 
-        let txId = try await initializer.rustBackend.extractAndStoreTxFromPCZT(
-            pcztWithProofs: pcztWithProofs,
-            pcztWithSigs: pcztWithSigs
-        )
+        let transactions = try await pendingSubmitPlanStore.createAndMarkAwaitingSubmitPlan {
+            let txId = try await initializer.rustBackend.extractAndStoreTxFromPCZT(
+                pcztWithProofs: pcztWithProofs,
+                pcztWithSigs: pcztWithSigs
+            )
 
-        let transactions = try await transactionEncoder.fetchTransactionsForTxIds([txId])
-        await pendingSubmitPlanStore.markAwaitingSubmitPlan(transactions)
+            return try await transactionEncoder.fetchTransactionsForTxIds([txId])
+        }
         sendFoundTransactionsEvent(transactions)
 
         return transactions

--- a/Sources/ZcashLightClientKit/Synchronizer/SDKSynchronizer.swift
+++ b/Sources/ZcashLightClientKit/Synchronizer/SDKSynchronizer.swift
@@ -49,13 +49,14 @@ public class SDKSynchronizer: Synchronizer {
     public let network: ZcashNetwork
     private var transactionEncoder: TransactionEncoder
     private let transactionRepository: TransactionRepository
+    private let pendingSubmitPlanStore: PendingSubmitPlanStore
 
     private let syncSessionIDGenerator: SyncSessionIDGenerator
     private let syncSession: SyncSession
     private let syncSessionTicker: SessionTicker
     var latestBlocksDataProvider: LatestBlocksDataProvider
 
-    private var broadcasterStorage: Broadcaster?
+    private var broadcasterStorage: SDKBroadcaster?
     public var broadcaster: Broadcaster {
         guard let broadcaster = broadcasterStorage else {
             preconditionFailure("Broadcaster accessed before initialization")
@@ -101,13 +102,16 @@ public class SDKSynchronizer: Synchronizer {
         self.syncSessionTicker = syncSessionTicker
         self.latestBlocksDataProvider = initializer.container.resolve(LatestBlocksDataProvider.self)
         self.sdkFlags = initializer.container.resolve(SDKFlags.self)
+        self.pendingSubmitPlanStore = initializer.container.resolve(PendingSubmitPlanStore.self)
 
         self.broadcasterStorage = SDKBroadcaster(
             transactionEncoder: transactionEncoder,
             initializer: initializer,
-            sdkFlags: sdkFlags,
             logger: logger,
             eventSubject: eventSubject,
+            pendingSubmitPlanStore: pendingSubmitPlanStore,
+            transactionSubmitter: initializer.container.resolve(TransactionSubmitter.self),
+            rawTransactionLookup: transactionRepository as? RawTransactionLookup,
             statusCheck: { [weak self] in
                 guard let self else {
                     throw ZcashError.synchronizerNotPrepared
@@ -460,7 +464,7 @@ public class SDKSynchronizer: Synchronizer {
         proposal: Proposal,
         spendingKey: UnifiedSpendingKey
     ) async throws -> AsyncThrowingStream<TransactionSubmitResult, Error> {
-        let transactions = try await broadcaster.createProposedTransactions(
+        let transactions = try await sdkBroadcaster().createProposedTransactionsForLegacySubmit(
             proposal: proposal,
             spendingKey: spendingKey
         )
@@ -532,7 +536,7 @@ public class SDKSynchronizer: Synchronizer {
     }
     
     public func createTransactionFromPCZT(pcztWithProofs: Pczt, pcztWithSigs: Pczt) async throws -> AsyncThrowingStream<TransactionSubmitResult, Error> {
-        let transactions = try await broadcaster.createTransactionFromPCZT(
+        let transactions = try await sdkBroadcaster().createTransactionFromPCZTForLegacySubmit(
             pcztWithProofs: pcztWithProofs,
             pcztWithSigs: pcztWithSigs
         )
@@ -760,6 +764,9 @@ public class SDKSynchronizer: Synchronizer {
                     self?.transactionRepository.closeDBConnection()
                 },
                 completion: { [weak self] possibleError in
+                    if possibleError == nil {
+                        await self?.pendingSubmitPlanStore.clear()
+                    }
                     await self?.updateStatus(.unprepared)
                     if let error = possibleError {
                         subject.send(completion: .failure(error))
@@ -781,6 +788,13 @@ public class SDKSynchronizer: Synchronizer {
 
     public func isSeedRelevantToAnyDerivedAccount(seed: [UInt8]) async throws -> Bool {
         try await initializer.rustBackend.isSeedRelevantToAnyDerivedAccount(seed: seed)
+    }
+
+    private func sdkBroadcaster() -> SDKBroadcaster {
+        guard let broadcaster = broadcasterStorage else {
+            preconditionFailure("Broadcaster accessed before initialization")
+        }
+        return broadcaster
     }
 
     /// Takes the list of endpoints and runs it through a series of checks to evaluate its performance.

--- a/Sources/ZcashLightClientKit/Transaction/PendingSubmitPlanStore.swift
+++ b/Sources/ZcashLightClientKit/Transaction/PendingSubmitPlanStore.swift
@@ -33,6 +33,8 @@ actor PendingSubmitPlanStore {
     private let logger: Logger
 
     private var plansByTransactionId: [String: [StoredEndpoint]] = [:]
+    // In-memory cache only. After restart, raw transaction submissions recover
+    // the transaction id through RawTransactionLookup before recording endpoints.
     private var transactionIdsByRawTransaction: [String: String] = [:]
     private var loadedFromPersistence = false
 
@@ -150,6 +152,9 @@ actor PendingSubmitPlanStore {
             }
 
             let storedPlans = try JSONDecoder().decode(StoredPlans.self, from: data)
+            guard storedPlans.version == StoredPlans.currentVersion else {
+                throw PendingSubmitPlanStoreError.unsupportedVersion(storedPlans.version)
+            }
             plansByTransactionId = storedPlans.plansByTransactionId
         } catch {
             logger.warn("Failed to load pending submit plans: \(error)")
@@ -171,13 +176,19 @@ private struct StoredPlans: Codable {
     let version: Int
     let plansByTransactionId: [String: [StoredEndpoint]]
 
+    static let currentVersion = 1
+
     init(
-        version: Int = 1,
+        version: Int = Self.currentVersion,
         plansByTransactionId: [String: [StoredEndpoint]]
     ) {
         self.version = version
         self.plansByTransactionId = plansByTransactionId
     }
+}
+
+private enum PendingSubmitPlanStoreError: Error {
+    case unsupportedVersion(Int)
 }
 
 private struct StoredEndpoint: Codable, Equatable {

--- a/Sources/ZcashLightClientKit/Transaction/PendingSubmitPlanStore.swift
+++ b/Sources/ZcashLightClientKit/Transaction/PendingSubmitPlanStore.swift
@@ -105,10 +105,11 @@ actor PendingSubmitPlanStore {
         loadFromPersistenceIfNeeded()
 
         let retainedTransactionIds = Set(transactionIds.map(\.stablePlanKey))
-        let previousCount = plansByTransactionId.count
+        let previousPlanCount = plansByTransactionId.count
         plansByTransactionId = plansByTransactionId.filter { retainedTransactionIds.contains($0.key) }
+        transactionIdsByRawTransaction = transactionIdsByRawTransaction.filter { retainedTransactionIds.contains($0.value) }
 
-        if plansByTransactionId.count != previousCount {
+        if plansByTransactionId.count != previousPlanCount {
             saveToPersistence()
         }
     }

--- a/Sources/ZcashLightClientKit/Transaction/PendingSubmitPlanStore.swift
+++ b/Sources/ZcashLightClientKit/Transaction/PendingSubmitPlanStore.swift
@@ -169,13 +169,13 @@ actor PendingSubmitPlanStore {
 
     private func loadFromPersistenceIfNeeded() {
         guard !loadedFromPersistence else { return }
-        defer { loadedFromPersistence = true }
 
         do {
             guard
                 let data = try persistence?.load(),
                 !data.isEmpty
             else {
+                loadedFromPersistence = true
                 return
             }
 
@@ -183,13 +183,38 @@ actor PendingSubmitPlanStore {
             guard storedPlans.version == StoredPlans.currentVersion else {
                 throw PendingSubmitPlanStoreError.unsupportedVersion(storedPlans.version)
             }
-            plansByTransactionId = storedPlans.plansByTransactionId
+            mergeLoadedPlans(storedPlans.plansByTransactionId)
+            loadedFromPersistence = true
         } catch {
             logger.warn("Failed to load pending submit plans: \(error)")
         }
     }
 
+    private func mergeLoadedPlans(_ loadedPlans: [String: [StoredEndpoint]]) {
+        guard !plansByTransactionId.isEmpty else {
+            plansByTransactionId = loadedPlans
+            return
+        }
+
+        var mergedPlans = loadedPlans
+        for (transactionId, currentEndpoints) in plansByTransactionId {
+            var endpoints = mergedPlans[transactionId] ?? []
+            currentEndpoints.forEach {
+                if !endpoints.contains($0) {
+                    endpoints.append($0)
+                }
+            }
+            mergedPlans[transactionId] = endpoints
+        }
+        plansByTransactionId = mergedPlans
+    }
+
     private func saveToPersistence() {
+        guard loadedFromPersistence else {
+            logger.warn("Skipping pending submit plan save because persisted plans have not loaded.")
+            return
+        }
+
         do {
             let storedPlans = StoredPlans(plansByTransactionId: plansByTransactionId)
             let data = try JSONEncoder().encode(storedPlans)

--- a/Sources/ZcashLightClientKit/Transaction/PendingSubmitPlanStore.swift
+++ b/Sources/ZcashLightClientKit/Transaction/PendingSubmitPlanStore.swift
@@ -1,0 +1,284 @@
+//
+//  PendingSubmitPlanStore.swift
+//  ZcashLightClientKit
+//
+//  Created by Adam Tucker on 2026-05-12.
+//
+
+import Foundation
+import Security
+
+protocol PendingSubmitPlanPersistence {
+    func load() throws -> Data?
+    func save(_ data: Data) throws
+    func clear() throws
+}
+
+struct TransactionSubmitPlan {
+    let endpoints: [LightWalletEndpoint]
+
+    init(endpoints: [LightWalletEndpoint]) {
+        precondition(!endpoints.isEmpty, "Transaction submit plan must include at least one endpoint.")
+        self.endpoints = endpoints
+    }
+}
+
+actor PendingSubmitPlanStore {
+    enum StoredSubmitPlan {
+        case awaitingPlan
+        case ready(TransactionSubmitPlan)
+    }
+
+    private let persistence: PendingSubmitPlanPersistence?
+    private let logger: Logger
+
+    private var plansByTransactionId: [String: [StoredEndpoint]] = [:]
+    private var transactionIdsByRawTransaction: [String: String] = [:]
+    private var loadedFromPersistence = false
+
+    init(
+        persistence: PendingSubmitPlanPersistence? = nil,
+        logger: Logger
+    ) {
+        self.persistence = persistence
+        self.logger = logger
+    }
+
+    func markAwaitingSubmitPlan(_ transactions: [ZcashTransaction.Overview]) {
+        loadFromPersistenceIfNeeded()
+
+        var changed = false
+        for transaction in transactions {
+            let transactionId = transaction.rawID.stablePlanKey
+            if let raw = transaction.raw {
+                transactionIdsByRawTransaction[raw.stablePlanKey] = transactionId
+            }
+            if plansByTransactionId[transactionId] == nil {
+                plansByTransactionId[transactionId] = []
+                changed = true
+            }
+        }
+
+        if changed {
+            saveToPersistence()
+        }
+    }
+
+    func addSubmitEndpoint(
+        rawTransaction: Data,
+        endpoint: LightWalletEndpoint
+    ) {
+        loadFromPersistenceIfNeeded()
+
+        guard let transactionId = transactionIdsByRawTransaction[rawTransaction.stablePlanKey] else {
+            return
+        }
+
+        addSubmitEndpoint(transactionId: transactionId, endpoint: endpoint)
+    }
+
+    func addSubmitEndpoint(
+        transaction: ZcashTransaction.Overview,
+        endpoint: LightWalletEndpoint
+    ) {
+        loadFromPersistenceIfNeeded()
+        if let raw = transaction.raw {
+            transactionIdsByRawTransaction[raw.stablePlanKey] = transaction.rawID.stablePlanKey
+        }
+        addSubmitEndpoint(transactionId: transaction.rawID.stablePlanKey, endpoint: endpoint)
+    }
+
+    func getSubmitPlan(for transactionId: Data) -> StoredSubmitPlan? {
+        loadFromPersistenceIfNeeded()
+
+        switch plansByTransactionId[transactionId.stablePlanKey] {
+        case nil:
+            return nil
+        case let endpoints? where endpoints.isEmpty:
+            return .awaitingPlan
+        case let endpoints?:
+            return .ready(TransactionSubmitPlan(endpoints: endpoints.map(\.endpoint)))
+        }
+    }
+
+    func retainPlans(for transactionIds: [Data]) {
+        loadFromPersistenceIfNeeded()
+
+        let retainedTransactionIds = Set(transactionIds.map(\.stablePlanKey))
+        let previousCount = plansByTransactionId.count
+        plansByTransactionId = plansByTransactionId.filter { retainedTransactionIds.contains($0.key) }
+
+        if plansByTransactionId.count != previousCount {
+            saveToPersistence()
+        }
+    }
+
+    func clear() {
+        plansByTransactionId.removeAll()
+        transactionIdsByRawTransaction.removeAll()
+        do {
+            try persistence?.clear()
+        } catch {
+            logger.warn("Failed to clear pending submit plans: \(error)")
+        }
+    }
+
+    private func addSubmitEndpoint(
+        transactionId: String,
+        endpoint: LightWalletEndpoint
+    ) {
+        let storedEndpoint = StoredEndpoint(endpoint: endpoint)
+        var endpoints = plansByTransactionId[transactionId] ?? []
+        guard !endpoints.contains(storedEndpoint) else { return }
+
+        endpoints.append(storedEndpoint)
+        plansByTransactionId[transactionId] = endpoints
+        saveToPersistence()
+    }
+
+    private func loadFromPersistenceIfNeeded() {
+        guard !loadedFromPersistence else { return }
+        defer { loadedFromPersistence = true }
+
+        do {
+            guard
+                let data = try persistence?.load(),
+                !data.isEmpty
+            else {
+                return
+            }
+
+            let storedPlans = try JSONDecoder().decode(StoredPlans.self, from: data)
+            plansByTransactionId = storedPlans.plansByTransactionId
+        } catch {
+            logger.warn("Failed to load pending submit plans: \(error)")
+        }
+    }
+
+    private func saveToPersistence() {
+        do {
+            let storedPlans = StoredPlans(plansByTransactionId: plansByTransactionId)
+            let data = try JSONEncoder().encode(storedPlans)
+            try persistence?.save(data)
+        } catch {
+            logger.warn("Failed to store pending submit plans: \(error)")
+        }
+    }
+}
+
+private struct StoredPlans: Codable {
+    let version: Int
+    let plansByTransactionId: [String: [StoredEndpoint]]
+
+    init(
+        version: Int = 1,
+        plansByTransactionId: [String: [StoredEndpoint]]
+    ) {
+        self.version = version
+        self.plansByTransactionId = plansByTransactionId
+    }
+}
+
+private struct StoredEndpoint: Codable, Equatable {
+    let host: String
+    let port: Int
+    let secure: Bool
+    let singleCallTimeoutInMillis: Int64
+    let streamingCallTimeoutInMillis: Int64
+
+    init(endpoint: LightWalletEndpoint) {
+        host = endpoint.host
+        port = endpoint.port
+        secure = endpoint.secure
+        singleCallTimeoutInMillis = endpoint.singleCallTimeoutInMillis
+        streamingCallTimeoutInMillis = endpoint.streamingCallTimeoutInMillis
+    }
+
+    var endpoint: LightWalletEndpoint {
+        LightWalletEndpoint(
+            address: host,
+            port: port,
+            secure: secure,
+            singleCallTimeoutInMillis: singleCallTimeoutInMillis,
+            streamingCallTimeoutInMillis: streamingCallTimeoutInMillis
+        )
+    }
+}
+
+private extension Data {
+    var stablePlanKey: String { hexEncodedString() }
+}
+
+struct KeychainSubmitPlanPersistence: PendingSubmitPlanPersistence {
+    private enum Constants {
+        static let service = "cash.z.ecc.ZcashLightClientKit.pending-submit-plans"
+    }
+
+    private let account: String
+
+    init(
+        alias: ZcashSynchronizerAlias,
+        networkType: NetworkType
+    ) {
+        self.account = "\(networkType.networkId)_\(alias.description)"
+    }
+
+    func load() throws -> Data? {
+        var query = baseQuery
+        query[kSecReturnData as String] = true
+        query[kSecMatchLimit as String] = kSecMatchLimitOne
+
+        var item: CFTypeRef?
+        let status = SecItemCopyMatching(query as CFDictionary, &item)
+
+        switch status {
+        case errSecSuccess:
+            return item as? Data
+        case errSecItemNotFound:
+            return nil
+        default:
+            throw KeychainSubmitPlanPersistenceError.unhandledStatus(status)
+        }
+    }
+
+    func save(_ data: Data) throws {
+        let attributes: [String: Any] = [
+            kSecValueData as String: data,
+            kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
+        ]
+
+        let updateStatus = SecItemUpdate(baseQuery as CFDictionary, attributes as CFDictionary)
+        switch updateStatus {
+        case errSecSuccess:
+            return
+        case errSecItemNotFound:
+            var addQuery = baseQuery
+            attributes.forEach { addQuery[$0.key] = $0.value }
+            let addStatus = SecItemAdd(addQuery as CFDictionary, nil)
+            guard addStatus == errSecSuccess else {
+                throw KeychainSubmitPlanPersistenceError.unhandledStatus(addStatus)
+            }
+        default:
+            throw KeychainSubmitPlanPersistenceError.unhandledStatus(updateStatus)
+        }
+    }
+
+    func clear() throws {
+        let status = SecItemDelete(baseQuery as CFDictionary)
+        guard status == errSecSuccess || status == errSecItemNotFound else {
+            throw KeychainSubmitPlanPersistenceError.unhandledStatus(status)
+        }
+    }
+
+    private var baseQuery: [String: Any] {
+        [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: Constants.service,
+            kSecAttrAccount as String: account
+        ]
+    }
+}
+
+private enum KeychainSubmitPlanPersistenceError: Error {
+    case unhandledStatus(OSStatus)
+}

--- a/Sources/ZcashLightClientKit/Transaction/PendingSubmitPlanStore.swift
+++ b/Sources/ZcashLightClientKit/Transaction/PendingSubmitPlanStore.swift
@@ -29,15 +29,32 @@ actor PendingSubmitPlanStore {
         case ready(TransactionSubmitPlan)
     }
 
+    private struct RetainToken {
+        let storeRevision: UInt64
+        let activeSubmitPlanCreations: Int
+    }
+
+    private struct SubmitPlanCreationToken {
+        let clearGeneration: UInt64
+    }
+
     private let persistence: PendingSubmitPlanPersistence?
     private let logger: Logger
-    private let lock = AsyncLock()
 
     private var plansByTransactionId: [String: [StoredEndpoint]] = [:]
     // In-memory cache only. After restart, raw transaction submissions recover
     // the transaction id through RawTransactionLookup before recording endpoints.
     private var transactionIdsByRawTransaction: [String: String] = [:]
     private var loadedFromPersistence = false
+    // Actor isolation prevents data races, but actor methods are reentrant
+    // across await. Candidate lookup returns a repository snapshot, so pruning
+    // only applies if no submit-plan creation was active and the store did not
+    // change while that lookup was suspended.
+    private var activeSubmitPlanCreations = 0
+    private var storeRevision: UInt64 = 0
+    // Prevents a creation that started before clear() from recording plans after
+    // clear() has removed the in-memory and persisted submit-plan state.
+    private var clearGeneration: UInt64 = 0
 
     init(
         persistence: PendingSubmitPlanPersistence? = nil,
@@ -50,54 +67,55 @@ actor PendingSubmitPlanStore {
     func createAndMarkAwaitingSubmitPlan(
         createTransactions: () async throws -> [ZcashTransaction.Overview]
     ) async rethrows -> [ZcashTransaction.Overview] {
-        try await lock.withLock {
-            loadFromPersistenceIfNeeded()
-            let transactions = try await createTransactions()
-            markAwaitingSubmitPlanWithoutLock(transactions)
-            return transactions
+        loadFromPersistenceIfNeeded()
+        let creationToken = beginSubmitPlanCreation()
+        defer { endSubmitPlanCreation() }
+
+        let transactions = try await createTransactions()
+        if canRecordSubmitPlanCreation(using: creationToken) {
+            markAwaitingSubmitPlan(transactions)
         }
+        return transactions
     }
 
     func addSubmitEndpoint(
         rawTransaction: Data,
         endpoint: LightWalletEndpoint
     ) async {
-        await lock.withLock {
-            loadFromPersistenceIfNeeded()
+        loadFromPersistenceIfNeeded()
 
-            guard let transactionId = transactionIdsByRawTransaction[rawTransaction.stablePlanKey] else {
-                return
-            }
-
-            addSubmitEndpoint(transactionId: transactionId, endpoint: endpoint)
+        guard let transactionId = transactionIdsByRawTransaction[rawTransaction.stablePlanKey] else {
+            return
         }
+
+        addSubmitEndpoint(transactionId: transactionId, endpoint: endpoint)
     }
 
     func addSubmitEndpoint(
         transaction: ZcashTransaction.Overview,
         endpoint: LightWalletEndpoint
     ) async {
-        await lock.withLock {
-            loadFromPersistenceIfNeeded()
-            if let raw = transaction.raw {
-                transactionIdsByRawTransaction[raw.stablePlanKey] = transaction.rawID.stablePlanKey
+        loadFromPersistenceIfNeeded()
+        if let raw = transaction.raw {
+            let transactionId = transaction.rawID.stablePlanKey
+            if transactionIdsByRawTransaction[raw.stablePlanKey] != transactionId {
+                transactionIdsByRawTransaction[raw.stablePlanKey] = transactionId
+                bumpStoreRevision()
             }
-            addSubmitEndpoint(transactionId: transaction.rawID.stablePlanKey, endpoint: endpoint)
         }
+        addSubmitEndpoint(transactionId: transaction.rawID.stablePlanKey, endpoint: endpoint)
     }
 
     func getSubmitPlan(for transactionId: Data) async -> StoredSubmitPlan? {
-        await lock.withLock {
-            loadFromPersistenceIfNeeded()
+        loadFromPersistenceIfNeeded()
 
-            switch plansByTransactionId[transactionId.stablePlanKey] {
-            case nil:
-                return nil
-            case let endpoints? where endpoints.isEmpty:
-                return .awaitingPlan
-            case let endpoints?:
-                return .ready(TransactionSubmitPlan(endpoints: endpoints.map(\.endpoint)))
-            }
+        switch plansByTransactionId[transactionId.stablePlanKey] {
+        case nil:
+            return nil
+        case let endpoints? where endpoints.isEmpty:
+            return .awaitingPlan
+        case let endpoints?:
+            return .ready(TransactionSubmitPlan(endpoints: endpoints.map(\.endpoint)))
         }
     }
 
@@ -105,40 +123,51 @@ actor PendingSubmitPlanStore {
         loadTransactions: () async throws -> [T],
         transactionId: (T) -> Data
     ) async rethrows -> [T] {
-        try await lock.withLock {
-            loadFromPersistenceIfNeeded()
-            let transactions = try await loadTransactions()
-            retainPlansWithoutLock(for: transactions.map(transactionId))
-            return transactions
+        loadFromPersistenceIfNeeded()
+        let retainToken = makeRetainToken()
+
+        let transactions = try await loadTransactions()
+        if canApplyRetain(using: retainToken) {
+            retainPlans(for: transactions.map(transactionId))
         }
+        return transactions
     }
 
     func clear() async {
-        await lock.withLock {
-            plansByTransactionId.removeAll()
-            transactionIdsByRawTransaction.removeAll()
-            do {
-                try persistence?.clear()
-            } catch {
-                logger.warn("Failed to clear pending submit plans: \(error)")
-            }
+        plansByTransactionId.removeAll()
+        transactionIdsByRawTransaction.removeAll()
+        clearGeneration &+= 1
+        bumpStoreRevision()
+        do {
+            try persistence?.clear()
+        } catch {
+            logger.warn("Failed to clear pending submit plans: \(error)")
         }
     }
 
-    private func markAwaitingSubmitPlanWithoutLock(_ transactions: [ZcashTransaction.Overview]) {
-        var changed = false
+    private func markAwaitingSubmitPlan(_ transactions: [ZcashTransaction.Overview]) {
+        var shouldSave = false
+        var didChange = false
         for transaction in transactions {
             let transactionId = transaction.rawID.stablePlanKey
             if let raw = transaction.raw {
-                transactionIdsByRawTransaction[raw.stablePlanKey] = transactionId
+                let rawTransactionKey = raw.stablePlanKey
+                if transactionIdsByRawTransaction[rawTransactionKey] != transactionId {
+                    transactionIdsByRawTransaction[rawTransactionKey] = transactionId
+                    didChange = true
+                }
             }
             if plansByTransactionId[transactionId] == nil {
                 plansByTransactionId[transactionId] = []
-                changed = true
+                shouldSave = true
+                didChange = true
             }
         }
 
-        if changed {
+        if didChange {
+            bumpStoreRevision()
+        }
+        if shouldSave {
             saveToPersistence()
         }
     }
@@ -153,18 +182,57 @@ actor PendingSubmitPlanStore {
 
         endpoints.append(storedEndpoint)
         plansByTransactionId[transactionId] = endpoints
+        bumpStoreRevision()
         saveToPersistence()
     }
 
-    private func retainPlansWithoutLock(for transactionIds: [Data]) {
+    private func retainPlans(for transactionIds: [Data]) {
         let retainedTransactionIds = Set(transactionIds.map(\.stablePlanKey))
         let previousPlanCount = plansByTransactionId.count
+        let previousRawTransactionCount = transactionIdsByRawTransaction.count
         plansByTransactionId = plansByTransactionId.filter { retainedTransactionIds.contains($0.key) }
         transactionIdsByRawTransaction = transactionIdsByRawTransaction.filter { retainedTransactionIds.contains($0.value) }
+
+        if plansByTransactionId.count != previousPlanCount ||
+            transactionIdsByRawTransaction.count != previousRawTransactionCount {
+            bumpStoreRevision()
+        }
 
         if plansByTransactionId.count != previousPlanCount {
             saveToPersistence()
         }
+    }
+
+    private func beginSubmitPlanCreation() -> SubmitPlanCreationToken {
+        activeSubmitPlanCreations += 1
+        bumpStoreRevision()
+        return SubmitPlanCreationToken(clearGeneration: clearGeneration)
+    }
+
+    private func endSubmitPlanCreation() {
+        precondition(activeSubmitPlanCreations > 0, "Attempted to end inactive submit-plan creation.")
+        activeSubmitPlanCreations -= 1
+    }
+
+    private func makeRetainToken() -> RetainToken {
+        RetainToken(
+            storeRevision: storeRevision,
+            activeSubmitPlanCreations: activeSubmitPlanCreations
+        )
+    }
+
+    private func canApplyRetain(using token: RetainToken) -> Bool {
+        token.activeSubmitPlanCreations == 0 &&
+            activeSubmitPlanCreations == 0 &&
+            storeRevision == token.storeRevision
+    }
+
+    private func canRecordSubmitPlanCreation(using token: SubmitPlanCreationToken) -> Bool {
+        clearGeneration == token.clearGeneration
+    }
+
+    private func bumpStoreRevision() {
+        storeRevision &+= 1
     }
 
     private func loadFromPersistenceIfNeeded() {
@@ -191,8 +259,12 @@ actor PendingSubmitPlanStore {
     }
 
     private func mergeLoadedPlans(_ loadedPlans: [String: [StoredEndpoint]]) {
+        let previousPlans = plansByTransactionId
         guard !plansByTransactionId.isEmpty else {
             plansByTransactionId = loadedPlans
+            if previousPlans != plansByTransactionId {
+                bumpStoreRevision()
+            }
             return
         }
 
@@ -207,6 +279,9 @@ actor PendingSubmitPlanStore {
             mergedPlans[transactionId] = endpoints
         }
         plansByTransactionId = mergedPlans
+        if previousPlans != plansByTransactionId {
+            bumpStoreRevision()
+        }
     }
 
     private func saveToPersistence() {
@@ -272,49 +347,6 @@ private struct StoredEndpoint: Codable, Equatable {
 
 private extension Data {
     var stablePlanKey: String { hexEncodedString() }
-}
-
-private final class AsyncLock {
-    private let state = State()
-
-    func withLock<T>(_ operation: () async throws -> T) async rethrows -> T {
-        await state.acquire()
-        do {
-            let result = try await operation()
-            await state.release()
-            return result
-        } catch {
-            await state.release()
-            throw error
-        }
-    }
-
-    private actor State {
-        private var isLocked = false
-        private var waiters: [CheckedContinuation<Void, Never>] = []
-
-        func acquire() async {
-            if !isLocked {
-                isLocked = true
-                return
-            }
-
-            await withCheckedContinuation { continuation in
-                waiters.append(continuation)
-            }
-        }
-
-        func release() {
-            precondition(isLocked, "Attempted to release an unlocked AsyncLock.")
-            guard !waiters.isEmpty else {
-                isLocked = false
-                return
-            }
-
-            let continuation = waiters.removeFirst()
-            continuation.resume()
-        }
-    }
 }
 
 struct KeychainSubmitPlanPersistence: PendingSubmitPlanPersistence {

--- a/Sources/ZcashLightClientKit/Transaction/PendingSubmitPlanStore.swift
+++ b/Sources/ZcashLightClientKit/Transaction/PendingSubmitPlanStore.swift
@@ -23,6 +23,12 @@ struct TransactionSubmitPlan {
     }
 }
 
+/// Tracks submit plans for pending transactions created through `Broadcaster`.
+///
+/// Transactions start as waiting for submit endpoints, then the store records
+/// the endpoints used for submission so resubmission can retry through the same
+/// path. Plans are persisted across launches and pruned when their transactions
+/// are no longer resubmission candidates.
 actor PendingSubmitPlanStore {
     enum StoredSubmitPlan {
         case awaitingPlan

--- a/Sources/ZcashLightClientKit/Transaction/PendingSubmitPlanStore.swift
+++ b/Sources/ZcashLightClientKit/Transaction/PendingSubmitPlanStore.swift
@@ -51,6 +51,7 @@ actor PendingSubmitPlanStore {
     // In-memory cache only. After restart, raw transaction submissions recover
     // the transaction id through RawTransactionLookup before recording endpoints.
     private var transactionIdsByRawTransaction: [String: String] = [:]
+    private var pendingEndpointsByRawTransaction: [String: [StoredEndpoint]] = [:]
     private var loadedFromPersistence = false
     // Actor isolation prevents data races, but actor methods are reentrant
     // across await. Candidate lookup returns a repository snapshot, so pruning
@@ -90,7 +91,11 @@ actor PendingSubmitPlanStore {
     ) async {
         loadFromPersistenceIfNeeded()
 
-        guard let transactionId = transactionIdsByRawTransaction[rawTransaction.stablePlanKey] else {
+        let rawTransactionKey = rawTransaction.stablePlanKey
+        guard let transactionId = transactionIdsByRawTransaction[rawTransactionKey] else {
+            if activeSubmitPlanCreations > 0 {
+                addPendingSubmitEndpoint(rawTransactionKey: rawTransactionKey, endpoint: endpoint)
+            }
             return
         }
 
@@ -142,6 +147,7 @@ actor PendingSubmitPlanStore {
     func clear() async {
         plansByTransactionId.removeAll()
         transactionIdsByRawTransaction.removeAll()
+        pendingEndpointsByRawTransaction.removeAll()
         clearGeneration &+= 1
         bumpStoreRevision()
         do {
@@ -150,7 +156,9 @@ actor PendingSubmitPlanStore {
             logger.warn("Failed to clear pending submit plans: \(error)")
         }
     }
+}
 
+private extension PendingSubmitPlanStore {
     private func markAwaitingSubmitPlan(_ transactions: [ZcashTransaction.Overview]) {
         var shouldSave = false
         var didChange = false
@@ -161,6 +169,15 @@ actor PendingSubmitPlanStore {
                 if transactionIdsByRawTransaction[rawTransactionKey] != transactionId {
                     transactionIdsByRawTransaction[rawTransactionKey] = transactionId
                     didChange = true
+                }
+                if let pendingEndpoints = pendingEndpointsByRawTransaction.removeValue(forKey: rawTransactionKey) {
+                    didChange = true
+                    var endpoints = plansByTransactionId[transactionId] ?? []
+                    for pendingEndpoint in pendingEndpoints where !endpoints.contains(pendingEndpoint) {
+                        endpoints.append(pendingEndpoint)
+                        shouldSave = true
+                    }
+                    plansByTransactionId[transactionId] = endpoints
                 }
             }
             if plansByTransactionId[transactionId] == nil {
@@ -192,6 +209,19 @@ actor PendingSubmitPlanStore {
         saveToPersistence()
     }
 
+    private func addPendingSubmitEndpoint(
+        rawTransactionKey: String,
+        endpoint: LightWalletEndpoint
+    ) {
+        let storedEndpoint = StoredEndpoint(endpoint: endpoint)
+        var endpoints = pendingEndpointsByRawTransaction[rawTransactionKey] ?? []
+        guard !endpoints.contains(storedEndpoint) else { return }
+
+        endpoints.append(storedEndpoint)
+        pendingEndpointsByRawTransaction[rawTransactionKey] = endpoints
+        bumpStoreRevision()
+    }
+
     private func retainPlans(for transactionIds: [Data]) {
         let retainedTransactionIds = Set(transactionIds.map(\.stablePlanKey))
         let previousPlanCount = plansByTransactionId.count
@@ -218,6 +248,10 @@ actor PendingSubmitPlanStore {
     private func endSubmitPlanCreation() {
         precondition(activeSubmitPlanCreations > 0, "Attempted to end inactive submit-plan creation.")
         activeSubmitPlanCreations -= 1
+        if activeSubmitPlanCreations == 0 && !pendingEndpointsByRawTransaction.isEmpty {
+            pendingEndpointsByRawTransaction.removeAll()
+            bumpStoreRevision()
+        }
     }
 
     private func makeRetainToken() -> RetainToken {

--- a/Sources/ZcashLightClientKit/Transaction/PendingSubmitPlanStore.swift
+++ b/Sources/ZcashLightClientKit/Transaction/PendingSubmitPlanStore.swift
@@ -31,6 +31,7 @@ actor PendingSubmitPlanStore {
 
     private let persistence: PendingSubmitPlanPersistence?
     private let logger: Logger
+    private let lock = AsyncLock()
 
     private var plansByTransactionId: [String: [StoredEndpoint]] = [:]
     // In-memory cache only. After restart, raw transaction submissions recover
@@ -46,9 +47,85 @@ actor PendingSubmitPlanStore {
         self.logger = logger
     }
 
-    func markAwaitingSubmitPlan(_ transactions: [ZcashTransaction.Overview]) {
-        loadFromPersistenceIfNeeded()
+    func createAndMarkAwaitingSubmitPlan(
+        createTransactions: () async throws -> [ZcashTransaction.Overview]
+    ) async rethrows -> [ZcashTransaction.Overview] {
+        try await lock.withLock {
+            loadFromPersistenceIfNeeded()
+            let transactions = try await createTransactions()
+            markAwaitingSubmitPlanWithoutLock(transactions)
+            return transactions
+        }
+    }
 
+    func addSubmitEndpoint(
+        rawTransaction: Data,
+        endpoint: LightWalletEndpoint
+    ) async {
+        await lock.withLock {
+            loadFromPersistenceIfNeeded()
+
+            guard let transactionId = transactionIdsByRawTransaction[rawTransaction.stablePlanKey] else {
+                return
+            }
+
+            addSubmitEndpoint(transactionId: transactionId, endpoint: endpoint)
+        }
+    }
+
+    func addSubmitEndpoint(
+        transaction: ZcashTransaction.Overview,
+        endpoint: LightWalletEndpoint
+    ) async {
+        await lock.withLock {
+            loadFromPersistenceIfNeeded()
+            if let raw = transaction.raw {
+                transactionIdsByRawTransaction[raw.stablePlanKey] = transaction.rawID.stablePlanKey
+            }
+            addSubmitEndpoint(transactionId: transaction.rawID.stablePlanKey, endpoint: endpoint)
+        }
+    }
+
+    func getSubmitPlan(for transactionId: Data) async -> StoredSubmitPlan? {
+        await lock.withLock {
+            loadFromPersistenceIfNeeded()
+
+            switch plansByTransactionId[transactionId.stablePlanKey] {
+            case nil:
+                return nil
+            case let endpoints? where endpoints.isEmpty:
+                return .awaitingPlan
+            case let endpoints?:
+                return .ready(TransactionSubmitPlan(endpoints: endpoints.map(\.endpoint)))
+            }
+        }
+    }
+
+    func loadTransactionsAndRetainSubmitPlans<T>(
+        loadTransactions: () async throws -> [T],
+        transactionId: (T) -> Data
+    ) async rethrows -> [T] {
+        try await lock.withLock {
+            loadFromPersistenceIfNeeded()
+            let transactions = try await loadTransactions()
+            retainPlansWithoutLock(for: transactions.map(transactionId))
+            return transactions
+        }
+    }
+
+    func clear() async {
+        await lock.withLock {
+            plansByTransactionId.removeAll()
+            transactionIdsByRawTransaction.removeAll()
+            do {
+                try persistence?.clear()
+            } catch {
+                logger.warn("Failed to clear pending submit plans: \(error)")
+            }
+        }
+    }
+
+    private func markAwaitingSubmitPlanWithoutLock(_ transactions: [ZcashTransaction.Overview]) {
         var changed = false
         for transaction in transactions {
             let transactionId = transaction.rawID.stablePlanKey
@@ -66,66 +143,6 @@ actor PendingSubmitPlanStore {
         }
     }
 
-    func addSubmitEndpoint(
-        rawTransaction: Data,
-        endpoint: LightWalletEndpoint
-    ) {
-        loadFromPersistenceIfNeeded()
-
-        guard let transactionId = transactionIdsByRawTransaction[rawTransaction.stablePlanKey] else {
-            return
-        }
-
-        addSubmitEndpoint(transactionId: transactionId, endpoint: endpoint)
-    }
-
-    func addSubmitEndpoint(
-        transaction: ZcashTransaction.Overview,
-        endpoint: LightWalletEndpoint
-    ) {
-        loadFromPersistenceIfNeeded()
-        if let raw = transaction.raw {
-            transactionIdsByRawTransaction[raw.stablePlanKey] = transaction.rawID.stablePlanKey
-        }
-        addSubmitEndpoint(transactionId: transaction.rawID.stablePlanKey, endpoint: endpoint)
-    }
-
-    func getSubmitPlan(for transactionId: Data) -> StoredSubmitPlan? {
-        loadFromPersistenceIfNeeded()
-
-        switch plansByTransactionId[transactionId.stablePlanKey] {
-        case nil:
-            return nil
-        case let endpoints? where endpoints.isEmpty:
-            return .awaitingPlan
-        case let endpoints?:
-            return .ready(TransactionSubmitPlan(endpoints: endpoints.map(\.endpoint)))
-        }
-    }
-
-    func retainPlans(for transactionIds: [Data]) {
-        loadFromPersistenceIfNeeded()
-
-        let retainedTransactionIds = Set(transactionIds.map(\.stablePlanKey))
-        let previousPlanCount = plansByTransactionId.count
-        plansByTransactionId = plansByTransactionId.filter { retainedTransactionIds.contains($0.key) }
-        transactionIdsByRawTransaction = transactionIdsByRawTransaction.filter { retainedTransactionIds.contains($0.value) }
-
-        if plansByTransactionId.count != previousPlanCount {
-            saveToPersistence()
-        }
-    }
-
-    func clear() {
-        plansByTransactionId.removeAll()
-        transactionIdsByRawTransaction.removeAll()
-        do {
-            try persistence?.clear()
-        } catch {
-            logger.warn("Failed to clear pending submit plans: \(error)")
-        }
-    }
-
     private func addSubmitEndpoint(
         transactionId: String,
         endpoint: LightWalletEndpoint
@@ -137,6 +154,17 @@ actor PendingSubmitPlanStore {
         endpoints.append(storedEndpoint)
         plansByTransactionId[transactionId] = endpoints
         saveToPersistence()
+    }
+
+    private func retainPlansWithoutLock(for transactionIds: [Data]) {
+        let retainedTransactionIds = Set(transactionIds.map(\.stablePlanKey))
+        let previousPlanCount = plansByTransactionId.count
+        plansByTransactionId = plansByTransactionId.filter { retainedTransactionIds.contains($0.key) }
+        transactionIdsByRawTransaction = transactionIdsByRawTransaction.filter { retainedTransactionIds.contains($0.value) }
+
+        if plansByTransactionId.count != previousPlanCount {
+            saveToPersistence()
+        }
     }
 
     private func loadFromPersistenceIfNeeded() {
@@ -219,6 +247,49 @@ private struct StoredEndpoint: Codable, Equatable {
 
 private extension Data {
     var stablePlanKey: String { hexEncodedString() }
+}
+
+private final class AsyncLock {
+    private let state = State()
+
+    func withLock<T>(_ operation: () async throws -> T) async rethrows -> T {
+        await state.acquire()
+        do {
+            let result = try await operation()
+            await state.release()
+            return result
+        } catch {
+            await state.release()
+            throw error
+        }
+    }
+
+    private actor State {
+        private var isLocked = false
+        private var waiters: [CheckedContinuation<Void, Never>] = []
+
+        func acquire() async {
+            if !isLocked {
+                isLocked = true
+                return
+            }
+
+            await withCheckedContinuation { continuation in
+                waiters.append(continuation)
+            }
+        }
+
+        func release() {
+            precondition(isLocked, "Attempted to release an unlocked AsyncLock.")
+            guard !waiters.isEmpty else {
+                isLocked = false
+                return
+            }
+
+            let continuation = waiters.removeFirst()
+            continuation.resume()
+        }
+    }
 }
 
 struct KeychainSubmitPlanPersistence: PendingSubmitPlanPersistence {

--- a/Sources/ZcashLightClientKit/Transaction/PendingSubmitPlanStore.swift
+++ b/Sources/ZcashLightClientKit/Transaction/PendingSubmitPlanStore.swift
@@ -279,33 +279,34 @@ private extension PendingSubmitPlanStore {
         guard !loadedFromPersistence else { return }
 
         do {
-            guard
-                let data = try persistence?.load(),
-                !data.isEmpty
-            else {
-                loadedFromPersistence = true
-                return
+            let shouldSaveAfterLoad: Bool
+            if let data = try persistence?.load(), !data.isEmpty {
+                let storedPlans = try JSONDecoder().decode(StoredPlans.self, from: data)
+                guard storedPlans.version == StoredPlans.currentVersion else {
+                    throw PendingSubmitPlanStoreError.unsupportedVersion(storedPlans.version)
+                }
+                shouldSaveAfterLoad = mergeLoadedPlans(storedPlans.plansByTransactionId)
+            } else {
+                shouldSaveAfterLoad = !plansByTransactionId.isEmpty
             }
 
-            let storedPlans = try JSONDecoder().decode(StoredPlans.self, from: data)
-            guard storedPlans.version == StoredPlans.currentVersion else {
-                throw PendingSubmitPlanStoreError.unsupportedVersion(storedPlans.version)
-            }
-            mergeLoadedPlans(storedPlans.plansByTransactionId)
             loadedFromPersistence = true
+            if shouldSaveAfterLoad {
+                saveToPersistence()
+            }
         } catch {
             logger.warn("Failed to load pending submit plans: \(error)")
         }
     }
 
-    private func mergeLoadedPlans(_ loadedPlans: [String: [StoredEndpoint]]) {
+    private func mergeLoadedPlans(_ loadedPlans: [String: [StoredEndpoint]]) -> Bool {
         let previousPlans = plansByTransactionId
         guard !plansByTransactionId.isEmpty else {
             plansByTransactionId = loadedPlans
             if previousPlans != plansByTransactionId {
                 bumpStoreRevision()
             }
-            return
+            return false
         }
 
         var mergedPlans = loadedPlans
@@ -322,6 +323,7 @@ private extension PendingSubmitPlanStore {
         if previousPlans != plansByTransactionId {
             bumpStoreRevision()
         }
+        return loadedPlans != plansByTransactionId
     }
 
     private func saveToPersistence() {

--- a/Sources/ZcashLightClientKit/Transaction/SubmitPlanExecutor.swift
+++ b/Sources/ZcashLightClientKit/Transaction/SubmitPlanExecutor.swift
@@ -1,0 +1,114 @@
+//
+//  SubmitPlanExecutor.swift
+//  ZcashLightClientKit
+//
+//  Created by Adam Tucker on 2026-05-12.
+//
+
+import Foundation
+
+protocol TransactionSubmitter {
+    func submit(
+        rawTransaction: Data,
+        to endpoint: LightWalletEndpoint
+    ) async throws
+
+    func submit(
+        transaction: EncodedTransaction,
+        to endpoint: LightWalletEndpoint
+    ) async throws
+}
+
+final class EndpointTransactionSubmitter: TransactionSubmitter {
+    private let torClient: TorClient
+    private let sdkFlags: SDKFlags
+
+    init(
+        torClient: TorClient,
+        sdkFlags: SDKFlags
+    ) {
+        self.torClient = torClient
+        self.sdkFlags = sdkFlags
+    }
+
+    func submit(
+        rawTransaction: Data,
+        to endpoint: LightWalletEndpoint
+    ) async throws {
+        try await submit(
+            rawTransaction: rawTransaction,
+            to: endpoint,
+            mode: await sdkFlags.torEnabled ? .uniqueTor : .direct
+        )
+    }
+
+    func submit(
+        transaction: EncodedTransaction,
+        to endpoint: LightWalletEndpoint
+    ) async throws {
+        let mode: ServiceMode
+        if await sdkFlags.torEnabled {
+            mode = ServiceMode.txIdGroup(prefix: "submit", txId: transaction.transactionId)
+        } else {
+            mode = .direct
+        }
+
+        try await submit(
+            rawTransaction: transaction.raw,
+            to: endpoint,
+            mode: mode
+        )
+    }
+
+    private func submit(
+        rawTransaction: Data,
+        to endpoint: LightWalletEndpoint,
+        mode: ServiceMode
+    ) async throws {
+        let service = LightWalletGRPCServiceOverTor(endpoint: endpoint, tor: torClient)
+        let response: any LightWalletServiceResponse
+        do {
+            response = try await service.submit(spendTransaction: rawTransaction, mode: mode)
+        } catch {
+            await service.closeConnections()
+            throw error
+        }
+
+        await service.closeConnections()
+
+        guard response.errorCode >= 0 else {
+            throw TransactionEncoderError.submitError(
+                code: Int(response.errorCode),
+                message: response.errorMessage
+            )
+        }
+    }
+}
+
+final class SubmitPlanExecutor {
+    private let transactionSubmitter: TransactionSubmitter
+
+    init(transactionSubmitter: TransactionSubmitter) {
+        self.transactionSubmitter = transactionSubmitter
+    }
+
+    func submit(
+        transaction: EncodedTransaction,
+        submitPlan: TransactionSubmitPlan
+    ) async throws {
+        var lastError: Error?
+
+        for endpoint in submitPlan.endpoints {
+            do {
+                try await transactionSubmitter.submit(transaction: transaction, to: endpoint)
+                return
+            } catch {
+                lastError = error
+            }
+        }
+
+        if let lastError {
+            throw lastError
+        }
+    }
+}

--- a/Sources/ZcashLightClientKit/Transaction/SubmitPlanExecutor.swift
+++ b/Sources/ZcashLightClientKit/Transaction/SubmitPlanExecutor.swift
@@ -87,9 +87,14 @@ final class EndpointTransactionSubmitter: TransactionSubmitter {
 
 final class SubmitPlanExecutor {
     private let transactionSubmitter: TransactionSubmitter
+    private let logger: Logger
 
-    init(transactionSubmitter: TransactionSubmitter) {
+    init(
+        transactionSubmitter: TransactionSubmitter,
+        logger: Logger
+    ) {
         self.transactionSubmitter = transactionSubmitter
+        self.logger = logger
     }
 
     func submit(
@@ -103,6 +108,9 @@ final class SubmitPlanExecutor {
                 try await transactionSubmitter.submit(transaction: transaction, to: endpoint)
                 return
             } catch {
+                logger.warn(
+                    "Submit plan endpoint \(endpoint.host):\(endpoint.port) failed: \(error)"
+                )
                 lastError = error
             }
         }

--- a/Tests/OfflineTests/BroadcasterTests.swift
+++ b/Tests/OfflineTests/BroadcasterTests.swift
@@ -71,12 +71,11 @@ final class BroadcasterTests: ZcashTestCase {
         await fulfillment(of: [foundTransactionsExpectation], timeout: 1.0)
     }
 
-    func testCreateProposedTransactionsMarksPendingPlanBeforeStoreReadsProceed() async throws {
+    func testCreateProposedTransactionsKeepsPlanWhenRetainRunsDuringCreation() async throws {
         let rawID = Data(repeating: 0xAB, count: 32)
         let createdTransactions = [makeTransaction(raw: Data([0x01, 0x02]), rawID: rawID)]
         let createStarted = AsyncSignal()
         let allowCreateToReturn = AsyncSignal()
-        let retainCompleted = AsyncFlag()
         let transactionEncoder = StubTransactionEncoder(createdTransactions: createdTransactions) {
             await createStarted.signal()
             await allowCreateToReturn.wait()
@@ -97,22 +96,14 @@ final class BroadcasterTests: ZcashTestCase {
         }
         await createStarted.wait()
 
-        let retainTask = Task {
-            _ = await pendingSubmitPlanStore.loadTransactionsAndRetainSubmitPlans(
-                loadTransactions: { createdTransactions },
-                transactionId: { $0.rawID }
-            )
-            await retainCompleted.set()
-        }
-
-        try await Task.sleep(nanoseconds: 20_000_000)
-        let didRetainComplete = await retainCompleted.get()
-        XCTAssertFalse(didRetainComplete)
+        _ = await pendingSubmitPlanStore.loadTransactionsAndRetainSubmitPlans(
+            loadTransactions: { [ZcashTransaction.Overview]() },
+            transactionId: { $0.rawID }
+        )
 
         await allowCreateToReturn.signal()
 
         let transactions = try await createTask.value
-        await retainTask.value
         XCTAssertEqual(transactions.map(\.rawID), [rawID])
         switch await pendingSubmitPlanStore.getSubmitPlan(for: rawID) {
         case .awaitingPlan:

--- a/Tests/OfflineTests/BroadcasterTests.swift
+++ b/Tests/OfflineTests/BroadcasterTests.swift
@@ -30,7 +30,11 @@ final class BroadcasterTests: ZcashTestCase {
         let rawTransaction = Data([0x01, 0x02, 0x03, 0x04])
         let createdTransactions = [makeTransaction(raw: rawTransaction, rawID: Data(repeating: 0xAB, count: 32))]
         let transactionEncoder = StubTransactionEncoder(createdTransactions: createdTransactions)
-        let synchronizer = try makeSynchronizer(transactionEncoder: transactionEncoder)
+        let pendingSubmitPlanStore = PendingSubmitPlanStore(logger: NullLogger())
+        let synchronizer = try makeSynchronizer(
+            transactionEncoder: transactionEncoder,
+            pendingSubmitPlanStore: pendingSubmitPlanStore
+        )
 
         let foundTransactionsExpectation = XCTestExpectation(description: "found transactions event")
 
@@ -57,6 +61,12 @@ final class BroadcasterTests: ZcashTestCase {
         XCTAssertEqual(transactionEncoder.receivedCreateArguments?.spendingKey, spendingKey)
         XCTAssertEqual(transactions.map(\.rawID), createdTransactions.map(\.rawID))
         XCTAssertEqual(try transactions.map { try XCTUnwrap($0.raw) }, [rawTransaction])
+        switch await pendingSubmitPlanStore.getSubmitPlan(for: createdTransactions[0].rawID) {
+        case .awaitingPlan:
+            break
+        default:
+            XCTFail("Expected created broadcaster transaction to wait for a submit plan.")
+        }
 
         await fulfillment(of: [foundTransactionsExpectation], timeout: 1.0)
     }
@@ -86,9 +96,13 @@ final class BroadcasterTests: ZcashTestCase {
         let rawTransaction = Data([0x01, 0x02, 0x03, 0x04])
         let createdTransactions = [makeTransaction(raw: rawTransaction, rawID: Data(repeating: 0xAB, count: 32))]
         let transactionEncoder = StubTransactionEncoder(createdTransactions: createdTransactions)
+        let pendingSubmitPlanStore = PendingSubmitPlanStore(logger: NullLogger())
         let service = try RecordingCompactTxStreamerService(sendResponse: makeSendResponse(errorCode: 0, errorMessage: ""))
         defer { try? service.stop() }
-        let synchronizer = try makeSynchronizer(transactionEncoder: transactionEncoder)
+        let synchronizer = try makeSynchronizer(
+            transactionEncoder: transactionEncoder,
+            pendingSubmitPlanStore: pendingSubmitPlanStore
+        )
 
         await synchronizer.updateStatus(.stopped)
 
@@ -108,6 +122,15 @@ final class BroadcasterTests: ZcashTestCase {
         try await synchronizer.broadcaster.submit(raw, to: service.endpoint)
 
         XCTAssertEqual(service.recordedTransactions(), [rawTransaction])
+        switch await pendingSubmitPlanStore.getSubmitPlan(for: createdTransactions[0].rawID) {
+        case .ready(let plan):
+            XCTAssertEqual(plan.endpoints.count, 1)
+            XCTAssertEqual(plan.endpoints[0].host, service.endpoint.host)
+            XCTAssertEqual(plan.endpoints[0].port, service.endpoint.port)
+            XCTAssertEqual(plan.endpoints[0].secure, service.endpoint.secure)
+        default:
+            XCTFail("Expected submit endpoint to be registered for retry.")
+        }
     }
 
     func testBroadcasterThrowsWhenNotPrepared() async throws {
@@ -264,7 +287,8 @@ final class BroadcasterTests: ZcashTestCase {
 
     private func makeSynchronizer(
         transactionEncoder: TransactionEncoder,
-        rustBackend: ZcashRustBackendWelding? = nil
+        rustBackend: ZcashRustBackendWelding? = nil,
+        pendingSubmitPlanStore: PendingSubmitPlanStore = PendingSubmitPlanStore(logger: NullLogger())
     ) throws -> SDKSynchronizer {
         let serviceMock = LightWalletServiceMock()
         let transactionRepository = TransactionRepositoryMock()
@@ -274,6 +298,7 @@ final class BroadcasterTests: ZcashTestCase {
         }
         mockContainer.mock(type: LightWalletService.self, isSingleton: true) { _ in serviceMock }
         mockContainer.mock(type: TransactionRepository.self, isSingleton: true) { _ in transactionRepository }
+        mockContainer.mock(type: PendingSubmitPlanStore.self, isSingleton: true) { _ in pendingSubmitPlanStore }
 
         let initializer = Initializer(
             container: mockContainer,

--- a/Tests/OfflineTests/BroadcasterTests.swift
+++ b/Tests/OfflineTests/BroadcasterTests.swift
@@ -71,6 +71,57 @@ final class BroadcasterTests: ZcashTestCase {
         await fulfillment(of: [foundTransactionsExpectation], timeout: 1.0)
     }
 
+    func testCreateProposedTransactionsMarksPendingPlanBeforeStoreReadsProceed() async throws {
+        let rawID = Data(repeating: 0xAB, count: 32)
+        let createdTransactions = [makeTransaction(raw: Data([0x01, 0x02]), rawID: rawID)]
+        let createStarted = AsyncSignal()
+        let allowCreateToReturn = AsyncSignal()
+        let retainCompleted = AsyncFlag()
+        let transactionEncoder = StubTransactionEncoder(createdTransactions: createdTransactions) {
+            await createStarted.signal()
+            await allowCreateToReturn.wait()
+        }
+        let pendingSubmitPlanStore = PendingSubmitPlanStore(logger: NullLogger())
+        let synchronizer = try makeSynchronizer(
+            transactionEncoder: transactionEncoder,
+            pendingSubmitPlanStore: pendingSubmitPlanStore
+        )
+
+        await synchronizer.updateStatus(.stopped)
+
+        let createTask = Task {
+            try await synchronizer.broadcaster.createProposedTransactions(
+                proposal: Proposal.testOnlyFakeProposal(totalFee: 10),
+                spendingKey: TestsData(networkType: .testnet).spendingKey
+            )
+        }
+        await createStarted.wait()
+
+        let retainTask = Task {
+            _ = await pendingSubmitPlanStore.loadTransactionsAndRetainSubmitPlans(
+                loadTransactions: { createdTransactions },
+                transactionId: { $0.rawID }
+            )
+            await retainCompleted.set()
+        }
+
+        try await Task.sleep(nanoseconds: 20_000_000)
+        let didRetainComplete = await retainCompleted.get()
+        XCTAssertFalse(didRetainComplete)
+
+        await allowCreateToReturn.signal()
+
+        let transactions = try await createTask.value
+        await retainTask.value
+        XCTAssertEqual(transactions.map(\.rawID), [rawID])
+        switch await pendingSubmitPlanStore.getSubmitPlan(for: rawID) {
+        case .awaitingPlan:
+            break
+        default:
+            XCTFail("Expected created broadcaster transaction to wait for a submit plan.")
+        }
+    }
+
     // MARK: - submit
 
     func testSubmitSendsRawBytesToProvidedEndpoint() async throws {
@@ -149,7 +200,7 @@ final class BroadcasterTests: ZcashTestCase {
             transactionRepository: transactionRepository
         )
 
-        await pendingSubmitPlanStore.markAwaitingSubmitPlan([storedTransaction])
+        _ = await pendingSubmitPlanStore.createAndMarkAwaitingSubmitPlan { [storedTransaction] }
 
         try await synchronizer.broadcaster.submit(rawTransaction, to: service.endpoint)
 
@@ -425,12 +476,17 @@ final class BroadcasterTests: ZcashTestCase {
 
 private final class StubTransactionEncoder: TransactionEncoder {
     private let createdTransactions: [ZcashTransaction.Overview]
+    private let beforeReturningCreatedTransactions: () async -> Void
     private(set) var receivedCreateArguments: (proposal: Proposal, spendingKey: UnifiedSpendingKey)?
     private(set) var receivedFetchTxIds: [Data]?
     private(set) var submittedTransactions: [EncodedTransaction] = []
 
-    init(createdTransactions: [ZcashTransaction.Overview]) {
+    init(
+        createdTransactions: [ZcashTransaction.Overview],
+        beforeReturningCreatedTransactions: @escaping () async -> Void = {}
+    ) {
         self.createdTransactions = createdTransactions
+        self.beforeReturningCreatedTransactions = beforeReturningCreatedTransactions
     }
 
     func proposeTransfer(
@@ -456,6 +512,7 @@ private final class StubTransactionEncoder: TransactionEncoder {
         spendingKey: UnifiedSpendingKey
     ) async throws -> [ZcashTransaction.Overview] {
         receivedCreateArguments = (proposal, spendingKey)
+        await beforeReturningCreatedTransactions()
         return createdTransactions
     }
 
@@ -555,6 +612,39 @@ private final class LookupTransactionRepository: TransactionRepository, RawTrans
     func find(rawTransaction: Data) async throws -> ZcashTransaction.Overview {
         receivedRawTransactions.append(rawTransaction)
         return transaction
+    }
+}
+
+private actor AsyncSignal {
+    private var isSignaled = false
+    private var continuation: CheckedContinuation<Void, Never>?
+
+    func signal() {
+        isSignaled = true
+        continuation?.resume()
+        continuation = nil
+    }
+
+    func wait() async {
+        if isSignaled {
+            return
+        }
+
+        await withCheckedContinuation { continuation in
+            self.continuation = continuation
+        }
+    }
+}
+
+private actor AsyncFlag {
+    private var value = false
+
+    func set() {
+        value = true
+    }
+
+    func get() -> Bool {
+        value
     }
 }
 

--- a/Tests/OfflineTests/BroadcasterTests.swift
+++ b/Tests/OfflineTests/BroadcasterTests.swift
@@ -133,6 +133,39 @@ final class BroadcasterTests: ZcashTestCase {
         }
     }
 
+    func testSubmitUsesRawTransactionLookupWhenRawMappingIsNotInMemory() async throws {
+        let rawID = Data(repeating: 0xAB, count: 32)
+        let rawTransaction = Data([0x01, 0x02, 0x03, 0x04])
+        let pendingSubmitPlanStore = PendingSubmitPlanStore(logger: NullLogger())
+        let storedTransaction = makeTransaction(raw: nil, rawID: rawID)
+        let lookupTransaction = makeTransaction(raw: rawTransaction, rawID: rawID)
+        let transactionRepository = LookupTransactionRepository(transaction: lookupTransaction)
+        let transactionEncoder = StubTransactionEncoder(createdTransactions: [])
+        let service = try RecordingCompactTxStreamerService(sendResponse: makeSendResponse(errorCode: 0, errorMessage: ""))
+        defer { try? service.stop() }
+        let synchronizer = try makeSynchronizer(
+            transactionEncoder: transactionEncoder,
+            pendingSubmitPlanStore: pendingSubmitPlanStore,
+            transactionRepository: transactionRepository
+        )
+
+        await pendingSubmitPlanStore.markAwaitingSubmitPlan([storedTransaction])
+
+        try await synchronizer.broadcaster.submit(rawTransaction, to: service.endpoint)
+
+        XCTAssertEqual(transactionRepository.receivedRawTransactions, [rawTransaction])
+        XCTAssertEqual(service.recordedTransactions(), [rawTransaction])
+        switch await pendingSubmitPlanStore.getSubmitPlan(for: rawID) {
+        case .ready(let plan):
+            XCTAssertEqual(plan.endpoints.count, 1)
+            XCTAssertEqual(plan.endpoints[0].host, service.endpoint.host)
+            XCTAssertEqual(plan.endpoints[0].port, service.endpoint.port)
+            XCTAssertEqual(plan.endpoints[0].secure, service.endpoint.secure)
+        default:
+            XCTFail("Expected raw lookup path to register the endpoint for retry.")
+        }
+    }
+
     func testBroadcasterThrowsWhenNotPrepared() async throws {
         let transactionEncoder = StubTransactionEncoder(createdTransactions: [])
         let synchronizer = try makeSynchronizer(transactionEncoder: transactionEncoder)
@@ -288,10 +321,10 @@ final class BroadcasterTests: ZcashTestCase {
     private func makeSynchronizer(
         transactionEncoder: TransactionEncoder,
         rustBackend: ZcashRustBackendWelding? = nil,
-        pendingSubmitPlanStore: PendingSubmitPlanStore = PendingSubmitPlanStore(logger: NullLogger())
+        pendingSubmitPlanStore: PendingSubmitPlanStore = PendingSubmitPlanStore(logger: NullLogger()),
+        transactionRepository: TransactionRepository = TransactionRepositoryMock()
     ) throws -> SDKSynchronizer {
         let serviceMock = LightWalletServiceMock()
-        let transactionRepository = TransactionRepositoryMock()
 
         if let rustBackend {
             mockContainer.mock(type: ZcashRustBackendWelding.self, isSingleton: true) { _ in rustBackend }
@@ -331,7 +364,7 @@ final class BroadcasterTests: ZcashTestCase {
         )
     }
 
-    private func makeTransaction(raw: Data, rawID: Data) -> ZcashTransaction.Overview {
+    private func makeTransaction(raw: Data?, rawID: Data) -> ZcashTransaction.Overview {
         ZcashTransaction.Overview(
             accountUUID: TestsData.mockedAccountUUID,
             blockTime: nil,
@@ -445,6 +478,84 @@ private final class StubTransactionEncoder: TransactionEncoder {
     }
 
     func closeDBConnection() { }
+}
+
+private final class LookupTransactionRepository: TransactionRepository, RawTransactionLookup {
+    private let transaction: ZcashTransaction.Overview
+    private(set) var receivedRawTransactions: [Data] = []
+
+    init(transaction: ZcashTransaction.Overview) {
+        self.transaction = transaction
+    }
+
+    func closeDBConnection() { }
+
+    func countAll() async throws -> Int { fatalError("Unused in test") }
+
+    func countUnmined() async throws -> Int { fatalError("Unused in test") }
+
+    func isInitialized() async throws -> Bool { fatalError("Unused in test") }
+
+    func fetchTxidsWithMemoContaining(searchTerm: String) async throws -> [Data] {
+        fatalError("Unused in test")
+    }
+
+    func find(rawID: Data) async throws -> ZcashTransaction.Overview {
+        fatalError("Unused in test")
+    }
+
+    func find(offset: Int, limit: Int, kind: TransactionKind) async throws -> [ZcashTransaction.Overview] {
+        fatalError("Unused in test")
+    }
+
+    func find(in range: CompactBlockRange, limit: Int, kind: TransactionKind) async throws -> [ZcashTransaction.Overview] {
+        fatalError("Unused in test")
+    }
+
+    func find(from: ZcashTransaction.Overview, limit: Int, kind: TransactionKind) async throws -> [ZcashTransaction.Overview] {
+        fatalError("Unused in test")
+    }
+
+    func findPendingTransactions(latestHeight: BlockHeight, offset: Int, limit: Int) async throws -> [ZcashTransaction.Overview] {
+        fatalError("Unused in test")
+    }
+
+    func findReceived(offset: Int, limit: Int) async throws -> [ZcashTransaction.Overview] {
+        fatalError("Unused in test")
+    }
+
+    func findSent(offset: Int, limit: Int) async throws -> [ZcashTransaction.Overview] {
+        fatalError("Unused in test")
+    }
+
+    func findForResubmission(upTo: BlockHeight) async throws -> [ZcashTransaction.Overview] {
+        fatalError("Unused in test")
+    }
+
+    func findMemos(for rawID: Data) async throws -> [Memo] {
+        fatalError("Unused in test")
+    }
+
+    func findMemos(for transaction: ZcashTransaction.Overview) async throws -> [Memo] {
+        fatalError("Unused in test")
+    }
+
+    func getRecipients(for rawID: Data) async throws -> [TransactionRecipient] {
+        fatalError("Unused in test")
+    }
+
+    func getTransactionOutputs(for rawID: Data) async throws -> [ZcashTransaction.Output] {
+        fatalError("Unused in test")
+    }
+
+    func debugDatabase(sql: String) -> String {
+        fatalError("Unused in test")
+    }
+
+    func find(rawTransaction: Data) async throws -> ZcashTransaction.Overview {
+        receivedRawTransactions.append(rawTransaction)
+        return transaction
+    }
 }
 
 private final class RecordingCompactTxStreamerService: CompactTxStreamerProvider {

--- a/Tests/OfflineTests/BroadcasterTests.swift
+++ b/Tests/OfflineTests/BroadcasterTests.swift
@@ -208,6 +208,47 @@ final class BroadcasterTests: ZcashTestCase {
         }
     }
 
+    func testSubmitFallsBackToRawSubmissionWhenRawTransactionIsNotFound() async throws {
+        let rawTransaction = Data([0x01, 0x02, 0x03, 0x04])
+        let transactionRepository = LookupTransactionRepository(result: .failure(ZcashError.transactionRepositoryEntityNotFound))
+        let transactionEncoder = StubTransactionEncoder(createdTransactions: [])
+        let service = try RecordingCompactTxStreamerService(sendResponse: makeSendResponse(errorCode: 0, errorMessage: ""))
+        defer { try? service.stop() }
+        let synchronizer = try makeSynchronizer(
+            transactionEncoder: transactionEncoder,
+            transactionRepository: transactionRepository
+        )
+
+        try await synchronizer.broadcaster.submit(rawTransaction, to: service.endpoint)
+
+        XCTAssertEqual(transactionRepository.receivedRawTransactions, [rawTransaction])
+        XCTAssertEqual(service.recordedTransactions(), [rawTransaction])
+    }
+
+    func testSubmitPropagatesRawTransactionLookupErrors() async throws {
+        let rawTransaction = Data([0x01, 0x02, 0x03, 0x04])
+        let transactionRepository = LookupTransactionRepository(result: .failure(BroadcasterTestError.rawLookupFailed))
+        let transactionEncoder = StubTransactionEncoder(createdTransactions: [])
+        let service = try RecordingCompactTxStreamerService(sendResponse: makeSendResponse(errorCode: 0, errorMessage: ""))
+        defer { try? service.stop() }
+        let synchronizer = try makeSynchronizer(
+            transactionEncoder: transactionEncoder,
+            transactionRepository: transactionRepository
+        )
+
+        do {
+            try await synchronizer.broadcaster.submit(rawTransaction, to: service.endpoint)
+            XCTFail("Expected raw transaction lookup failure to be propagated.")
+        } catch BroadcasterTestError.rawLookupFailed {
+            // Expected.
+        } catch {
+            XCTFail("Expected rawLookupFailed but got \(error).")
+        }
+
+        XCTAssertEqual(transactionRepository.receivedRawTransactions, [rawTransaction])
+        XCTAssertEqual(service.recordedTransactions(), [])
+    }
+
     func testBroadcasterThrowsWhenNotPrepared() async throws {
         let transactionEncoder = StubTransactionEncoder(createdTransactions: [])
         let synchronizer = try makeSynchronizer(transactionEncoder: transactionEncoder)
@@ -465,6 +506,10 @@ final class BroadcasterTests: ZcashTestCase {
 
 // MARK: - Test Doubles
 
+private enum BroadcasterTestError: Error {
+    case rawLookupFailed
+}
+
 private final class StubTransactionEncoder: TransactionEncoder {
     private let createdTransactions: [ZcashTransaction.Overview]
     private let beforeReturningCreatedTransactions: () async -> Void
@@ -529,11 +574,15 @@ private final class StubTransactionEncoder: TransactionEncoder {
 }
 
 private final class LookupTransactionRepository: TransactionRepository, RawTransactionLookup {
-    private let transaction: ZcashTransaction.Overview
+    private let result: Result<ZcashTransaction.Overview, Error>
     private(set) var receivedRawTransactions: [Data] = []
 
     init(transaction: ZcashTransaction.Overview) {
-        self.transaction = transaction
+        result = .success(transaction)
+    }
+
+    init(result: Result<ZcashTransaction.Overview, Error>) {
+        self.result = result
     }
 
     func closeDBConnection() { }
@@ -602,7 +651,7 @@ private final class LookupTransactionRepository: TransactionRepository, RawTrans
 
     func find(rawTransaction: Data) async throws -> ZcashTransaction.Overview {
         receivedRawTransactions.append(rawTransaction)
-        return transaction
+        return try result.get()
     }
 }
 

--- a/Tests/OfflineTests/PendingSubmitPlanStoreTests.swift
+++ b/Tests/OfflineTests/PendingSubmitPlanStoreTests.swift
@@ -145,6 +145,205 @@ final class PendingSubmitPlanStoreTests: ZcashTestCase {
         XCTAssertNil(prunedPlan)
     }
 
+    func testRetainSkipsPruneWhenCreationCompletesDuringCandidateLookup() async throws {
+        let transaction = makeTransaction(rawID: Data(repeating: 0xAB, count: 32))
+        let store = PendingSubmitPlanStore(logger: NullLogger())
+        let lookupStarted = AsyncSignal()
+        let allowLookupToReturn = AsyncSignal()
+
+        let retainTask = Task {
+            await store.loadTransactionsAndRetainSubmitPlans(
+                loadTransactions: {
+                    await lookupStarted.signal()
+                    await allowLookupToReturn.wait()
+                    return [ZcashTransaction.Overview]()
+                },
+                transactionId: { $0.rawID }
+            )
+        }
+        await lookupStarted.wait()
+
+        await markAwaiting([transaction], in: store)
+        await allowLookupToReturn.signal()
+        _ = await retainTask.value
+
+        switch await store.getSubmitPlan(for: transaction.rawID) {
+        case .awaitingPlan:
+            break
+        default:
+            XCTFail("Expected submit plan created during candidate lookup to survive stale pruning.")
+        }
+    }
+
+    func testRetainSkipsPruneWhenCreationWasAlreadyActiveDuringCandidateLookup() async throws {
+        let existingTransaction = makeTransaction(rawID: Data(repeating: 0xAB, count: 32))
+        let store = PendingSubmitPlanStore(logger: NullLogger())
+        let creationStarted = AsyncSignal()
+        let allowCreationToReturn = AsyncSignal()
+        let lookupStarted = AsyncSignal()
+        let allowLookupToReturn = AsyncSignal()
+
+        await markAwaiting([existingTransaction], in: store)
+
+        let creationTask = Task {
+            await store.createAndMarkAwaitingSubmitPlan {
+                await creationStarted.signal()
+                await allowCreationToReturn.wait()
+                return []
+            }
+        }
+        await creationStarted.wait()
+
+        let retainTask = Task {
+            await store.loadTransactionsAndRetainSubmitPlans(
+                loadTransactions: {
+                    await lookupStarted.signal()
+                    await allowLookupToReturn.wait()
+                    return [ZcashTransaction.Overview]()
+                },
+                transactionId: { $0.rawID }
+            )
+        }
+        await lookupStarted.wait()
+
+        await allowCreationToReturn.signal()
+        _ = await creationTask.value
+        await allowLookupToReturn.signal()
+        _ = await retainTask.value
+
+        switch await store.getSubmitPlan(for: existingTransaction.rawID) {
+        case .awaitingPlan:
+            break
+        default:
+            XCTFail("Expected stale pruning to be skipped when lookup started during transaction creation.")
+        }
+    }
+
+    func testEndpointRegistrationDuringCandidateLookupInvalidatesPrune() async throws {
+        let transaction = makeTransaction(rawID: Data(repeating: 0xAB, count: 32))
+        let endpoint = LightWalletEndpoint(address: "submit.z.cash", port: 443, secure: true)
+        let store = PendingSubmitPlanStore(logger: NullLogger())
+        let lookupStarted = AsyncSignal()
+        let allowLookupToReturn = AsyncSignal()
+
+        let retainTask = Task {
+            await store.loadTransactionsAndRetainSubmitPlans(
+                loadTransactions: {
+                    await lookupStarted.signal()
+                    await allowLookupToReturn.wait()
+                    return [ZcashTransaction.Overview]()
+                },
+                transactionId: { $0.rawID }
+            )
+        }
+        await lookupStarted.wait()
+
+        await store.addSubmitEndpoint(transaction: transaction, endpoint: endpoint)
+        await allowLookupToReturn.signal()
+        _ = await retainTask.value
+
+        switch await store.getSubmitPlan(for: transaction.rawID) {
+        case .ready(let plan):
+            XCTAssertEqual(plan.endpoints.count, 1)
+            assertEndpoint(plan.endpoints[0], equals: endpoint)
+        default:
+            XCTFail("Expected endpoint registration during candidate lookup to invalidate stale pruning.")
+        }
+
+        await loadAndRetain([], in: store)
+        let planAfterCleanRetain = await store.getSubmitPlan(for: transaction.rawID)
+        XCTAssertNil(planAfterCleanRetain)
+    }
+
+    func testOverlappingRetainsDoNotBothPruneFromStaleSnapshots() async throws {
+        let firstTransaction = makeTransaction(rawID: Data(repeating: 0xAB, count: 32))
+        let secondTransaction = makeTransaction(rawID: Data(repeating: 0xCD, count: 32))
+        let store = PendingSubmitPlanStore(logger: NullLogger())
+        let firstLookupStarted = AsyncSignal()
+        let secondLookupStarted = AsyncSignal()
+        let allowFirstLookupToReturn = AsyncSignal()
+        let allowSecondLookupToReturn = AsyncSignal()
+
+        await markAwaiting([firstTransaction, secondTransaction], in: store)
+
+        let firstRetainTask = Task {
+            await store.loadTransactionsAndRetainSubmitPlans(
+                loadTransactions: {
+                    await firstLookupStarted.signal()
+                    await allowFirstLookupToReturn.wait()
+                    return [firstTransaction]
+                },
+                transactionId: { $0.rawID }
+            )
+        }
+        let secondRetainTask = Task {
+            await store.loadTransactionsAndRetainSubmitPlans(
+                loadTransactions: {
+                    await secondLookupStarted.signal()
+                    await allowSecondLookupToReturn.wait()
+                    return [secondTransaction]
+                },
+                transactionId: { $0.rawID }
+            )
+        }
+        await firstLookupStarted.wait()
+        await secondLookupStarted.wait()
+
+        await allowFirstLookupToReturn.signal()
+        _ = await firstRetainTask.value
+        await allowSecondLookupToReturn.signal()
+        _ = await secondRetainTask.value
+
+        let firstPlan = await store.getSubmitPlan(for: firstTransaction.rawID)
+        let secondPlan = await store.getSubmitPlan(for: secondTransaction.rawID)
+        XCTAssertNotNil(firstPlan)
+        XCTAssertNil(secondPlan)
+    }
+
+    func testThrowingCreationDoesNotSuppressFuturePruning() async throws {
+        let staleTransaction = makeTransaction(rawID: Data(repeating: 0xAB, count: 32))
+        let store = PendingSubmitPlanStore(logger: NullLogger())
+
+        await markAwaiting([staleTransaction], in: store)
+
+        do {
+            _ = try await store.createAndMarkAwaitingSubmitPlan {
+                throw CancellationError()
+            }
+            XCTFail("Expected transaction creation to throw.")
+        } catch is CancellationError {
+            // Expected.
+        }
+
+        await loadAndRetain([], in: store)
+
+        let plan = await store.getSubmitPlan(for: staleTransaction.rawID)
+        XCTAssertNil(plan)
+    }
+
+    func testClearDuringCreationPreventsPlanFromBeingRecorded() async throws {
+        let transaction = makeTransaction(rawID: Data(repeating: 0xAB, count: 32))
+        let store = PendingSubmitPlanStore(logger: NullLogger())
+        let creationStarted = AsyncSignal()
+        let allowCreationToReturn = AsyncSignal()
+
+        let creationTask = Task {
+            await store.createAndMarkAwaitingSubmitPlan {
+                await creationStarted.signal()
+                await allowCreationToReturn.wait()
+                return [transaction]
+            }
+        }
+        await creationStarted.wait()
+
+        await store.clear()
+        await allowCreationToReturn.signal()
+        _ = await creationTask.value
+
+        let plan = await store.getSubmitPlan(for: transaction.rawID)
+        XCTAssertNil(plan)
+    }
+
     func testTxResubmissionSkipsTransactionsAwaitingSubmitPlan() async throws {
         let awaitingTransaction = makeTransaction(rawID: Data(repeating: 0xAB, count: 32))
         let legacyTransaction = makeTransaction(rawID: Data(repeating: 0xCD, count: 32))
@@ -212,18 +411,12 @@ final class PendingSubmitPlanStoreTests: ZcashTestCase {
         let transactionEncoder = RecordingTransactionEncoder()
         let store = PendingSubmitPlanStore(logger: NullLogger())
         let submitter = RecordingTransactionSubmitter()
-        let createCompleted = AsyncFlag()
-        var createTask: Task<Void, Never>?
+        let lookupStarted = AsyncSignal()
+        let allowLookupToReturn = AsyncSignal()
 
         transactionRepository.findForResubmissionUpToClosure = { _ in
-            createTask = Task {
-                await self.markAwaiting([createdTransaction], in: store)
-                await createCompleted.set()
-            }
-
-            try await Task.sleep(nanoseconds: 20_000_000)
-            let didCreateComplete = await createCompleted.get()
-            XCTAssertFalse(didCreateComplete)
+            await lookupStarted.signal()
+            await allowLookupToReturn.wait()
             return []
         }
 
@@ -237,13 +430,14 @@ final class PendingSubmitPlanStoreTests: ZcashTestCase {
 
         let action = TxResubmissionAction(container: mockContainer)
         action.latestResolvedTime = 0
-        _ = try await action.run(with: resubmissionContext()) { _ in }
-
-        guard let createTask else {
-            XCTFail("Expected test to start concurrent transaction creation.")
-            return
+        let actionTask = Task {
+            try await action.run(with: resubmissionContext()) { _ in }
         }
-        await createTask.value
+        await lookupStarted.wait()
+
+        await markAwaiting([createdTransaction], in: store)
+        await allowLookupToReturn.signal()
+        _ = try await actionTask.value
 
         switch await store.getSubmitPlan(for: createdTransaction.rawID) {
         case .awaitingPlan:
@@ -355,6 +549,30 @@ private final class InMemorySubmitPlanPersistence: PendingSubmitPlanPersistence 
 
 private enum SubmitPlanPersistenceTestError: Error {
     case loadFailed
+}
+
+private actor AsyncSignal {
+    private var isSignaled = false
+    private var continuations: [CheckedContinuation<Void, Never>] = []
+
+    func signal() {
+        guard !isSignaled else { return }
+
+        isSignaled = true
+        let continuations = self.continuations
+        self.continuations = []
+        continuations.forEach { $0.resume() }
+    }
+
+    func wait() async {
+        if isSignaled {
+            return
+        }
+
+        await withCheckedContinuation { continuation in
+            continuations.append(continuation)
+        }
+    }
 }
 
 private final class RecordingTransactionEncoder: TransactionEncoder {

--- a/Tests/OfflineTests/PendingSubmitPlanStoreTests.swift
+++ b/Tests/OfflineTests/PendingSubmitPlanStoreTests.swift
@@ -1,0 +1,282 @@
+//
+//  PendingSubmitPlanStoreTests.swift
+//  ZcashLightClientKitTests
+//
+
+import XCTest
+@testable import TestUtils
+@testable import ZcashLightClientKit
+
+final class PendingSubmitPlanStoreTests: ZcashTestCase {
+    func testCreatedTransactionsWaitForSubmitPlan() async throws {
+        let transaction = makeTransaction(rawID: Data(repeating: 0xAB, count: 32))
+        let store = PendingSubmitPlanStore(logger: NullLogger())
+
+        await store.markAwaitingSubmitPlan([transaction])
+
+        switch await store.getSubmitPlan(for: transaction.rawID) {
+        case .awaitingPlan:
+            break
+        default:
+            XCTFail("Expected transaction to wait for a submit plan.")
+        }
+    }
+
+    func testPersistsSubmitPlans() async throws {
+        let persistence = InMemorySubmitPlanPersistence()
+        let transaction = makeTransaction(rawID: Data(repeating: 0xAB, count: 32))
+        let endpoint = LightWalletEndpointBuilder.default
+        let firstStore = PendingSubmitPlanStore(persistence: persistence, logger: NullLogger())
+
+        await firstStore.markAwaitingSubmitPlan([transaction])
+        await firstStore.addSubmitEndpoint(transaction: transaction, endpoint: endpoint)
+
+        let secondStore = PendingSubmitPlanStore(persistence: persistence, logger: NullLogger())
+        switch await secondStore.getSubmitPlan(for: transaction.rawID) {
+        case .ready(let plan):
+            XCTAssertEqual(plan.endpoints.count, 1)
+            assertEndpoint(plan.endpoints[0], equals: endpoint)
+        default:
+            XCTFail("Expected persisted submit plan.")
+        }
+    }
+
+    func testAddsSubmittedEndpointsToExistingPlan() async throws {
+        let transaction = makeTransaction(rawID: Data(repeating: 0xAB, count: 32))
+        let firstEndpoint = LightWalletEndpoint(address: "a.z.cash", port: 443, secure: true)
+        let secondEndpoint = LightWalletEndpoint(address: "b.z.cash", port: 443, secure: true)
+        let store = PendingSubmitPlanStore(logger: NullLogger())
+
+        await store.markAwaitingSubmitPlan([transaction])
+        await store.addSubmitEndpoint(transaction: transaction, endpoint: firstEndpoint)
+        await store.addSubmitEndpoint(transaction: transaction, endpoint: secondEndpoint)
+
+        switch await store.getSubmitPlan(for: transaction.rawID) {
+        case .ready(let plan):
+            XCTAssertEqual(plan.endpoints.count, 2)
+            assertEndpoint(plan.endpoints[0], equals: firstEndpoint)
+            assertEndpoint(plan.endpoints[1], equals: secondEndpoint)
+        default:
+            XCTFail("Expected submit plan with both endpoints.")
+        }
+    }
+
+    func testPrunesPlansThatAreNoLongerResubmissionCandidates() async throws {
+        let persistence = InMemorySubmitPlanPersistence()
+        let retainedTransaction = makeTransaction(rawID: Data(repeating: 0xAB, count: 32))
+        let prunedTransaction = makeTransaction(rawID: Data(repeating: 0xCD, count: 32))
+        let store = PendingSubmitPlanStore(persistence: persistence, logger: NullLogger())
+
+        await store.markAwaitingSubmitPlan([retainedTransaction, prunedTransaction])
+        await store.addSubmitEndpoint(transaction: retainedTransaction, endpoint: LightWalletEndpointBuilder.default)
+        await store.addSubmitEndpoint(transaction: prunedTransaction, endpoint: LightWalletEndpointBuilder.eccTestnet)
+        await store.retainPlans(for: [retainedTransaction.rawID])
+
+        let reloadedStore = PendingSubmitPlanStore(persistence: persistence, logger: NullLogger())
+        let retainedPlan = await reloadedStore.getSubmitPlan(for: retainedTransaction.rawID)
+        let prunedPlan = await reloadedStore.getSubmitPlan(for: prunedTransaction.rawID)
+        XCTAssertNotNil(retainedPlan)
+        XCTAssertNil(prunedPlan)
+    }
+
+    func testTxResubmissionSkipsTransactionsAwaitingSubmitPlan() async throws {
+        let awaitingTransaction = makeTransaction(rawID: Data(repeating: 0xAB, count: 32))
+        let legacyTransaction = makeTransaction(rawID: Data(repeating: 0xCD, count: 32))
+        let transactionRepository = TransactionRepositoryMock()
+        let transactionEncoder = RecordingTransactionEncoder()
+        let store = PendingSubmitPlanStore(logger: NullLogger())
+        let submitter = RecordingTransactionSubmitter()
+
+        transactionRepository.findForResubmissionUpToReturnValue = [
+            awaitingTransaction,
+            legacyTransaction
+        ]
+
+        mockContainer.mock(type: TransactionRepository.self, isSingleton: true) { _ in transactionRepository }
+        mockContainer.mock(type: TransactionEncoder.self, isSingleton: true) { _ in transactionEncoder }
+        mockContainer.mock(type: PendingSubmitPlanStore.self, isSingleton: true) { _ in store }
+        mockContainer.mock(type: SubmitPlanExecutor.self, isSingleton: true) { _ in
+            SubmitPlanExecutor(transactionSubmitter: submitter)
+        }
+        mockContainer.mock(type: Logger.self, isSingleton: true) { _ in NullLogger() }
+
+        await store.markAwaitingSubmitPlan([awaitingTransaction])
+
+        let action = TxResubmissionAction(container: mockContainer)
+        action.latestResolvedTime = 0
+        _ = try await action.run(with: resubmissionContext()) { _ in }
+
+        XCTAssertEqual(transactionEncoder.submittedTransactions.map(\.transactionId), [legacyTransaction.rawID])
+        XCTAssertTrue(submitter.submissions.isEmpty)
+    }
+
+    func testTxResubmissionUsesRegisteredSubmitPlan() async throws {
+        let transaction = makeTransaction(rawID: Data(repeating: 0xAB, count: 32))
+        let endpoint = LightWalletEndpoint(address: "submit.z.cash", port: 443, secure: true)
+        let transactionRepository = TransactionRepositoryMock()
+        let transactionEncoder = RecordingTransactionEncoder()
+        let store = PendingSubmitPlanStore(logger: NullLogger())
+        let submitter = RecordingTransactionSubmitter()
+
+        transactionRepository.findForResubmissionUpToReturnValue = [transaction]
+
+        mockContainer.mock(type: TransactionRepository.self, isSingleton: true) { _ in transactionRepository }
+        mockContainer.mock(type: TransactionEncoder.self, isSingleton: true) { _ in transactionEncoder }
+        mockContainer.mock(type: PendingSubmitPlanStore.self, isSingleton: true) { _ in store }
+        mockContainer.mock(type: SubmitPlanExecutor.self, isSingleton: true) { _ in
+            SubmitPlanExecutor(transactionSubmitter: submitter)
+        }
+        mockContainer.mock(type: Logger.self, isSingleton: true) { _ in NullLogger() }
+
+        await store.markAwaitingSubmitPlan([transaction])
+        await store.addSubmitEndpoint(transaction: transaction, endpoint: endpoint)
+
+        let action = TxResubmissionAction(container: mockContainer)
+        action.latestResolvedTime = 0
+        _ = try await action.run(with: resubmissionContext()) { _ in }
+
+        XCTAssertTrue(transactionEncoder.submittedTransactions.isEmpty)
+        XCTAssertEqual(submitter.submissions.map(\.transaction.transactionId), [transaction.rawID])
+        assertEndpoint(try XCTUnwrap(submitter.submissions.first?.endpoint), equals: endpoint)
+    }
+
+    private func resubmissionContext() -> ActionContextMock {
+        let context = ActionContextMock.default()
+        context.underlyingSyncControlData = SyncControlData(
+            latestBlockHeight: 1000,
+            latestScannedHeight: nil,
+            firstUnenhancedHeight: nil
+        )
+        return context
+    }
+
+    private func makeTransaction(rawID: Data) -> ZcashTransaction.Overview {
+        ZcashTransaction.Overview(
+            accountUUID: TestsData.mockedAccountUUID,
+            blockTime: nil,
+            expiryHeight: 123_456,
+            fee: Zatoshi(10_000),
+            index: 0,
+            isShielding: false,
+            hasChange: false,
+            memoCount: 0,
+            minedHeight: nil,
+            raw: Data([0x01, 0x02]),
+            rawID: rawID,
+            receivedNoteCount: 0,
+            sentNoteCount: 1,
+            value: Zatoshi(-1_000),
+            isExpiredUmined: false,
+            totalSpent: nil,
+            totalReceived: nil
+        )
+    }
+
+    private func assertEndpoint(
+        _ actual: LightWalletEndpoint,
+        equals expected: LightWalletEndpoint,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) {
+        XCTAssertEqual(actual.host, expected.host, file: file, line: line)
+        XCTAssertEqual(actual.port, expected.port, file: file, line: line)
+        XCTAssertEqual(actual.secure, expected.secure, file: file, line: line)
+        XCTAssertEqual(
+            actual.singleCallTimeoutInMillis,
+            expected.singleCallTimeoutInMillis,
+            file: file,
+            line: line
+        )
+        XCTAssertEqual(
+            actual.streamingCallTimeoutInMillis,
+            expected.streamingCallTimeoutInMillis,
+            file: file,
+            line: line
+        )
+    }
+}
+
+private final class InMemorySubmitPlanPersistence: PendingSubmitPlanPersistence {
+    var data: Data?
+
+    func load() throws -> Data? {
+        data
+    }
+
+    func save(_ data: Data) throws {
+        self.data = data
+    }
+
+    func clear() throws {
+        data = nil
+    }
+}
+
+private final class RecordingTransactionEncoder: TransactionEncoder {
+    private(set) var submittedTransactions: [EncodedTransaction] = []
+
+    func proposeTransfer(
+        accountUUID: AccountUUID,
+        recipient: String,
+        amount: Zatoshi,
+        memoBytes: MemoBytes?
+    ) async throws -> Proposal {
+        fatalError("Unused in test")
+    }
+
+    func proposeShielding(
+        accountUUID: AccountUUID,
+        shieldingThreshold: Zatoshi,
+        memoBytes: MemoBytes?,
+        transparentReceiver: String?
+    ) async throws -> Proposal? {
+        fatalError("Unused in test")
+    }
+
+    func createProposedTransactions(
+        proposal: Proposal,
+        spendingKey: UnifiedSpendingKey
+    ) async throws -> [ZcashTransaction.Overview] {
+        fatalError("Unused in test")
+    }
+
+    func proposeFulfillingPaymentFromURI(
+        _ uri: String,
+        accountUUID: AccountUUID
+    ) async throws -> Proposal {
+        fatalError("Unused in test")
+    }
+
+    func submit(transaction: EncodedTransaction) async throws {
+        submittedTransactions.append(transaction)
+    }
+
+    func fetchTransactionsForTxIds(_ txIds: [Data]) async throws -> [ZcashTransaction.Overview] {
+        fatalError("Unused in test")
+    }
+
+    func closeDBConnection() { }
+}
+
+private final class RecordingTransactionSubmitter: TransactionSubmitter {
+    struct Submission {
+        let transaction: EncodedTransaction
+        let endpoint: LightWalletEndpoint
+    }
+
+    private(set) var submissions: [Submission] = []
+
+    func submit(
+        rawTransaction: Data,
+        to endpoint: LightWalletEndpoint
+    ) async throws {
+        fatalError("Unused in test")
+    }
+
+    func submit(
+        transaction: EncodedTransaction,
+        to endpoint: LightWalletEndpoint
+    ) async throws {
+        submissions.append(Submission(transaction: transaction, endpoint: endpoint))
+    }
+}

--- a/Tests/OfflineTests/PendingSubmitPlanStoreTests.swift
+++ b/Tests/OfflineTests/PendingSubmitPlanStoreTests.swift
@@ -162,7 +162,7 @@ final class PendingSubmitPlanStoreTests: ZcashTestCase {
         mockContainer.mock(type: TransactionEncoder.self, isSingleton: true) { _ in transactionEncoder }
         mockContainer.mock(type: PendingSubmitPlanStore.self, isSingleton: true) { _ in store }
         mockContainer.mock(type: SubmitPlanExecutor.self, isSingleton: true) { _ in
-            SubmitPlanExecutor(transactionSubmitter: submitter)
+            SubmitPlanExecutor(transactionSubmitter: submitter, logger: NullLogger())
         }
         mockContainer.mock(type: Logger.self, isSingleton: true) { _ in NullLogger() }
 
@@ -190,7 +190,7 @@ final class PendingSubmitPlanStoreTests: ZcashTestCase {
         mockContainer.mock(type: TransactionEncoder.self, isSingleton: true) { _ in transactionEncoder }
         mockContainer.mock(type: PendingSubmitPlanStore.self, isSingleton: true) { _ in store }
         mockContainer.mock(type: SubmitPlanExecutor.self, isSingleton: true) { _ in
-            SubmitPlanExecutor(transactionSubmitter: submitter)
+            SubmitPlanExecutor(transactionSubmitter: submitter, logger: NullLogger())
         }
         mockContainer.mock(type: Logger.self, isSingleton: true) { _ in NullLogger() }
 
@@ -231,7 +231,7 @@ final class PendingSubmitPlanStoreTests: ZcashTestCase {
         mockContainer.mock(type: TransactionEncoder.self, isSingleton: true) { _ in transactionEncoder }
         mockContainer.mock(type: PendingSubmitPlanStore.self, isSingleton: true) { _ in store }
         mockContainer.mock(type: SubmitPlanExecutor.self, isSingleton: true) { _ in
-            SubmitPlanExecutor(transactionSubmitter: submitter)
+            SubmitPlanExecutor(transactionSubmitter: submitter, logger: NullLogger())
         }
         mockContainer.mock(type: Logger.self, isSingleton: true) { _ in NullLogger() }
 

--- a/Tests/OfflineTests/PendingSubmitPlanStoreTests.swift
+++ b/Tests/OfflineTests/PendingSubmitPlanStoreTests.swift
@@ -119,6 +119,36 @@ final class PendingSubmitPlanStoreTests: ZcashTestCase {
         }
     }
 
+    func testRawEndpointRegistrationDuringCreationIsPreserved() async throws {
+        let rawTransaction = Data([0x01, 0x02])
+        let transaction = makeTransaction(rawID: Data(repeating: 0xAB, count: 32), raw: rawTransaction)
+        let endpoint = LightWalletEndpoint(address: "submit.z.cash", port: 443, secure: true)
+        let store = PendingSubmitPlanStore(logger: NullLogger())
+        let creationStarted = AsyncSignal()
+        let allowCreationToReturn = AsyncSignal()
+
+        let creationTask = Task {
+            await store.createAndMarkAwaitingSubmitPlan {
+                await creationStarted.signal()
+                await allowCreationToReturn.wait()
+                return [transaction]
+            }
+        }
+        await creationStarted.wait()
+
+        await store.addSubmitEndpoint(rawTransaction: rawTransaction, endpoint: endpoint)
+        await allowCreationToReturn.signal()
+        _ = await creationTask.value
+
+        switch await store.getSubmitPlan(for: transaction.rawID) {
+        case .ready(let plan):
+            XCTAssertEqual(plan.endpoints.count, 1)
+            assertEndpoint(plan.endpoints[0], equals: endpoint)
+        default:
+            XCTFail("Expected raw endpoint registration during creation to be preserved.")
+        }
+    }
+
     func testPrunesPlansThatAreNoLongerResubmissionCandidates() async throws {
         let persistence = InMemorySubmitPlanPersistence()
         let prunedRawTransaction = Data([0x03, 0x04])

--- a/Tests/OfflineTests/PendingSubmitPlanStoreTests.swift
+++ b/Tests/OfflineTests/PendingSubmitPlanStoreTests.swift
@@ -81,14 +81,22 @@ final class PendingSubmitPlanStoreTests: ZcashTestCase {
 
     func testPrunesPlansThatAreNoLongerResubmissionCandidates() async throws {
         let persistence = InMemorySubmitPlanPersistence()
-        let retainedTransaction = makeTransaction(rawID: Data(repeating: 0xAB, count: 32))
-        let prunedTransaction = makeTransaction(rawID: Data(repeating: 0xCD, count: 32))
+        let prunedRawTransaction = Data([0x03, 0x04])
+        let retainedTransaction = makeTransaction(
+            rawID: Data(repeating: 0xAB, count: 32),
+            raw: Data([0x01, 0x02])
+        )
+        let prunedTransaction = makeTransaction(
+            rawID: Data(repeating: 0xCD, count: 32),
+            raw: prunedRawTransaction
+        )
         let store = PendingSubmitPlanStore(persistence: persistence, logger: NullLogger())
 
         await store.markAwaitingSubmitPlan([retainedTransaction, prunedTransaction])
         await store.addSubmitEndpoint(transaction: retainedTransaction, endpoint: LightWalletEndpointBuilder.default)
         await store.addSubmitEndpoint(transaction: prunedTransaction, endpoint: LightWalletEndpointBuilder.eccTestnet)
         await store.retainPlans(for: [retainedTransaction.rawID])
+        await store.addSubmitEndpoint(rawTransaction: prunedRawTransaction, endpoint: LightWalletEndpointBuilder.eccTestnet)
 
         let reloadedStore = PendingSubmitPlanStore(persistence: persistence, logger: NullLogger())
         let retainedPlan = await reloadedStore.getSubmitPlan(for: retainedTransaction.rawID)

--- a/Tests/OfflineTests/PendingSubmitPlanStoreTests.swift
+++ b/Tests/OfflineTests/PendingSubmitPlanStoreTests.swift
@@ -61,6 +61,24 @@ final class PendingSubmitPlanStoreTests: ZcashTestCase {
         }
     }
 
+    func testAddsSubmittedEndpointByRawTransaction() async throws {
+        let rawTransaction = Data([0x01, 0x02])
+        let transaction = makeTransaction(rawID: Data(repeating: 0xAB, count: 32), raw: rawTransaction)
+        let endpoint = LightWalletEndpoint(address: "submit.z.cash", port: 443, secure: true)
+        let store = PendingSubmitPlanStore(logger: NullLogger())
+
+        await store.markAwaitingSubmitPlan([transaction])
+        await store.addSubmitEndpoint(rawTransaction: rawTransaction, endpoint: endpoint)
+
+        switch await store.getSubmitPlan(for: transaction.rawID) {
+        case .ready(let plan):
+            XCTAssertEqual(plan.endpoints.count, 1)
+            assertEndpoint(plan.endpoints[0], equals: endpoint)
+        default:
+            XCTFail("Expected raw transaction submit path to register the endpoint.")
+        }
+    }
+
     func testPrunesPlansThatAreNoLongerResubmissionCandidates() async throws {
         let persistence = InMemorySubmitPlanPersistence()
         let retainedTransaction = makeTransaction(rawID: Data(repeating: 0xAB, count: 32))
@@ -150,7 +168,10 @@ final class PendingSubmitPlanStoreTests: ZcashTestCase {
         return context
     }
 
-    private func makeTransaction(rawID: Data) -> ZcashTransaction.Overview {
+    private func makeTransaction(
+        rawID: Data,
+        raw: Data = Data([0x01, 0x02])
+    ) -> ZcashTransaction.Overview {
         ZcashTransaction.Overview(
             accountUUID: TestsData.mockedAccountUUID,
             blockTime: nil,
@@ -161,7 +182,7 @@ final class PendingSubmitPlanStoreTests: ZcashTestCase {
             hasChange: false,
             memoCount: 0,
             minedHeight: nil,
-            raw: Data([0x01, 0x02]),
+            raw: raw,
             rawID: rawID,
             receivedNoteCount: 0,
             sentNoteCount: 1,

--- a/Tests/OfflineTests/PendingSubmitPlanStoreTests.swift
+++ b/Tests/OfflineTests/PendingSubmitPlanStoreTests.swift
@@ -41,6 +41,32 @@ final class PendingSubmitPlanStoreTests: ZcashTestCase {
         }
     }
 
+    func testIgnoresPersistedSubmitPlansWithUnsupportedVersion() async throws {
+        let persistence = InMemorySubmitPlanPersistence()
+        let transaction = makeTransaction(rawID: Data(repeating: 0xAB, count: 32))
+        persistence.data = """
+        {
+            "version": 2,
+            "plansByTransactionId": {
+                "\(transaction.rawID.hexEncodedString())": [
+                    {
+                        "host": "submit.z.cash",
+                        "port": 443,
+                        "secure": true,
+                        "singleCallTimeoutInMillis": 1000,
+                        "streamingCallTimeoutInMillis": 2000
+                    }
+                ]
+            }
+        }
+        """.data(using: .utf8)
+
+        let store = PendingSubmitPlanStore(persistence: persistence, logger: NullLogger())
+        let plan = await store.getSubmitPlan(for: transaction.rawID)
+
+        XCTAssertNil(plan)
+    }
+
     func testAddsSubmittedEndpointsToExistingPlan() async throws {
         let transaction = makeTransaction(rawID: Data(repeating: 0xAB, count: 32))
         let firstEndpoint = LightWalletEndpoint(address: "a.z.cash", port: 443, secure: true)

--- a/Tests/OfflineTests/PendingSubmitPlanStoreTests.swift
+++ b/Tests/OfflineTests/PendingSubmitPlanStoreTests.swift
@@ -81,6 +81,45 @@ final class PendingSubmitPlanStoreTests: ZcashTestCase {
         XCTAssertEqual(persistence.data, originalData)
     }
 
+    func testPersistsMergedInMemoryPlansAfterLoadRecovery() async throws {
+        let persistence = InMemorySubmitPlanPersistence()
+        let persistedTransaction = makeTransaction(rawID: Data(repeating: 0xAB, count: 32))
+        let recoveredTransaction = makeTransaction(rawID: Data(repeating: 0xCD, count: 32))
+        let persistedEndpoint = LightWalletEndpoint(address: "persisted.z.cash", port: 443, secure: true)
+        let recoveredEndpoint = LightWalletEndpoint(address: "recovered.z.cash", port: 443, secure: true)
+        let initialStore = PendingSubmitPlanStore(persistence: persistence, logger: NullLogger())
+
+        await markAwaiting([persistedTransaction], in: initialStore)
+        await initialStore.addSubmitEndpoint(transaction: persistedTransaction, endpoint: persistedEndpoint)
+        let saveCallCountAfterInitialStore = persistence.saveCallCount
+
+        persistence.loadError = SubmitPlanPersistenceTestError.loadFailed
+        let recoveryStore = PendingSubmitPlanStore(persistence: persistence, logger: NullLogger())
+        await markAwaiting([recoveredTransaction], in: recoveryStore)
+        await recoveryStore.addSubmitEndpoint(transaction: recoveredTransaction, endpoint: recoveredEndpoint)
+        XCTAssertEqual(persistence.saveCallCount, saveCallCountAfterInitialStore)
+
+        persistence.loadError = nil
+        _ = await recoveryStore.getSubmitPlan(for: persistedTransaction.rawID)
+
+        XCTAssertEqual(persistence.saveCallCount, saveCallCountAfterInitialStore + 1)
+        let reloadedStore = PendingSubmitPlanStore(persistence: persistence, logger: NullLogger())
+        switch await reloadedStore.getSubmitPlan(for: persistedTransaction.rawID) {
+        case .ready(let plan):
+            XCTAssertEqual(plan.endpoints.count, 1)
+            assertEndpoint(plan.endpoints[0], equals: persistedEndpoint)
+        default:
+            XCTFail("Expected persisted submit plan to survive load recovery.")
+        }
+        switch await reloadedStore.getSubmitPlan(for: recoveredTransaction.rawID) {
+        case .ready(let plan):
+            XCTAssertEqual(plan.endpoints.count, 1)
+            assertEndpoint(plan.endpoints[0], equals: recoveredEndpoint)
+        default:
+            XCTFail("Expected recovered in-memory submit plan to be persisted after load recovery.")
+        }
+    }
+
     func testAddsSubmittedEndpointsToExistingPlan() async throws {
         let transaction = makeTransaction(rawID: Data(repeating: 0xAB, count: 32))
         let firstEndpoint = LightWalletEndpoint(address: "a.z.cash", port: 443, secure: true)

--- a/Tests/OfflineTests/PendingSubmitPlanStoreTests.swift
+++ b/Tests/OfflineTests/PendingSubmitPlanStoreTests.swift
@@ -67,6 +67,20 @@ final class PendingSubmitPlanStoreTests: ZcashTestCase {
         XCTAssertNil(plan)
     }
 
+    func testDoesNotOverwritePersistedSubmitPlansWhenLoadFails() async throws {
+        let persistence = InMemorySubmitPlanPersistence()
+        let originalData = Data("persisted submit plans".utf8)
+        let transaction = makeTransaction(rawID: Data(repeating: 0xAB, count: 32))
+        persistence.data = originalData
+        persistence.loadError = SubmitPlanPersistenceTestError.loadFailed
+        let store = PendingSubmitPlanStore(persistence: persistence, logger: NullLogger())
+
+        await markAwaiting([transaction], in: store)
+
+        XCTAssertEqual(persistence.saveCallCount, 0)
+        XCTAssertEqual(persistence.data, originalData)
+    }
+
     func testAddsSubmittedEndpointsToExistingPlan() async throws {
         let transaction = makeTransaction(rawID: Data(repeating: 0xAB, count: 32))
         let firstEndpoint = LightWalletEndpoint(address: "a.z.cash", port: 443, secure: true)
@@ -319,18 +333,28 @@ final class PendingSubmitPlanStoreTests: ZcashTestCase {
 
 private final class InMemorySubmitPlanPersistence: PendingSubmitPlanPersistence {
     var data: Data?
+    var loadError: Error?
+    private(set) var saveCallCount = 0
 
     func load() throws -> Data? {
-        data
+        if let loadError {
+            throw loadError
+        }
+        return data
     }
 
     func save(_ data: Data) throws {
+        saveCallCount += 1
         self.data = data
     }
 
     func clear() throws {
         data = nil
     }
+}
+
+private enum SubmitPlanPersistenceTestError: Error {
+    case loadFailed
 }
 
 private final class RecordingTransactionEncoder: TransactionEncoder {

--- a/Tests/OfflineTests/PendingSubmitPlanStoreTests.swift
+++ b/Tests/OfflineTests/PendingSubmitPlanStoreTests.swift
@@ -12,7 +12,7 @@ final class PendingSubmitPlanStoreTests: ZcashTestCase {
         let transaction = makeTransaction(rawID: Data(repeating: 0xAB, count: 32))
         let store = PendingSubmitPlanStore(logger: NullLogger())
 
-        await store.markAwaitingSubmitPlan([transaction])
+        await markAwaiting([transaction], in: store)
 
         switch await store.getSubmitPlan(for: transaction.rawID) {
         case .awaitingPlan:
@@ -28,7 +28,7 @@ final class PendingSubmitPlanStoreTests: ZcashTestCase {
         let endpoint = LightWalletEndpointBuilder.default
         let firstStore = PendingSubmitPlanStore(persistence: persistence, logger: NullLogger())
 
-        await firstStore.markAwaitingSubmitPlan([transaction])
+        await markAwaiting([transaction], in: firstStore)
         await firstStore.addSubmitEndpoint(transaction: transaction, endpoint: endpoint)
 
         let secondStore = PendingSubmitPlanStore(persistence: persistence, logger: NullLogger())
@@ -73,7 +73,7 @@ final class PendingSubmitPlanStoreTests: ZcashTestCase {
         let secondEndpoint = LightWalletEndpoint(address: "b.z.cash", port: 443, secure: true)
         let store = PendingSubmitPlanStore(logger: NullLogger())
 
-        await store.markAwaitingSubmitPlan([transaction])
+        await markAwaiting([transaction], in: store)
         await store.addSubmitEndpoint(transaction: transaction, endpoint: firstEndpoint)
         await store.addSubmitEndpoint(transaction: transaction, endpoint: secondEndpoint)
 
@@ -93,7 +93,7 @@ final class PendingSubmitPlanStoreTests: ZcashTestCase {
         let endpoint = LightWalletEndpoint(address: "submit.z.cash", port: 443, secure: true)
         let store = PendingSubmitPlanStore(logger: NullLogger())
 
-        await store.markAwaitingSubmitPlan([transaction])
+        await markAwaiting([transaction], in: store)
         await store.addSubmitEndpoint(rawTransaction: rawTransaction, endpoint: endpoint)
 
         switch await store.getSubmitPlan(for: transaction.rawID) {
@@ -118,10 +118,10 @@ final class PendingSubmitPlanStoreTests: ZcashTestCase {
         )
         let store = PendingSubmitPlanStore(persistence: persistence, logger: NullLogger())
 
-        await store.markAwaitingSubmitPlan([retainedTransaction, prunedTransaction])
+        await markAwaiting([retainedTransaction, prunedTransaction], in: store)
         await store.addSubmitEndpoint(transaction: retainedTransaction, endpoint: LightWalletEndpointBuilder.default)
         await store.addSubmitEndpoint(transaction: prunedTransaction, endpoint: LightWalletEndpointBuilder.eccTestnet)
-        await store.retainPlans(for: [retainedTransaction.rawID])
+        await loadAndRetain([retainedTransaction], in: store)
         await store.addSubmitEndpoint(rawTransaction: prunedRawTransaction, endpoint: LightWalletEndpointBuilder.eccTestnet)
 
         let reloadedStore = PendingSubmitPlanStore(persistence: persistence, logger: NullLogger())
@@ -152,7 +152,7 @@ final class PendingSubmitPlanStoreTests: ZcashTestCase {
         }
         mockContainer.mock(type: Logger.self, isSingleton: true) { _ in NullLogger() }
 
-        await store.markAwaitingSubmitPlan([awaitingTransaction])
+        await markAwaiting([awaitingTransaction], in: store)
 
         let action = TxResubmissionAction(container: mockContainer)
         action.latestResolvedTime = 0
@@ -180,7 +180,7 @@ final class PendingSubmitPlanStoreTests: ZcashTestCase {
         }
         mockContainer.mock(type: Logger.self, isSingleton: true) { _ in NullLogger() }
 
-        await store.markAwaitingSubmitPlan([transaction])
+        await markAwaiting([transaction], in: store)
         await store.addSubmitEndpoint(transaction: transaction, endpoint: endpoint)
 
         let action = TxResubmissionAction(container: mockContainer)
@@ -192,6 +192,53 @@ final class PendingSubmitPlanStoreTests: ZcashTestCase {
         assertEndpoint(try XCTUnwrap(submitter.submissions.first?.endpoint), equals: endpoint)
     }
 
+    func testTxResubmissionDoesNotPrunePlanCreatedAfterCandidateLookup() async throws {
+        let createdTransaction = makeTransaction(rawID: Data(repeating: 0xAB, count: 32))
+        let transactionRepository = TransactionRepositoryMock()
+        let transactionEncoder = RecordingTransactionEncoder()
+        let store = PendingSubmitPlanStore(logger: NullLogger())
+        let submitter = RecordingTransactionSubmitter()
+        let createCompleted = AsyncFlag()
+        var createTask: Task<Void, Never>?
+
+        transactionRepository.findForResubmissionUpToClosure = { _ in
+            createTask = Task {
+                await self.markAwaiting([createdTransaction], in: store)
+                await createCompleted.set()
+            }
+
+            try await Task.sleep(nanoseconds: 20_000_000)
+            let didCreateComplete = await createCompleted.get()
+            XCTAssertFalse(didCreateComplete)
+            return []
+        }
+
+        mockContainer.mock(type: TransactionRepository.self, isSingleton: true) { _ in transactionRepository }
+        mockContainer.mock(type: TransactionEncoder.self, isSingleton: true) { _ in transactionEncoder }
+        mockContainer.mock(type: PendingSubmitPlanStore.self, isSingleton: true) { _ in store }
+        mockContainer.mock(type: SubmitPlanExecutor.self, isSingleton: true) { _ in
+            SubmitPlanExecutor(transactionSubmitter: submitter)
+        }
+        mockContainer.mock(type: Logger.self, isSingleton: true) { _ in NullLogger() }
+
+        let action = TxResubmissionAction(container: mockContainer)
+        action.latestResolvedTime = 0
+        _ = try await action.run(with: resubmissionContext()) { _ in }
+
+        guard let createTask else {
+            XCTFail("Expected test to start concurrent transaction creation.")
+            return
+        }
+        await createTask.value
+
+        switch await store.getSubmitPlan(for: createdTransaction.rawID) {
+        case .awaitingPlan:
+            break
+        default:
+            XCTFail("Expected concurrent broadcaster transaction plan to survive pruning.")
+        }
+    }
+
     private func resubmissionContext() -> ActionContextMock {
         let context = ActionContextMock.default()
         context.underlyingSyncControlData = SyncControlData(
@@ -200,6 +247,25 @@ final class PendingSubmitPlanStoreTests: ZcashTestCase {
             firstUnenhancedHeight: nil
         )
         return context
+    }
+
+    @discardableResult
+    private func markAwaiting(
+        _ transactions: [ZcashTransaction.Overview],
+        in store: PendingSubmitPlanStore
+    ) async -> [ZcashTransaction.Overview] {
+        await store.createAndMarkAwaitingSubmitPlan { transactions }
+    }
+
+    @discardableResult
+    private func loadAndRetain(
+        _ transactions: [ZcashTransaction.Overview],
+        in store: PendingSubmitPlanStore
+    ) async -> [ZcashTransaction.Overview] {
+        await store.loadTransactionsAndRetainSubmitPlans(
+            loadTransactions: { transactions },
+            transactionId: { $0.rawID }
+        )
     }
 
     private func makeTransaction(
@@ -333,5 +399,17 @@ private final class RecordingTransactionSubmitter: TransactionSubmitter {
         to endpoint: LightWalletEndpoint
     ) async throws {
         submissions.append(Submission(transaction: transaction, endpoint: endpoint))
+    }
+}
+
+private actor AsyncFlag {
+    private var value = false
+
+    func set() {
+        value = true
+    }
+
+    func get() -> Bool {
+        value
     }
 }


### PR DESCRIPTION
## Summary
- Prevents the sync resubmission path from needing an ever-growing list of Broadcaster transactions to skip by recording the submit plan it should use for retry (cref https://github.com/zcash/zcash-android-wallet-sdk/pull/1937#discussion_r3222459596)
- Adds pending submit plan storage for transactions created through `Broadcaster`.
- Records the endpoints used by `Broadcaster.submit` and retries pending transactions with those endpoints instead of the synchronizer default endpoint.
- Keeps legacy synchronizer submit paths on the existing SDK owned retry behavior.

## Testing
- `swift test --filter OfflineTests`
- Targeted `swiftlint lint` on touched files, with only the existing `SDKSynchronizer.swift:268` force unwrap warning reported.