### PR TITLE
Centralize voting FFI constants

### DIFF
--- a/Sources/ZcashLightClientKit/Rust/Voting/VotingConstants.swift
+++ b/Sources/ZcashLightClientKit/Rust/Voting/VotingConstants.swift
@@ -10,15 +10,16 @@ let votingMinSeedByteCount = 32
 let votingSeedFingerprintByteCount = 32
 let votingShareNullifierByteCount = 32
 let votingShareNullifierHexCharacterCount = votingShareNullifierByteCount * 2
+let votingVoteRoundIdHexCharacterCount = 64
 let votingKeystoneSignatureByteCount = 64
 let votingPcztSighashByteCount = 32
 let votingRandomizedKeyByteCount = 32
+let votingHotkeyRawAddressByteCount = 43
 let votingPirRootByteCount = 32
-let votingPirNullifierBoundsByteCount = 96
+let votingPirNullifierBoundsByteCount = votingPirRootByteCount * 3
 let votingPirPathElementCount = 29
 let votingPirPathByteCount = votingPirPathElementCount * votingPirRootByteCount
 let votingPirNullifierByteCount = 32
-let votingPirExpectedRootByteCount = 32
 
 // ASCII byte bounds used when validating hex-encoded voting inputs.
 let votingCharacterByteZero = UInt8(ascii: "0")

--- a/Sources/ZcashLightClientKit/Rust/Voting/VotingRustBackend.swift
+++ b/Sources/ZcashLightClientKit/Rust/Voting/VotingRustBackend.swift
@@ -1740,9 +1740,9 @@ extension VotingRustBackend {
                 "nullifier must be exactly \(votingPirNullifierByteCount) bytes"
             )
         }
