### PR TITLE
Pin libzcashlc binary to 2.6.0-alpha.2

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -30,8 +30,8 @@ if useLocalFFI {
     targets.append(
         .binaryTarget(
             name: "libzcashlc",
-            url: "https://github.com/zcash/zcash-swift-wallet-sdk/releases/download/2.6.0-alpha.1/libzcashlc.xcframework.zip",
-            checksum: "215e2c97cc2bfb11b0a8d15530431b5959ad44ab112e2df08699f9bfb463d4a1"
+            url: "https://github.com/zcash/zcash-swift-wallet-sdk/releases/download/2.6.0-alpha.2/libzcashlc.xcframework.zip",
+            checksum: "eab2e1be4b884b35af2333cd597a9570cff2a128dfb9d67a771451fefcd952e3"
         )
     )
     sdkDependencies.append("libzcashlc")


### PR DESCRIPTION
## Summary
- point the libzcashlc binary target at the 2.6.0-alpha.2 release artifact
- update the checksum to match the published alpha.2 xcframework
- keep the package source aligned with the current voting FFI API shape

## Verification
- swift package dump-package
- zashi-internal archive and Simulator build completed locally using this SDK checkout and alpha.2 artifact