### PR TITLE
Bump zcash_voting to 0.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,10 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 # Unreleased
 
 ## Changed
-- Bumped `zcash_voting` to `0.7.0` for required voting input validation and paginated vote commitment tree sync
-  responses with per-block roots. Updated hotkey generation APIs to drop the unused round ID.
+- Bumped `zcash_voting` to `0.7.1` for required voting input validation,
+  paginated vote commitment tree sync responses with per-block roots, and
+  shared Orchard note conversion. Updated hotkey generation APIs to drop the
+  unused round ID.
 
 # 2.5.0 - 2026-05-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 # Unreleased
 
 ## Changed
-- Bumped `zcash_voting` to `0.6.0` for paginated vote commitment tree sync
-  responses with per-block roots. No public Swift API changes.
+- Bumped `zcash_voting` to `0.7.0` for required voting input validation and paginated vote commitment tree sync
+  responses with per-block roots. Updated hotkey generation APIs to drop the unused round ID.
 
 # 2.5.0 - 2026-05-11
 
@@ -72,7 +72,7 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `addSentServers(roundId:bundleIndex:proposalId:shareIndex:newURLs:)` → `zcashlc_voting_add_sent_servers`
 
   Delegation workflow
-  - `generateHotkey(roundId:seed:)` → `zcashlc_voting_generate_hotkey` (frees `FfiVotingHotkey` via `zcashlc_voting_free_hotkey`)
+  - `generateHotkey(seed:)` → `zcashlc_voting_generate_hotkey` (frees `FfiVotingHotkey` via `zcashlc_voting_free_hotkey`)
   - `setupBundles(roundId:notes:)` → `zcashlc_voting_setup_bundles` (frees `FfiBundleSetupResult` via `zcashlc_voting_free_bundle_setup_result`)
   - `getBundleCount(roundId:)` → `zcashlc_voting_get_bundle_count`
   - `buildPczt(_:)` → `zcashlc_voting_build_pczt` (takes `VotingBuildPcztParams`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
+## Changed
+- Bumped `zcash_voting` to `0.6.0` for paginated vote commitment tree sync
+  responses with per-block roots. No public Swift API changes.
+
 # 2.5.0 - 2026-05-11
 
 ## Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,11 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 # Unreleased
 
 ## Changed
-- Bumped `zcash_voting` to `0.7.1` for required voting input validation,
-  paginated vote commitment tree sync responses with per-block roots, and
-  shared Orchard note conversion. Updated hotkey generation APIs to drop the
-  unused round ID.
+- Bumped `zcash_voting` to `0.8.1` for the pre-launch voting SQLite schema
+  reset, crate-owned recovery store missing-row errors, required voting input
+  validation, paginated vote commitment tree sync responses with per-block
+  roots, and shared Orchard note conversion. Updated hotkey generation APIs to
+  drop the unused round ID.
 
 # 2.5.0 - 2026-05-11
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7149,9 +7149,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_voting"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0a85b72657ecf9f7f2fdbca47ac108284568b67b16511100dfd5095f266a923"
+checksum = "eb4c54bb4850795760612921fa2ac0a1b5e90f5af756d3f433b3990b916d8cfe"
 dependencies = [
  "anyhow",
  "blake2b_simd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7149,9 +7149,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_voting"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb4c54bb4850795760612921fa2ac0a1b5e90f5af756d3f433b3990b916d8cfe"
+checksum = "81ab18823d071b582fc922f2370a5a30a68e4173b2699b81296e717ddab72954"
 dependencies = [
  "anyhow",
  "blake2b_simd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6143,9 +6143,9 @@ checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "vote-commitment-tree"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0fb2456313f571003c0bed8d38fb166d78da85653caf828823c1a82f4e1aef1"
+checksum = "be25d43d8b918599f579168a7aa2c0a12b2557bdc641324510f0d5797b1d59ac"
 dependencies = [
  "anyhow",
  "ff",
@@ -6160,9 +6160,9 @@ dependencies = [
 
 [[package]]
 name = "vote-commitment-tree-client"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb05b7a0434a89c2d9017bbab9a5157f1992fb746dce58a1077669e9dd0a13c5"
+checksum = "4ad6904ca2fdff4e39cea4700e924227eda14fb123b4212f917d0aea2b0a39c8"
 dependencies = [
  "base64",
  "ff",
@@ -6176,9 +6176,9 @@ dependencies = [
 
 [[package]]
 name = "voting-circuits"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ba6635f8e207689c290634f6e34f7eddaf1b254aa0f9b0ef65418d89d1d1ae7"
+checksum = "0436d69b5884ca107db3de1be5e3e92981a35cd15dbfc6919361316a5dfa8e89"
 dependencies = [
  "blake2b_simd",
  "ff",
@@ -7149,9 +7149,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_voting"
-version = "0.5.7"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "900ed070eefad32d3dd7b65353b6c71888f7ebeb6539fcaf71ce8fd9eb335107"
+checksum = "c0a85b72657ecf9f7f2fdbca47ac108284568b67b16511100dfd5095f266a923"
 dependencies = [
  "anyhow",
  "blake2b_simd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7149,9 +7149,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_voting"
-version = "0.7.1"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81ab18823d071b582fc922f2370a5a30a68e4173b2699b81296e717ddab72954"
+checksum = "c2345d90daf1c4c30c1e6276d0c3e1f7e7952d3923ed31abee22f3c7fa090dec"
 dependencies = [
  "anyhow",
  "blake2b_simd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,7 +84,7 @@ rust_decimal = { version = "1", default-features = false, features = ["c-repr"] 
 xz2 = { version = "0.1", features = ["static"] }
 
 # Voting
-zcash_voting = { version = "0.6.0", default-features = false, features = [
+zcash_voting = { version = "0.7.0", default-features = false, features = [
     "client-pir",
     "client-tree-sync",
 ] }
@@ -92,7 +92,7 @@ zcash_keys = { version = "0.13", features = ["orchard"] }
 incrementalmerkletree = { version = "0.8", default-features = false }
 
 [dev-dependencies]
-zcash_voting = { version = "0.6.0", default-features = false, features = ["test-fixtures"] }
+zcash_voting = { version = "0.7.0", default-features = false, features = ["test-fixtures"] }
 
 [build-dependencies]
 bindgen = "0.72"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,7 +84,7 @@ rust_decimal = { version = "1", default-features = false, features = ["c-repr"] 
 xz2 = { version = "0.1", features = ["static"] }
 
 # Voting
-zcash_voting = { version = "0.7.0", default-features = false, features = [
+zcash_voting = { version = "0.7.1", default-features = false, features = [
     "client-pir",
     "client-tree-sync",
 ] }
@@ -92,7 +92,7 @@ zcash_keys = { version = "0.13", features = ["orchard"] }
 incrementalmerkletree = { version = "0.8", default-features = false }
 
 [dev-dependencies]
-zcash_voting = { version = "0.7.0", default-features = false, features = ["test-fixtures"] }
+zcash_voting = { version = "0.7.1", default-features = false, features = ["test-fixtures"] }
 
 [build-dependencies]
 bindgen = "0.72"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,7 +84,7 @@ rust_decimal = { version = "1", default-features = false, features = ["c-repr"] 
 xz2 = { version = "0.1", features = ["static"] }
 
 # Voting
-zcash_voting = { version = "0.7.1", default-features = false, features = [
+zcash_voting = { version = "0.8.1", default-features = false, features = [
     "client-pir",
     "client-tree-sync",
 ] }
@@ -92,7 +92,7 @@ zcash_keys = { version = "0.13", features = ["orchard"] }
 incrementalmerkletree = { version = "0.8", default-features = false }
 
 [dev-dependencies]
-zcash_voting = { version = "0.7.1", default-features = false, features = ["test-fixtures"] }
+zcash_voting = { version = "0.8.1", default-features = false, features = ["test-fixtures"] }
 
 [build-dependencies]
 bindgen = "0.72"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,7 +84,7 @@ rust_decimal = { version = "1", default-features = false, features = ["c-repr"] 
 xz2 = { version = "0.1", features = ["static"] }
 
 # Voting
-zcash_voting = { version = "0.5.7", default-features = false, features = [
+zcash_voting = { version = "0.6.0", default-features = false, features = [
     "client-pir",
     "client-tree-sync",
 ] }
@@ -92,7 +92,7 @@ zcash_keys = { version = "0.13", features = ["orchard"] }
 incrementalmerkletree = { version = "0.8", default-features = false }
 
 [dev-dependencies]
-zcash_voting = { version = "0.5.7", default-features = false, features = ["test-fixtures"] }
+zcash_voting = { version = "0.6.0", default-features = false, features = ["test-fixtures"] }
 
 [build-dependencies]
 bindgen = "0.72"

--- a/Sources/ZcashLightClientKit/Rust/Voting/VotingRustBackend.swift
+++ b/Sources/ZcashLightClientKit/Rust/Voting/VotingRustBackend.swift
@@ -1390,25 +1390,19 @@ extension VotingRustBackend {
 // MARK: - Delegation workflow
 
 extension VotingRustBackend {
-    /// Generate a voting hotkey for a round.
+    /// Generate a voting hotkey.
     ///
     /// The returned secret key is owned by Swift after this call. The Rust
     /// allocation is freed before this method returns; callers should treat
     /// the secret bytes with the same care as any other key material.
-    public func generateHotkey(roundId: String, seed: [UInt8]) throws -> VotingHotkey {
-        let roundIdBytes = [UInt8](roundId.utf8)
-
+    public func generateHotkey(seed: [UInt8]) throws -> VotingHotkey {
         let ptr: UnsafeMutablePointer<FfiVotingHotkey> = try withHandle { dbh in
-            let ptr: UnsafeMutablePointer<FfiVotingHotkey>? = roundIdBytes.withUnsafeBufferPointer { ridBuf in
-                seed.withUnsafeBufferPointer { seedBuf in
-                    zcashlc_voting_generate_hotkey(
-                        dbh,
-                        ridBuf.baseAddress,
-                        UInt(ridBuf.count),
-                        seedBuf.baseAddress,
-                        UInt(seedBuf.count)
-                    )
-                }
+            let ptr: UnsafeMutablePointer<FfiVotingHotkey>? = seed.withUnsafeBufferPointer { seedBuf in
+                zcashlc_voting_generate_hotkey(
+                    dbh,
+                    seedBuf.baseAddress,
+                    UInt(seedBuf.count)
+                )
             }
             guard let ptr else {
                 throw VotingRustBackendError.rustError(

--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -7,8 +7,8 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Changed
-- Bumped `zcash_voting` to `0.6.0` for paginated vote commitment tree sync
-  responses with per-block roots.
+- Bumped `zcash_voting` to `0.7.0` for required voting input validation and paginated vote commitment tree sync
+  responses with per-block roots, and dropped the unused round ID from `zcashlc_voting_generate_hotkey`.
 
 ## 2.5.0 - 2026-05-11
 

--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -7,8 +7,10 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Changed
-- Bumped `zcash_voting` to `0.7.0` for required voting input validation and paginated vote commitment tree sync
-  responses with per-block roots, and dropped the unused round ID from `zcashlc_voting_generate_hotkey`.
+- Bumped `zcash_voting` to `0.7.1` for required voting input validation,
+  paginated vote commitment tree sync responses with per-block roots, and the
+  shared Orchard note conversion used by `zcashlc_voting_get_wallet_notes`.
+  Dropped the unused round ID from `zcashlc_voting_generate_hotkey`.
 
 ## 2.5.0 - 2026-05-11
 

--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -7,10 +7,12 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Changed
-- Bumped `zcash_voting` to `0.7.1` for required voting input validation,
-  paginated vote commitment tree sync responses with per-block roots, and the
-  shared Orchard note conversion used by `zcashlc_voting_get_wallet_notes`.
-  Dropped the unused round ID from `zcashlc_voting_generate_hotkey`.
+- Bumped `zcash_voting` to `0.8.1` for the pre-launch voting SQLite schema
+  reset, crate-owned recovery store missing-row errors, required voting input
+  validation, paginated vote commitment tree sync responses with per-block
+  roots, and the shared Orchard note conversion used by
+  `zcashlc_voting_get_wallet_notes`. Dropped the unused round ID from
+  `zcashlc_voting_generate_hotkey`.
 
 ## 2.5.0 - 2026-05-11
 

--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -6,6 +6,10 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+- Bumped `zcash_voting` to `0.6.0` for paginated vote commitment tree sync
+  responses with per-block roots.
+
 ## 2.5.0 - 2026-05-11
 
 ### Added

--- a/rust/src/voting/delegation.rs
+++ b/rust/src/voting/delegation.rs
@@ -57,7 +57,7 @@ fn validate_cached_tree_state_for_round(
 // VotingDatabase methods — Delegation proof
 // =============================================================================
 
-/// Generate a voting hotkey for a round.
+/// Generate a voting hotkey.
 ///
 /// Returns a pointer to `FfiVotingHotkey` on success, or null on error.
 /// Call `zcashlc_voting_free_hotkey` to free the returned pointer.
@@ -68,8 +68,6 @@ fn validate_cached_tree_state_for_round(
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn zcashlc_voting_generate_hotkey(
     db: *mut VotingDatabaseHandle,
-    round_id: *const u8,
-    round_id_len: usize,
     seed: *const u8,
     seed_len: usize,
 ) -> *mut FfiVotingHotkey {
@@ -77,12 +75,11 @@ pub unsafe extern "C" fn zcashlc_voting_generate_hotkey(
     let res = catch_panic(|| {
         let handle =
             unsafe { db.as_ref() }.ok_or_else(|| anyhow!("VotingDatabaseHandle is null"))?;
-        let round_id_str = unsafe { str_from_ptr(round_id, round_id_len) }?;
         let seed_bytes = unsafe { bytes_from_ptr(seed, seed_len) }?;
 
         let hotkey = handle
             .db
-            .generate_hotkey(&round_id_str, seed_bytes)
+            .generate_hotkey(seed_bytes)
             .map_err(|e| anyhow!("generate_hotkey failed: {}", e))?;
 
         Ok(Box::into_raw(Box::new(voting_hotkey_to_ffi(hotkey)?)))
@@ -1121,13 +1118,7 @@ mod tests {
 
         assert!(
             unsafe {
-                zcashlc_voting_generate_hotkey(
-                    std::ptr::null_mut(),
-                    round.as_ptr(),
-                    round.len(),
-                    bytes.as_ptr(),
-                    bytes.len(),
-                )
+                zcashlc_voting_generate_hotkey(std::ptr::null_mut(), bytes.as_ptr(), bytes.len())
             }
             .is_null()
         );
@@ -1254,17 +1245,8 @@ mod tests {
     fn generate_hotkey_returns_freeable_ffi_value() {
         let db = open_memory_voting_db();
         let seed = [7u8; 32];
-        let round = TEST_ROUND_ID.as_bytes();
 
-        let hotkey = unsafe {
-            zcashlc_voting_generate_hotkey(
-                db,
-                round.as_ptr(),
-                round.len(),
-                seed.as_ptr(),
-                seed.len(),
-            )
-        };
+        let hotkey = unsafe { zcashlc_voting_generate_hotkey(db, seed.as_ptr(), seed.len()) };
 
         assert!(!hotkey.is_null());
         let hotkey_ref = unsafe { hotkey.as_ref() }.expect("hotkey");
@@ -1284,17 +1266,8 @@ mod tests {
     fn generate_hotkey_rejects_short_seed() {
         let db = open_memory_voting_db();
         let seed = [7u8; 31];
-        let round = TEST_ROUND_ID.as_bytes();
 
-        let hotkey = unsafe {
-            zcashlc_voting_generate_hotkey(
-                db,
-                round.as_ptr(),
-                round.len(),
-                seed.as_ptr(),
-                seed.len(),
-            )
-        };
+        let hotkey = unsafe { zcashlc_voting_generate_hotkey(db, seed.as_ptr(), seed.len()) };
 
         assert!(hotkey.is_null());
         unsafe { zcashlc_voting_db_free(db) };

--- a/rust/src/voting/helpers.rs
+++ b/rust/src/voting/helpers.rs
@@ -1,11 +1,10 @@
 use std::ffi::CString;
 
 use anyhow::anyhow;
-use orchard::note::ExtractedNoteCommitment;
 use serde::Serialize;
 use zcash_client_sqlite::util::SystemClock;
-use zcash_keys::keys::{UnifiedFullViewingKey, UnifiedSpendingKey};
-use zcash_protocol::consensus::{self, Network};
+use zcash_keys::keys::UnifiedSpendingKey;
+use zcash_protocol::consensus::Network;
 use zcash_voting as voting;
 use zip32::{AccountId, Scope};
 
@@ -57,53 +56,6 @@ pub(super) fn json_to_boxed_slice<T: Serialize>(
 ) -> anyhow::Result<*mut crate::ffi::BoxedSlice> {
     let json = serde_json::to_vec(value)?;
     Ok(crate::ffi::BoxedSlice::some(json))
-}
-
-/// Convert a librustzcash ReceivedNote (orchard) into zcash_voting's NoteInfo.
-///
-/// Requires the account's UFVK and network to compute the nullifier and
-/// encode the UFVK string.
-pub(super) fn received_note_to_note_info<P: consensus::Parameters>(
-    note: &zcash_client_backend::wallet::ReceivedNote<
-        zcash_client_sqlite::ReceivedNoteId,
-        orchard::note::Note,
-    >,
-    ufvk: &UnifiedFullViewingKey,
-    network: &P,
-) -> anyhow::Result<voting::NoteInfo> {
-    let orchard_note = note.note();
-    let fvk = ufvk
-        .orchard()
-        .ok_or_else(|| anyhow!("UFVK has no Orchard component"))?;
-
-    let nullifier = orchard_note.nullifier(fvk);
-    // `voting::NoteInfo::commitment` is the wire-form (extracted) cmx, not the affine
-    // note commitment, so the affine value is converted here before serialization.
-    let cmx: ExtractedNoteCommitment = orchard_note.commitment().into();
-
-    // Extract raw fields
-    let diversifier = orchard_note.recipient().diversifier().as_array().to_vec();
-    let value = orchard_note.value().inner();
-    let rho = orchard_note.rho().to_bytes().to_vec();
-    let rseed = orchard_note.rseed().as_bytes().to_vec();
-    let position = u64::from(note.note_commitment_tree_position());
-    let scope = match note.spending_key_scope() {
-        Scope::External => 0u32,
-        Scope::Internal => 1u32,
-    };
-    let ufvk_str = ufvk.encode(network);
-
-    Ok(voting::NoteInfo {
-        commitment: cmx.to_bytes().to_vec(),
-        nullifier: nullifier.to_bytes().to_vec(),
-        value,
-        position,
-        diversifier,
-        rho,
-        rseed,
-        scope,
-        ufvk_str,
-    })
 }
 
 /// Open the wallet database.

--- a/rust/src/voting/notes.rs
+++ b/rust/src/voting/notes.rs
@@ -7,9 +7,7 @@ use zcash_client_backend::data_api::{Account, WalletRead};
 use crate::unwrap_exc_or_null;
 
 use super::db::VotingDatabaseHandle;
-use super::helpers::{
-    bytes_from_ptr, json_to_boxed_slice, open_wallet_db, received_note_to_note_info, str_from_ptr,
-};
+use super::helpers::{bytes_from_ptr, json_to_boxed_slice, open_wallet_db, str_from_ptr};
 use super::json::JsonNoteInfo;
 
 // =============================================================================
@@ -100,7 +98,13 @@ pub unsafe extern "C" fn zcashlc_voting_get_wallet_notes(
         let network = wallet_db.params();
         let mut json_notes = Vec::with_capacity(received_notes.len());
         for rn in &received_notes {
-            let note_info = received_note_to_note_info(rn, ufvk, network)?;
+            let note_info = zcash_voting::NoteInfo::from_orchard_note(
+                rn.note(),
+                u64::from(rn.note_commitment_tree_position()),
+                rn.spending_key_scope(),
+                ufvk,
+                network,
+            )?;
             json_notes.push(JsonNoteInfo::from(note_info));
         }
         json_to_boxed_slice(&json_notes)

--- a/rust/src/voting/recovery.rs
+++ b/rust/src/voting/recovery.rs
@@ -52,11 +52,6 @@ pub unsafe extern "C" fn zcashlc_voting_store_delegation_tx_hash(
             unsafe { db.as_ref() }.ok_or_else(|| anyhow!("VotingDatabaseHandle is null"))?;
         let round_id_str = unsafe { str_from_ptr(round_id, round_id_len) }?;
         let tx_hash_str = unsafe { str_from_ptr(tx_hash, tx_hash_len) }?;
-        // Check if the bundle exists
-        handle
-            .db
-            .get_delegation_tx_hash(&round_id_str, bundle_index)
-            .map_err(|e| anyhow!("store_delegation_tx_hash failed: {}", e))?;
         handle
             .db
             .store_delegation_tx_hash(&round_id_str, bundle_index, &tx_hash_str)


### PR DESCRIPTION
Updates the Rust voting dependency to `zcash_voting 0.8.1`, refreshes `Cargo.lock`, and records the bump in both changelogs.

This carries the existing voting SDK updates forward and adds the 0.8.x voting DB behavior. Pre-launch voting SQLite state resets to the current schema, recovery store operations now fail from the crate when the target bundle or vote row is missing, and the SDK FFI no longer does its own delegation hash existence read before storing.

Validation:
- `cargo fmt`
- `git diff --check`
- `cargo tree -p libzcashlc -i zcash_voting --locked --edges normal -e features`
- `cargo test -p libzcashlc voting:: --lib --locked`
- `cargo test -p libzcashlc --lib --locked`