-        guard proof.expectedRoot.count == votingPirExpectedRootByteCount else {
+        guard proof.expectedRoot.count == votingPirRootByteCount else {
             throw VotingRustBackendError.invalidData(
-                "expectedRoot must be exactly \(votingPirExpectedRootByteCount) bytes"
+                "expectedRoot must be exactly \(votingPirRootByteCount) bytes"
             )
         }
 

--- a/Tests/OfflineTests/VotingRustBackendTests.swift
+++ b/Tests/OfflineTests/VotingRustBackendTests.swift
@@ -25,18 +25,16 @@ private let roundTripHelperBURL = "https://helper-b.example"
 private let roundTripFirstSubmitAt: UInt64 = 1000
 private let roundTripSecondSubmitAt: UInt64 = 2000
 private let roundTripCreatedAt: Int64 = 1_000
-private let roundTripFieldElementByteCount = 32
-private let roundTripKeystoneSignatureByteCount = 64
 private let roundTripDiversifierByteCount = 11
 private let roundTripEligibleNoteValue: UInt64 = 13_000_000
 private let roundTripSQLiteSuccessCode = SQLITE_OK
 private let roundTripSQLiteDoneCode = SQLITE_DONE
-private let roundTripRoundParameter = [UInt8](repeating: 0x07, count: roundTripFieldElementByteCount)
-private let roundTripKeystoneSignature = [UInt8](repeating: 0x01, count: roundTripKeystoneSignatureByteCount)
-private let roundTripPcztSighash = [UInt8](repeating: 0x02, count: roundTripFieldElementByteCount)
-private let roundTripRandomizedKey = [UInt8](repeating: 0x03, count: roundTripFieldElementByteCount)
-private let roundTripShareNullifier = String(repeating: "dd", count: roundTripFieldElementByteCount)
-private let roundTripVoteCommitment = [UInt8](repeating: 0xAA, count: roundTripFieldElementByteCount)
+private let roundTripRoundParameter = [UInt8](repeating: 0x07, count: votingFieldElementByteCount)
+private let roundTripKeystoneSignature = [UInt8](repeating: 0x01, count: votingKeystoneSignatureByteCount)
+private let roundTripPcztSighash = [UInt8](repeating: 0x02, count: votingPcztSighashByteCount)
+private let roundTripRandomizedKey = [UInt8](repeating: 0x03, count: votingRandomizedKeyByteCount)
+private let roundTripShareNullifier = String(repeating: "dd", count: votingShareNullifierByteCount)
+private let roundTripVoteCommitment = [UInt8](repeating: 0xAA, count: votingFieldElementByteCount)
 
 final class VotingRustBackendTests: XCTestCase {
     private var dbPath: String?
@@ -52,9 +50,9 @@ final class VotingRustBackendTests: XCTestCase {
     // MARK: - computeShareNullifier
 
     func test_computeShareNullifier_returnsExpectedValueForKnownFixture() throws {
-        var voteCommitment = [UInt8](repeating: 0, count: 32)
+        var voteCommitment = [UInt8](repeating: 0, count: votingFieldElementByteCount)
         voteCommitment[0] = 0x01
-        var primaryBlind = [UInt8](repeating: 0, count: 32)
+        var primaryBlind = [UInt8](repeating: 0, count: votingFieldElementByteCount)
         primaryBlind[0] = 0x03
 
         let nullifier = try VotingRustBackend.computeShareNullifier(
@@ -73,9 +71,9 @@ final class VotingRustBackendTests: XCTestCase {
     }
 
     func test_computeShareNullifier_throwsInvalidData_whenInputsAreNot32Bytes() {
-        let valid = [UInt8](repeating: 0x01, count: 32)
-        let tooShort = [UInt8](repeating: 0x01, count: 31)
-        let tooLong = [UInt8](repeating: 0x01, count: 33)
+        let valid = [UInt8](repeating: 0x01, count: votingFieldElementByteCount)
+        let tooShort = [UInt8](repeating: 0x01, count: votingFieldElementByteCount - 1)
+        let tooLong = [UInt8](repeating: 0x01, count: votingFieldElementByteCount + 1)
 
         for (vc, blind, label) in [
             (tooShort, valid, "voteCommitment too short"),
@@ -238,8 +236,8 @@ final class VotingRustBackendTests: XCTestCase {
     }
 
     func test_generateDelegationInputs_rejectsShortSeeds() {
-        let short = [UInt8](repeating: 0x01, count: 31)
-        let valid = [UInt8](repeating: 0x02, count: 32)
+        let short = [UInt8](repeating: 0x01, count: votingMinSeedByteCount - 1)
+        let valid = [UInt8](repeating: 0x02, count: votingMinSeedByteCount)
         XCTAssertThrowsError(
             try VotingRustBackend.generateDelegationInputs(
                 senderSeed: short,
@@ -263,13 +261,13 @@ final class VotingRustBackendTests: XCTestCase {
             let label: String
         }
 
-        let validHotkey = [UInt8](repeating: 0x02, count: 32)
-        let validFvk = [UInt8](repeating: 0x03, count: 96)
-        let validFp = [UInt8](repeating: 0x04, count: 32)
+        let validHotkey = [UInt8](repeating: 0x02, count: votingMinSeedByteCount)
+        let validFvk = [UInt8](repeating: 0x03, count: votingOrchardFvkByteCount)
+        let validFp = [UInt8](repeating: 0x04, count: votingSeedFingerprintByteCount)
         let cases: [Case] = [
-            .init(fvk: [UInt8](repeating: 0, count: 95), hotkey: validHotkey, fingerprint: validFp, label: "fvk too short"),
-            .init(fvk: validFvk, hotkey: [UInt8](repeating: 0, count: 31), fingerprint: validFp, label: "hotkey too short"),
-            .init(fvk: validFvk, hotkey: validHotkey, fingerprint: [UInt8](repeating: 0, count: 31), label: "fingerprint too short")
+            .init(fvk: [UInt8](repeating: 0, count: votingOrchardFvkByteCount - 1), hotkey: validHotkey, fingerprint: validFp, label: "fvk too short"),
+            .init(fvk: validFvk, hotkey: [UInt8](repeating: 0, count: votingMinSeedByteCount - 1), fingerprint: validFp, label: "hotkey too short"),
+            .init(fvk: validFvk, hotkey: validHotkey, fingerprint: [UInt8](repeating: 0, count: votingSeedFingerprintByteCount - 1), label: "fingerprint too short")
         ]
         for testCase in cases {
             let fvk = testCase.fvk
@@ -325,53 +323,56 @@ final class VotingRustBackendTests: XCTestCase {
             let label: String
         }
 
-        let valid32 = [UInt8](repeating: 0x01, count: 32)
-        let valid96 = [UInt8](repeating: 0x02, count: 96)
-        let valid928 = [UInt8](repeating: 0x03, count: 928)
+        let validRoot = [UInt8](repeating: 0x01, count: votingPirRootByteCount)
+        let validBounds = [UInt8](repeating: 0x02, count: votingPirNullifierBoundsByteCount)
+        let validPath = [UInt8](repeating: 0x03, count: votingPirPathByteCount)
+        let validNullifier = [UInt8](repeating: 0x04, count: votingPirNullifierByteCount)
+        let validExpectedRoot = [UInt8](repeating: 0x05, count: votingPirRootByteCount)
 
-        let bad31 = [UInt8](repeating: 0, count: 31)
-        let bad95 = [UInt8](repeating: 0, count: 95)
-        let bad927 = [UInt8](repeating: 0, count: 927)
+        let badRoot = [UInt8](repeating: 0, count: votingPirRootByteCount - 1)
+        let badBounds = [UInt8](repeating: 0, count: votingPirNullifierBoundsByteCount - 1)
+        let badPath = [UInt8](repeating: 0, count: votingPirPathByteCount - 1)
+        let badNullifier = [UInt8](repeating: 0, count: votingPirNullifierByteCount - 1)
 
         let cases: [Case] = [
             .init(
-                root: bad31,
-                nfBounds: valid96,
-                path: valid928,
-                nullifier: valid32,
-                expectedRoot: valid32,
+                root: badRoot,
+                nfBounds: validBounds,
+                path: validPath,
+                nullifier: validNullifier,
+                expectedRoot: validExpectedRoot,
                 label: "root too short"
             ),
             .init(
-                root: valid32,
-                nfBounds: bad95,
-                path: valid928,
-                nullifier: valid32,
-                expectedRoot: valid32,
+                root: validRoot,
+                nfBounds: badBounds,
+                path: validPath,
+                nullifier: validNullifier,
+                expectedRoot: validExpectedRoot,
                 label: "nfBounds too short"
             ),
             .init(
-                root: valid32,
-                nfBounds: valid96,
-                path: bad927,
-                nullifier: valid32,
-                expectedRoot: valid32,
+                root: validRoot,
+                nfBounds: validBounds,
+                path: badPath,
+                nullifier: validNullifier,
+                expectedRoot: validExpectedRoot,
                 label: "path too short"
             ),
             .init(
-                root: valid32,
-                nfBounds: valid96,
-                path: valid928,
-                nullifier: bad31,
-                expectedRoot: valid32,
+                root: validRoot,
+                nfBounds: validBounds,
+                path: validPath,
+                nullifier: badNullifier,
+                expectedRoot: validExpectedRoot,
                 label: "nullifier too short"
             ),
             .init(
-                root: valid32,
-                nfBounds: valid96,
-                path: valid928,
-                nullifier: valid32,
-                expectedRoot: bad31,
+                root: validRoot,
+                nfBounds: validBounds,
+                path: validPath,
+                nullifier: validNullifier,
+                expectedRoot: badRoot,
                 label: "expectedRoot too short"
             )
         ]
@@ -402,7 +403,7 @@ final class VotingRustBackendTests: XCTestCase {
         let backend = try makeReadyBackend()
         defer { backend.close() }
 
-        let valid = [UInt8](repeating: 0x07, count: 32)
+        let valid = [UInt8](repeating: 0x07, count: votingFieldElementByteCount)
         try backend.initRound(
             roundId: "round-1",
             snapshotHeight: 1234,
@@ -424,8 +425,8 @@ final class VotingRustBackendTests: XCTestCase {
         let backend = try makeReadyBackend()
         defer { backend.close() }
 
-        let valid = [UInt8](repeating: 0x07, count: 32)
-        let short = [UInt8](repeating: 0x07, count: 31)
+        let valid = [UInt8](repeating: 0x07, count: votingFieldElementByteCount)
+        let short = [UInt8](repeating: 0x07, count: votingFieldElementByteCount - 1)
 
         XCTAssertThrowsError(
             try backend.initRound(
@@ -455,7 +456,7 @@ final class VotingRustBackendTests: XCTestCase {
         let backend = try makeReadyBackend()
         defer { backend.close() }
 
-        let valid = [UInt8](repeating: 0x07, count: 32)
+        let valid = [UInt8](repeating: 0x07, count: votingFieldElementByteCount)
         try backend.initRound(
             roundId: "round-1",
             snapshotHeight: 42,
@@ -480,7 +481,7 @@ final class VotingRustBackendTests: XCTestCase {
         let backend = try makeReadyBackend()
         defer { backend.close() }
 
-        let valid = [UInt8](repeating: 0x07, count: 32)
+        let valid = [UInt8](repeating: 0x07, count: votingFieldElementByteCount)
         try backend.initRound(
             roundId: "round",
             snapshotHeight: 1,
@@ -643,7 +644,7 @@ final class VotingRustBackendTests: XCTestCase {
         let backend = try makeReadyBackend()
         defer { backend.close() }
 
-        let valid = [UInt8](repeating: 0x07, count: 32)
+        let valid = [UInt8](repeating: 0x07, count: votingFieldElementByteCount)
         try backend.initRound(
             roundId: "round",
             snapshotHeight: 1,
@@ -659,14 +660,14 @@ final class VotingRustBackendTests: XCTestCase {
             let label: String
         }
 
-        let validSig = [UInt8](repeating: 0x01, count: 64)
-        let validSighash = [UInt8](repeating: 0x02, count: 32)
-        let validRk = [UInt8](repeating: 0x03, count: 32)
+        let validSig = [UInt8](repeating: 0x01, count: votingKeystoneSignatureByteCount)
+        let validSighash = [UInt8](repeating: 0x02, count: votingPcztSighashByteCount)
+        let validRk = [UInt8](repeating: 0x03, count: votingRandomizedKeyByteCount)
 
         let cases: [Case] = [
-            .init(sig: [UInt8](repeating: 0, count: 63), sighash: validSighash, randomizedKey: validRk, label: "sig too short"),
-            .init(sig: validSig, sighash: [UInt8](repeating: 0, count: 31), randomizedKey: validRk, label: "sighash too short"),
-            .init(sig: validSig, sighash: validSighash, randomizedKey: [UInt8](repeating: 0, count: 31), label: "rk too short")
+            .init(sig: [UInt8](repeating: 0, count: votingKeystoneSignatureByteCount - 1), sighash: validSighash, randomizedKey: validRk, label: "sig too short"),
+            .init(sig: validSig, sighash: [UInt8](repeating: 0, count: votingPcztSighashByteCount - 1), randomizedKey: validRk, label: "sighash too short"),
+            .init(sig: validSig, sighash: validSighash, randomizedKey: [UInt8](repeating: 0, count: votingRandomizedKeyByteCount - 1), label: "rk too short")
         ]
         for testCase in cases {
             XCTAssertThrowsError(
@@ -764,7 +765,7 @@ final class VotingRustBackendTests: XCTestCase {
         let backend = try makeReadyBackend()
         defer { backend.close() }
 
-        let bad = String(repeating: "aa", count: 31)
+        let bad = String(repeating: "aa", count: votingShareNullifierByteCount - 1)
         XCTAssertThrowsError(
             try backend.recordShareDelegation(
                 roundId: "round",
@@ -797,7 +798,7 @@ final class VotingRustBackendTests: XCTestCase {
         let backend = try makeReadyBackend()
         defer { backend.close() }
 
-        let valid = [UInt8](repeating: 0x07, count: 32)
+        let valid = [UInt8](repeating: 0x07, count: votingFieldElementByteCount)
         try backend.initRound(
             roundId: "round",
             snapshotHeight: 1,
@@ -820,11 +821,11 @@ final class VotingRustBackendTests: XCTestCase {
             roundId: "round",
             bundleIndex: 0,
             notes: [],
-            fvk: [UInt8](repeating: 0, count: 96),
-            hotkeyRawAddress: [UInt8](repeating: 0, count: 43),
+            fvk: [UInt8](repeating: 0, count: votingOrchardFvkByteCount),
+            hotkeyRawAddress: [UInt8](repeating: 0, count: votingHotkeyRawAddressByteCount),
             consensusBranchId: 0,
             coinType: 0,
-            seedFingerprint: [UInt8](repeating: 0, count: 31),
+            seedFingerprint: [UInt8](repeating: 0, count: votingSeedFingerprintByteCount - 1),
             accountIndex: 0,
             roundName: "Round",
             addressIndex: 0
@@ -845,8 +846,8 @@ final class VotingRustBackendTests: XCTestCase {
             try backend.getDelegationSubmission(
                 roundId: "round",
                 bundleIndex: 0,
-                keystoneSig: [UInt8](repeating: 0, count: 63),
-                sighash: [UInt8](repeating: 0, count: 32)
+                keystoneSig: [UInt8](repeating: 0, count: votingKeystoneSignatureByteCount - 1),
+                sighash: [UInt8](repeating: 0, count: votingPcztSighashByteCount)
             )
         ) { error in
             guard case VotingRustBackendError.invalidData = error else {
@@ -858,8 +859,8 @@ final class VotingRustBackendTests: XCTestCase {
             try backend.getDelegationSubmission(
                 roundId: "round",
                 bundleIndex: 0,
-                keystoneSig: [UInt8](repeating: 0, count: 64),
-                sighash: [UInt8](repeating: 0, count: 31)
+                keystoneSig: [UInt8](repeating: 0, count: votingKeystoneSignatureByteCount),
+                sighash: [UInt8](repeating: 0, count: votingPcztSighashByteCount - 1)
             )
         ) { error in
             guard case VotingRustBackendError.invalidData = error else {
@@ -873,7 +874,7 @@ final class VotingRustBackendTests: XCTestCase {
 
     func test_initRound_beforeOpen_throwsDatabaseNotOpen() {
         let backend = VotingRustBackend()
-        let valid = [UInt8](repeating: 0, count: 32)
+        let valid = [UInt8](repeating: 0, count: votingFieldElementByteCount)
         XCTAssertThrowsError(
             try backend.initRound(
                 roundId: "r",
@@ -973,9 +974,9 @@ final class VotingRustBackendTests: XCTestCase {
             try backend.storeKeystoneSignature(
                 roundId: "r",
                 bundleIndex: 0,
-                sig: [UInt8](repeating: 0, count: 64),
-                sighash: [UInt8](repeating: 0, count: 32),
-                randomizedKey: [UInt8](repeating: 0, count: 32)
+                sig: [UInt8](repeating: 0, count: votingKeystoneSignatureByteCount),
+                sighash: [UInt8](repeating: 0, count: votingPcztSighashByteCount),
+                randomizedKey: [UInt8](repeating: 0, count: votingRandomizedKeyByteCount)
             )
         ) { error in
             guard case VotingRustBackendError.databaseNotOpen = error else {
@@ -1010,7 +1011,7 @@ final class VotingRustBackendTests: XCTestCase {
                 roundId: "r",
                 bundleIndex: 0,
                 notes: [],
-                hotkeyRawAddress: [UInt8](repeating: 0, count: 43),
+                hotkeyRawAddress: [UInt8](repeating: 0, count: votingHotkeyRawAddressByteCount),
                 pirEndpoints: ["https://stub"],
                 expectedSnapshotHeight: 0,
                 networkId: 1,
@@ -1078,13 +1079,13 @@ final class VotingRustBackendTests: XCTestCase {
             _ = try await backend.buildVoteCommitment(
                 roundId: "round1",
                 bundleIndex: 0,
-                hotkeySeed: [UInt8](repeating: 1, count: 32),
+                hotkeySeed: [UInt8](repeating: 1, count: votingMinSeedByteCount),
                 networkId: 1,
                 proposalId: 0,
                 choice: 0,
                 numOptions: 2,
                 vanWitness: VotingVanWitness(
-                    authPath: [[UInt8](repeating: 1, count: 32)],
+                    authPath: [[UInt8](repeating: 1, count: votingFieldElementByteCount)],
                     position: 0,
                     anchorHeight: 0
                 ),
@@ -1111,7 +1112,7 @@ final class VotingRustBackendTests: XCTestCase {
             _ = try await backend.buildVoteCommitment(
                 roundId: "round1",
                 bundleIndex: 0,
-                hotkeySeed: [UInt8](repeating: 1, count: 31),
+                hotkeySeed: [UInt8](repeating: 1, count: votingMinSeedByteCount - 1),
                 networkId: 1,
                 proposalId: 0,
                 choice: 0,
@@ -1205,10 +1206,10 @@ final class VotingRustBackendTests: XCTestCase {
             shareIndex: payloads[0].encShare.shareIndex,
             primaryBlind: payloads[0].primaryBlind
         )
-        XCTAssertEqual(nullifier.count, 64)
+        XCTAssertEqual(nullifier.count, votingShareNullifierHexCharacterCount)
 
         let signature = try VotingRustBackend.signCastVote(
-            hotkeySeed: [UInt8](repeating: 1, count: 32),
+            hotkeySeed: [UInt8](repeating: 1, count: votingMinSeedByteCount),
             networkId: 1,
             commitment: commitment
         )
@@ -1241,7 +1242,7 @@ final class VotingRustBackendTests: XCTestCase {
     func test_signCastVote_invalidCommitment_throwsRustError() {
         XCTAssertThrowsError(
             try VotingRustBackend.signCastVote(
-                hotkeySeed: [UInt8](repeating: 1, count: 32),
+                hotkeySeed: [UInt8](repeating: 1, count: votingMinSeedByteCount),
                 networkId: 1,
                 commitment: makeVoteCommitmentBundle(voteRoundId: "too-short")
             )
@@ -1256,7 +1257,7 @@ final class VotingRustBackendTests: XCTestCase {
     func test_signCastVote_rejectsShortSeed() {
         XCTAssertThrowsError(
             try VotingRustBackend.signCastVote(
-                hotkeySeed: [UInt8](repeating: 1, count: 31),
+                hotkeySeed: [UInt8](repeating: 1, count: votingMinSeedByteCount - 1),
                 networkId: 1,
                 commitment: makeVoteCommitmentBundle()
             )
@@ -1270,7 +1271,7 @@ final class VotingRustBackendTests: XCTestCase {
     }
 
     func test_signCastVote_rejectsWrongSizedCanonicalFields() {
-        let short = [UInt8](repeating: 1, count: 31)
+        let short = [UInt8](repeating: 1, count: votingFieldElementByteCount - 1)
 
         let cases: [(String, VotingVoteCommitmentBundle, String)] = [
             (
@@ -1303,7 +1304,7 @@ final class VotingRustBackendTests: XCTestCase {
         for (label, commitment, expectedMessage) in cases {
             XCTAssertThrowsError(
                 try VotingRustBackend.signCastVote(
-                    hotkeySeed: [UInt8](repeating: 1, count: 32),
+                    hotkeySeed: [UInt8](repeating: 1, count: votingMinSeedByteCount),
                     networkId: 1,
                     commitment: commitment
                 ),
@@ -1323,7 +1324,7 @@ final class VotingRustBackendTests: XCTestCase {
 
     func test_signCastVote_validFixture_returnsSignature() throws {
         let signature = try VotingRustBackend.signCastVote(
-            hotkeySeed: [UInt8](repeating: 1, count: 32),
+            hotkeySeed: [UInt8](repeating: 1, count: votingMinSeedByteCount),
             networkId: 1,
             commitment: makeVoteCommitmentBundle()
         )
@@ -1416,13 +1417,13 @@ final class VotingRustBackendTests: XCTestCase {
 
     private func makeEligibleNote() -> VotingNoteInfo {
         VotingNoteInfo(
-            commitment: [UInt8](repeating: 0x01, count: roundTripFieldElementByteCount),
-            nullifier: [UInt8](repeating: 0x02, count: roundTripFieldElementByteCount),
+            commitment: [UInt8](repeating: 0x01, count: votingFieldElementByteCount),
+            nullifier: [UInt8](repeating: 0x02, count: votingFieldElementByteCount),
             value: roundTripEligibleNoteValue,
             position: 0,
             diversifier: [UInt8](repeating: 0, count: roundTripDiversifierByteCount),
-            rho: [UInt8](repeating: 0, count: roundTripFieldElementByteCount),
-            rseed: [UInt8](repeating: 0, count: roundTripFieldElementByteCount),
+            rho: [UInt8](repeating: 0, count: votingFieldElementByteCount),
+            rseed: [UInt8](repeating: 0, count: votingFieldElementByteCount),
             scope: 0,
             ufvkStr: ""
         )
@@ -1554,20 +1555,20 @@ final class VotingRustBackendTests: XCTestCase {
     }
 
     private func makeVoteCommitmentBundle(
-        voteRoundId: String = String(repeating: "a", count: 64),
-        vanNullifier: [UInt8] = [UInt8](repeating: 1, count: 32),
-        voteAuthorityNoteNew: [UInt8] = [UInt8](repeating: 2, count: 32),
-        voteCommitment: [UInt8] = [UInt8](repeating: 3, count: 32),
+        voteRoundId: String = String(repeating: "a", count: votingVoteRoundIdHexCharacterCount),
+        vanNullifier: [UInt8] = [UInt8](repeating: 1, count: votingFieldElementByteCount),
+        voteAuthorityNoteNew: [UInt8] = [UInt8](repeating: 2, count: votingFieldElementByteCount),
+        voteCommitment: [UInt8] = [UInt8](repeating: 3, count: votingFieldElementByteCount),
         proposalId: UInt32 = 0,
         encShares: [VotingWireEncryptedShare] = [
             VotingWireEncryptedShare(
-                ciphertext1: [UInt8](repeating: 5, count: 32),
-                ciphertext2: [UInt8](repeating: 6, count: 32),
+                ciphertext1: [UInt8](repeating: 5, count: votingFieldElementByteCount),
+                ciphertext2: [UInt8](repeating: 6, count: votingFieldElementByteCount),
                 shareIndex: 0
             )
         ],
-        rVpkBytes: [UInt8] = [UInt8](repeating: 10, count: 32),
-        alphaV: [UInt8] = [UInt8](repeating: 11, count: 32)
+        rVpkBytes: [UInt8] = [UInt8](repeating: 10, count: votingFieldElementByteCount),
+        alphaV: [UInt8] = [UInt8](repeating: 11, count: votingFieldElementByteCount)
     ) -> VotingVoteCommitmentBundle {
         VotingVoteCommitmentBundle(
             vanNullifier: vanNullifier,
@@ -1579,8 +1580,8 @@ final class VotingRustBackendTests: XCTestCase {
             anchorHeight: 1,
             voteRoundId: voteRoundId,
             sharesHash: [7],
-            shareBlinds: [[UInt8](repeating: 8, count: 32)],
-            shareComms: [[UInt8](repeating: 9, count: 32)],
+            shareBlinds: [[UInt8](repeating: 8, count: votingFieldElementByteCount)],
+            shareComms: [[UInt8](repeating: 9, count: votingFieldElementByteCount)],
             rVpkBytes: rVpkBytes,
             alphaV: alphaV
         )

--- a/rust/src/voting/constants.rs
+++ b/rust/src/voting/constants.rs
@@ -1,11 +1,55 @@
+/// Canonical byte length for Pallas field elements used at the voting FFI boundary.
+pub(super) const CANONICAL_FIELD_LEN: usize = 32;
+
 /// Minimum seed length accepted by Zcash seed-based key derivation.
 pub(super) const MIN_SEED_LEN: usize = 32;
+
+/// Binary account UUID length passed across the voting FFI boundary.
+pub(super) const ACCOUNT_UUID_BYTE_LEN: usize = 16;
 
 /// Length of a Pallas seed fingerprint in bytes.
 pub(super) const SEED_FINGERPRINT_LEN: usize = 32;
 
-/// Canonical byte length for Pallas field elements used at the voting FFI boundary.
-pub(super) const CANONICAL_FIELD_LEN: usize = 32;
+/// Orchard full viewing key byte length used by delegation input generation.
+pub(super) const ORCHARD_FVK_LEN: usize = 96;
+
+/// Raw Orchard address byte length consumed by `zcash_voting`.
+pub(super) const HOTKEY_RAW_ADDRESS_LEN: usize = 43;
+
+/// Byte length of Keystone / RedPallas signatures at the voting FFI boundary.
+pub(super) const KEYSTONE_SIGNATURE_LEN: usize = 64;
+
+/// Byte length of ZIP-244 PCZT sighashes at the voting FFI boundary.
+pub(super) const PCZT_SIGHASH_LEN: usize = 32;
+
+/// Byte length of randomized verification keys at the voting FFI boundary.
+pub(super) const RANDOMIZED_KEY_LEN: usize = 32;
+
+/// Byte length of share reveal nullifiers.
+pub(super) const SHARE_NULLIFIER_LEN: usize = 32;
+
+/// Hex string length for share reveal nullifiers.
+pub(super) const SHARE_NULLIFIER_HEX_LEN: usize = SHARE_NULLIFIER_LEN * 2;
 
 /// Hex string length for canonical voting round identifiers.
-pub(super) const VOTE_ROUND_ID_HEX_LEN: usize = CANONICAL_FIELD_LEN * 2;
+pub(super) const VOTE_ROUND_ID_HEX_LEN: usize = 64;
+
+/// Byte length of root elements in PIR-fetched IMT non-membership proofs.
+pub(super) const PIR_ROOT_LEN: usize = 32;
+
+/// Byte length of `ImtProofData::nf_bounds`.
+pub(super) const PIR_NULLIFIER_BOUNDS_LEN: usize = PIR_ROOT_LEN * 3;
+
+/// Number of authentication path siblings in a PIR-fetched IMT proof.
+///
+/// Matches `zcash_voting::ImtProofData::path` and
+/// `voting_circuits::delegation::imt::IMT_DEPTH` (29). Kept local because
+/// `voting-circuits` is not a direct dependency of this crate and
+/// `zcash_voting` does not currently re-export the constant.
+pub(super) const PIR_PATH_ELEMENT_COUNT: usize = 29;
+
+/// Byte length of `ImtProofData::path`.
+pub(super) const PIR_PATH_LEN: usize = PIR_PATH_ELEMENT_COUNT * PIR_ROOT_LEN;
+
+/// Byte length of PIR nullifier field elements.
+pub(super) const PIR_NULLIFIER_LEN: usize = 32;

--- a/rust/src/voting/delegation.rs
+++ b/rust/src/voting/delegation.rs
@@ -12,7 +12,10 @@ use zcash_voting::{self as voting, zkp1};
 
 use crate::{unwrap_exc_or, unwrap_exc_or_null};
 
-use super::constants::SEED_FINGERPRINT_LEN;
+use super::constants::{
+    CANONICAL_FIELD_LEN, PIR_NULLIFIER_BOUNDS_LEN, PIR_NULLIFIER_LEN, PIR_PATH_ELEMENT_COUNT,
+    PIR_PATH_LEN, PIR_ROOT_LEN, SEED_FINGERPRINT_LEN,
+};
 use super::db::VotingDatabaseHandle;
 use super::ffi_types::{FfiBundleSetupResult, FfiVotingHotkey};
 use super::helpers::{
@@ -654,17 +657,6 @@ pub unsafe extern "C" fn zcashlc_voting_store_van_position(
     unwrap_exc_or(res, -1)
 }
 
-/// Depth of the IMT non-membership tree: number of authentication path
-/// siblings in a PIR-fetched proof. Matches `zcash_voting::ImtProofData::path`
-/// and `voting_circuits::delegation::imt::IMT_DEPTH` (29). Kept local because
-/// `voting-circuits` is not a direct dependency of this crate and
-/// `zcash_voting` does not currently re-export the constant.
-const NUM_PATH_ELEMENTS: usize = 29;
-
-/// Wire size of `ImtProofData::path` in bytes: one canonical 32-byte
-/// pallas::Base element per IMT depth level.
-const PATH_BYTES: usize = NUM_PATH_ELEMENTS * 32;
-
 /// Validate a PIR-fetched IMT non-membership proof bytewise.
 ///
 /// Inputs are the wire format of `zcash_voting::ImtProofData`: 32-byte LE
@@ -689,29 +681,41 @@ pub unsafe extern "C" fn zcashlc_voting_validate_pir_proof(
     expected_root: *const u8,
 ) -> i32 {
     let res = catch_panic(|| {
-        let root_bytes: [u8; 32] = unsafe { std::slice::from_raw_parts(root, 32) }
-            .try_into()
-            .map_err(|_| anyhow!("root must be exactly 32 bytes"))?;
-        let nf_bounds_bytes: [u8; 96] = unsafe { std::slice::from_raw_parts(nf_bounds, 96) }
-            .try_into()
-            .map_err(|_| anyhow!("nf_bounds must be exactly 96 bytes"))?;
-        let path_bytes: [u8; PATH_BYTES] = unsafe { std::slice::from_raw_parts(path, PATH_BYTES) }
-            .try_into()
-            .map_err(|_| anyhow!("path must be exactly {PATH_BYTES} bytes"))?;
-        let nullifier_bytes: [u8; 32] = unsafe { std::slice::from_raw_parts(nullifier, 32) }
-            .try_into()
-            .map_err(|_| anyhow!("nullifier must be exactly 32 bytes"))?;
-        let expected_root_bytes: [u8; 32] =
-            unsafe { std::slice::from_raw_parts(expected_root, 32) }
+        let root_bytes: [u8; PIR_ROOT_LEN] =
+            unsafe { std::slice::from_raw_parts(root, PIR_ROOT_LEN) }
                 .try_into()
-                .map_err(|_| anyhow!("expected_root must be exactly 32 bytes"))?;
+                .map_err(|_| anyhow!("root must be exactly {PIR_ROOT_LEN} bytes"))?;
+        let nf_bounds_bytes: [u8; PIR_NULLIFIER_BOUNDS_LEN] =
+            unsafe { std::slice::from_raw_parts(nf_bounds, PIR_NULLIFIER_BOUNDS_LEN) }
+                .try_into()
+                .map_err(|_| {
+                    anyhow!("nf_bounds must be exactly {PIR_NULLIFIER_BOUNDS_LEN} bytes")
+                })?;
+        let path_bytes: [u8; PIR_PATH_LEN] =
+            unsafe { std::slice::from_raw_parts(path, PIR_PATH_LEN) }
+                .try_into()
+                .map_err(|_| anyhow!("path must be exactly {PIR_PATH_LEN} bytes"))?;
+        let nullifier_bytes: [u8; PIR_NULLIFIER_LEN] =
+            unsafe { std::slice::from_raw_parts(nullifier, PIR_NULLIFIER_LEN) }
+                .try_into()
+                .map_err(|_| anyhow!("nullifier must be exactly {PIR_NULLIFIER_LEN} bytes"))?;
+        let expected_root_bytes: [u8; PIR_ROOT_LEN] =
+            unsafe { std::slice::from_raw_parts(expected_root, PIR_ROOT_LEN) }
+                .try_into()
+                .map_err(|_| anyhow!("expected_root must be exactly {PIR_ROOT_LEN} bytes"))?;
 
         let proof = zcash_voting::ImtProofData {
             root: parse_base(&root_bytes, "root")?,
             nf_bounds: [
-                parse_base(&nf_bounds_bytes[0..32], "nf_bounds[0]")?,
-                parse_base(&nf_bounds_bytes[32..64], "nf_bounds[1]")?,
-                parse_base(&nf_bounds_bytes[64..96], "nf_bounds[2]")?,
+                parse_base(&nf_bounds_bytes[0..CANONICAL_FIELD_LEN], "nf_bounds[0]")?,
+                parse_base(
+                    &nf_bounds_bytes[CANONICAL_FIELD_LEN..CANONICAL_FIELD_LEN * 2],
+                    "nf_bounds[1]",
+                )?,
+                parse_base(
+                    &nf_bounds_bytes[CANONICAL_FIELD_LEN * 2..PIR_NULLIFIER_BOUNDS_LEN],
+                    "nf_bounds[2]",
+                )?,
             ],
             leaf_pos,
             path: parse_path(&path_bytes)?,
@@ -729,16 +733,16 @@ pub unsafe extern "C" fn zcashlc_voting_validate_pir_proof(
 }
 
 fn parse_base(bytes: &[u8], label: &str) -> anyhow::Result<pallas::Base> {
-    let bytes: [u8; 32] = bytes
+    let bytes: [u8; CANONICAL_FIELD_LEN] = bytes
         .try_into()
-        .map_err(|_| anyhow!("{label} must be exactly 32 bytes"))?;
+        .map_err(|_| anyhow!("{label} must be exactly {CANONICAL_FIELD_LEN} bytes"))?;
     Option::from(pallas::Base::from_repr(bytes))
         .ok_or_else(|| anyhow!("{label} is not a canonical pallas::Base encoding"))
 }
 
-fn parse_path(bytes: &[u8]) -> anyhow::Result<[pallas::Base; NUM_PATH_ELEMENTS]> {
-    let mut path = [pallas::Base::from(0); NUM_PATH_ELEMENTS];
-    for (i, chunk) in bytes.chunks_exact(32).enumerate() {
+fn parse_path(bytes: &[u8]) -> anyhow::Result<[pallas::Base; PIR_PATH_ELEMENT_COUNT]> {
+    let mut path = [pallas::Base::from(0); PIR_PATH_ELEMENT_COUNT];
+    for (i, chunk) in bytes.chunks_exact(CANONICAL_FIELD_LEN).enumerate() {
         path[i] = parse_base(chunk, "path element")?;
     }
     Ok(path)
@@ -793,7 +797,7 @@ mod tests {
         proof_root: &[u8; 32],
         nf_bounds: &[u8; 96],
         leaf_pos: u32,
-        path: &[u8; PATH_BYTES],
+        path: &[u8; PIR_PATH_LEN],
         nullifier: &[u8; 32],
         expected_root: &[u8; 32],
     ) -> i32 {
@@ -1444,7 +1448,7 @@ mod tests {
     fn validate_pir_proof_accepts_valid() {
         let root = decode_hex::<32>(ROOT);
         let nf_bounds = decode_hex::<96>(NF_BOUNDS);
-        let path = decode_hex::<PATH_BYTES>(PATH);
+        let path = decode_hex::<PIR_PATH_LEN>(PATH);
         let nullifier = decode_hex::<32>(NULLIFIER);
         let expected_root = decode_hex::<32>(EXPECTED_ROOT);
 
@@ -1465,7 +1469,7 @@ mod tests {
     fn validate_pir_proof_rejects_root_mismatch() {
         let root = decode_hex::<32>(ROOT);
         let nf_bounds = decode_hex::<96>(NF_BOUNDS);
-        let path = decode_hex::<PATH_BYTES>(PATH);
+        let path = decode_hex::<PIR_PATH_LEN>(PATH);
         let nullifier = decode_hex::<32>(NULLIFIER);
         let mut expected_root = decode_hex::<32>(EXPECTED_ROOT);
         expected_root[0] ^= 1;
@@ -1487,7 +1491,7 @@ mod tests {
     fn validate_pir_proof_rejects_corrupted_path() {
         let root = decode_hex::<32>(ROOT);
         let nf_bounds = decode_hex::<96>(NF_BOUNDS);
-        let mut path = decode_hex::<PATH_BYTES>(PATH);
+        let mut path = decode_hex::<PIR_PATH_LEN>(PATH);
         let nullifier = decode_hex::<32>(NULLIFIER);
         let expected_root = decode_hex::<32>(EXPECTED_ROOT);
         path[0] ^= 1;
@@ -1508,7 +1512,7 @@ mod tests {
     #[test]
     fn validate_pir_proof_rejects_non_canonical_field_encoding() {
         let nf_bounds = decode_hex::<96>(NF_BOUNDS);
-        let path = decode_hex::<PATH_BYTES>(PATH);
+        let path = decode_hex::<PIR_PATH_LEN>(PATH);
         let non_canonical_root = [0xff; 32];
         let nullifier = decode_hex::<32>(NULLIFIER);
         let expected_root = decode_hex::<32>(EXPECTED_ROOT);

--- a/rust/src/voting/helpers.rs
+++ b/rust/src/voting/helpers.rs
@@ -9,7 +9,7 @@ use zcash_protocol::consensus::{self, Network};
 use zcash_voting as voting;
 use zip32::{AccountId, Scope};
 
-use super::constants::MIN_SEED_LEN;
+use super::constants::{HOTKEY_RAW_ADDRESS_LEN, MIN_SEED_LEN};
 use super::ffi_types::FfiVotingHotkey;
 
 // =============================================================================
@@ -177,12 +177,12 @@ pub(super) fn derive_hotkey_side_inputs(
     let hotkey_addr = hotkey_orchard_fvk.address_at(0u32, Scope::External);
     let hotkey_raw_address = hotkey_addr.to_raw_address_bytes().to_vec();
 
-    let hotkey_addr_43: [u8; 43] = hotkey_raw_address
+    let hotkey_addr_bytes: [u8; HOTKEY_RAW_ADDRESS_LEN] = hotkey_raw_address
         .as_slice()
         .try_into()
-        .map_err(|_| anyhow!("address serialization must be 43 bytes"))?;
+        .map_err(|_| anyhow!("address serialization must be {HOTKEY_RAW_ADDRESS_LEN} bytes"))?;
     let (g_d_new_x, pk_d_new_x) =
-        voting::action::derive_hotkey_x_coords_from_raw_address(&hotkey_addr_43)
+        voting::action::derive_hotkey_x_coords_from_raw_address(&hotkey_addr_bytes)
             .map_err(|e| anyhow!("derive_hotkey_x_coords failed: {}", e))?;
 
     Ok(HotkeySideInputs {

--- a/rust/src/voting/notes.rs
+++ b/rust/src/voting/notes.rs
@@ -6,6 +6,7 @@ use zcash_client_backend::data_api::{Account, WalletRead};
 
 use crate::unwrap_exc_or_null;
 
+use super::constants::ACCOUNT_UUID_BYTE_LEN;
 use super::db::VotingDatabaseHandle;
 use super::helpers::{
     bytes_from_ptr, json_to_boxed_slice, open_wallet_db, received_note_to_note_info, str_from_ptr,
@@ -15,9 +16,6 @@ use super::json::JsonNoteInfo;
 // =============================================================================
 // VotingDatabase methods — Wallet notes
 // =============================================================================
-
-/// Byte length of the binary account UUID passed as `account_uuid` / `account_uuid_len`.
-const ACCOUNT_UUID_BYTE_LEN: usize = 16;
 
 /// Get wallet notes eligible for voting at the given snapshot height.
 ///

--- a/rust/src/voting/recovery.rs
+++ b/rust/src/voting/recovery.rs
@@ -5,12 +5,9 @@ use ffi_helpers::panic::catch_panic;
 
 use crate::{unwrap_exc_or, unwrap_exc_or_null};
 
+use super::constants::{KEYSTONE_SIGNATURE_LEN, PCZT_SIGHASH_LEN, RANDOMIZED_KEY_LEN};
 use super::db::VotingDatabaseHandle;
 use super::helpers::{bytes_from_ptr, json_to_boxed_slice, str_from_ptr};
-
-const KEYSTONE_SIGNATURE_LEN: usize = 64;
-const PCZT_SIGHASH_LEN: usize = 32;
-const RANDOMIZED_KEY_LEN: usize = 32;
 
 #[derive(serde::Serialize)]
 struct JsonKeystoneSignatureRecord {

--- a/rust/src/voting/share_tracking.rs
+++ b/rust/src/voting/share_tracking.rs
@@ -10,10 +10,9 @@ use zcash_voting as voting;
 
 use crate::{unwrap_exc_or, unwrap_exc_or_null};
 
+use super::constants::{CANONICAL_FIELD_LEN, SHARE_NULLIFIER_HEX_LEN, SHARE_NULLIFIER_LEN};
 use super::db::VotingDatabaseHandle;
 use super::helpers::{bytes_from_ptr, json_to_boxed_slice, str_from_ptr};
-
-const SHARE_NULLIFIER_LEN: usize = 32;
 
 /// JSON representation for share delegation records crossing the FFI boundary.
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -65,10 +64,10 @@ fn hex_nibble(byte: u8) -> anyhow::Result<u8> {
 }
 
 fn decode_share_nullifier_hex(hex: &str) -> anyhow::Result<[u8; SHARE_NULLIFIER_LEN]> {
-    if hex.len() != SHARE_NULLIFIER_LEN * 2 {
+    if hex.len() != SHARE_NULLIFIER_HEX_LEN {
         return Err(anyhow!(
             "nullifier must be {} hex chars, got {}",
-            SHARE_NULLIFIER_LEN * 2,
+            SHARE_NULLIFIER_HEX_LEN,
             hex.len()
         ));
     }
@@ -95,12 +94,18 @@ pub unsafe extern "C" fn zcashlc_voting_compute_share_nullifier(
     share_index: u32,
 ) -> *mut c_char {
     let res = catch_panic(|| {
-        let vc: [u8; 32] = unsafe { std::slice::from_raw_parts(vote_commitment, 32) }
-            .try_into()
-            .map_err(|_| anyhow!("vote_commitment must be exactly 32 bytes"))?;
-        let blind: [u8; 32] = unsafe { std::slice::from_raw_parts(primary_blind, 32) }
-            .try_into()
-            .map_err(|_| anyhow!("primary_blind must be exactly 32 bytes"))?;
+        let vc: [u8; CANONICAL_FIELD_LEN] =
+            unsafe { std::slice::from_raw_parts(vote_commitment, CANONICAL_FIELD_LEN) }
+                .try_into()
+                .map_err(|_| {
+                    anyhow!("vote_commitment must be exactly {CANONICAL_FIELD_LEN} bytes")
+                })?;
+        let blind: [u8; CANONICAL_FIELD_LEN] =
+            unsafe { std::slice::from_raw_parts(primary_blind, CANONICAL_FIELD_LEN) }
+                .try_into()
+                .map_err(|_| {
+                    anyhow!("primary_blind must be exactly {CANONICAL_FIELD_LEN} bytes")
+                })?;
 
         let nullifier = voting::share_tracking::compute_share_nullifier(&vc, share_index, &blind)
             .map_err(|e| anyhow!("compute_share_nullifier failed: {}", e))?;

--- a/rust/src/voting/util.rs
+++ b/rust/src/voting/util.rs
@@ -8,7 +8,7 @@ use zip32::AccountId;
 
 use crate::{unwrap_exc_or, unwrap_exc_or_null};
 
-use super::constants::SEED_FINGERPRINT_LEN;
+use super::constants::{ORCHARD_FVK_LEN, SEED_FINGERPRINT_LEN};
 use super::helpers::{
     bytes_from_ptr, derive_hotkey_side_inputs, json_to_boxed_slice, str_from_ptr, usk_from_seed,
 };
@@ -130,8 +130,12 @@ pub unsafe extern "C" fn zcashlc_voting_generate_delegation_inputs_with_fvk(
         let hotkey = unsafe { bytes_from_ptr(hotkey_seed, hotkey_seed_len) }?;
         let seed_fp = unsafe { bytes_from_ptr(seed_fingerprint, seed_fingerprint_len) }?.to_vec();
 
-        if fvk.len() != 96 {
-            return Err(anyhow!("fvk_bytes must be 96 bytes, got {}", fvk.len()));
+        if fvk.len() != ORCHARD_FVK_LEN {
+            return Err(anyhow!(
+                "fvk_bytes must be {} bytes, got {}",
+                ORCHARD_FVK_LEN,
+                fvk.len()
+            ));
         }
         if seed_fp.len() != SEED_FINGERPRINT_LEN {
             return Err(anyhow!(
@@ -305,7 +309,7 @@ mod tests {
         bytes
     }
 
-    fn derive_test_ufvk(network: Network) -> (String, [u8; 96]) {
+    fn derive_test_ufvk(network: Network) -> (String, [u8; ORCHARD_FVK_LEN]) {
         let seed = [0u8; 32];
         let account = AccountId::try_from(0).expect("account 0");
         let usk = UnifiedSpendingKey::from_seed(&network, &seed, account).expect("from_seed");
@@ -433,7 +437,11 @@ mod tests {
         let actual = unsafe { (*result).as_slice() }.to_vec();
         free(result);
 
-        assert_eq!(actual.len(), 96, "Orchard FVK must be 96 bytes");
+        assert_eq!(
+            actual.len(),
+            ORCHARD_FVK_LEN,
+            "Orchard FVK must be {ORCHARD_FVK_LEN} bytes"
+        );
         assert_eq!(actual, expected.to_vec(), "FVK bytes must match");
     }
 
@@ -452,7 +460,11 @@ mod tests {
         let actual = unsafe { (*result).as_slice() }.to_vec();
         free(result);
 
-        assert_eq!(actual.len(), 96, "Orchard FVK must be 96 bytes");
+        assert_eq!(
+            actual.len(),
+            ORCHARD_FVK_LEN,
+            "Orchard FVK must be {ORCHARD_FVK_LEN} bytes"
+        );
         assert_eq!(actual, expected.to_vec(), "FVK bytes must match");
     }
 

--- a/rust/src/voting/vote.rs
+++ b/rust/src/voting/vote.rs
@@ -104,11 +104,12 @@ pub unsafe extern "C" fn zcashlc_voting_build_vote_commitment(
         let auth_path_bytes =
             unsafe { bytes_from_ptr(van_auth_path_json, van_auth_path_json_len) }?;
         let auth_path_vecs: Vec<Vec<u8>> = serde_json::from_slice(auth_path_bytes)?;
-        let auth_path: Vec<[u8; 32]> = auth_path_vecs
+        let auth_path: Vec<[u8; CANONICAL_FIELD_LEN]> = auth_path_vecs
             .into_iter()
             .map(|v| {
-                v.try_into()
-                    .map_err(|_| anyhow!("each auth_path sibling must be 32 bytes"))
+                v.try_into().map_err(|_| {
+                    anyhow!("each auth_path sibling must be {CANONICAL_FIELD_LEN} bytes")
+                })
             })
             .collect::<anyhow::Result<Vec<_>>>()?;
 


### PR DESCRIPTION
This is just a clean up PR from the voting merge, centralizing more constants

Checks:
- `cargo test -p libzcashlc voting:: --lib --locked`
- `swift test --filter VotingRustBackendTests`
