### PR TITLE
Use released zcash_voting 0.10.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6127,9 +6127,9 @@ checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "vote-commitment-tree"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da7a7df678ac99da806f2b1a25c4074a21c653469f7532725af50aeebf36acc6"
+checksum = "870b893a2c53ec015d46fd3a33cf91715a9a968d34531208144f48e46398321c"
 dependencies = [
  "anyhow",
  "ff",
@@ -6144,9 +6144,9 @@ dependencies = [
 
 [[package]]
 name = "vote-commitment-tree-client"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d2b33754e263d55b684e486b396b2a06cead0ea4a754778b5b63064f13bd4f1"
+checksum = "03af018a5afbd7e58f2b233c96e64cc581d56cf12dd7daedd337cf6eaa10f80e"
 dependencies = [
  "base64",
  "ff",
@@ -7131,9 +7131,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_voting"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f78bb0f7c38d2c470f42ab454cd94054309d8d2e8315e7173ec3804d4bd81f3"
+checksum = "f23827ed8aa8fe8bd1bdda0f72cfffca36fe1d8fafde82e72b0f5561a7aae845"
 dependencies = [
  "anyhow",
  "blake2b_simd",
@@ -7148,12 +7148,14 @@ dependencies = [
  "hyper",
  "hyper-rustls",
  "hyper-util",
+ "imt-tree",
  "incrementalmerkletree",
  "nonempty",
  "orchard",
  "pasta_curves",
  "pczt",
  "pir-client",
+ "pir-types",
  "rand 0.8.6",
  "rusqlite",
  "serde",
@@ -7162,6 +7164,8 @@ dependencies = [
  "subtle",
  "thiserror 2.0.18",
  "tokio",
+ "valar-spiral-rs",
+ "valar-ypir",
  "vote-commitment-tree",
  "vote-commitment-tree-client",
  "voting-circuits",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -136,7 +136,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -147,7 +147,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1310,7 +1310,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1537,7 +1537,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2426,7 +2426,7 @@ version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a1886916523694cd6ea3d175f03a1e5010699a2a4cc13696d83d7bea1d80638"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2769,7 +2769,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3858,7 +3858,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4387,7 +4387,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4562,7 +4562,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6128,7 +6128,7 @@ checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 [[package]]
 name = "vote-commitment-tree"
 version = "0.2.0"
-source = "git+https://github.com/valargroup/zcash_voting?rev=10d800a40b182072c8e9f4f533424d0e261787e7#10d800a40b182072c8e9f4f533424d0e261787e7"
+source = "git+https://github.com/valargroup/zcash_voting?rev=0ab43e511b48866fa7511788e078a6e00e58a920#0ab43e511b48866fa7511788e078a6e00e58a920"
 dependencies = [
  "anyhow",
  "ff",
@@ -6144,7 +6144,7 @@ dependencies = [
 [[package]]
 name = "vote-commitment-tree-client"
 version = "0.4.0"
-source = "git+https://github.com/valargroup/zcash_voting?rev=10d800a40b182072c8e9f4f533424d0e261787e7#10d800a40b182072c8e9f4f533424d0e261787e7"
+source = "git+https://github.com/valargroup/zcash_voting?rev=0ab43e511b48866fa7511788e078a6e00e58a920#0ab43e511b48866fa7511788e078a6e00e58a920"
 dependencies = [
  "base64",
  "ff",
@@ -6364,7 +6364,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7098,7 +7098,7 @@ dependencies = [
 [[package]]
 name = "zcash_voting"
 version = "0.8.1"
-source = "git+https://github.com/valargroup/zcash_voting?rev=10d800a40b182072c8e9f4f533424d0e261787e7#10d800a40b182072c8e9f4f533424d0e261787e7"
+source = "git+https://github.com/valargroup/zcash_voting?rev=0ab43e511b48866fa7511788e078a6e00e58a920#0ab43e511b48866fa7511788e078a6e00e58a920"
 dependencies = [
  "anyhow",
  "blake2b_simd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3489,7 +3489,7 @@ dependencies = [
  "derive-deftly",
  "libc",
  "paste",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -6160,9 +6160,9 @@ dependencies = [
 
 [[package]]
 name = "voting-circuits"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a24eb3e3d2f7cf35c35703a4fff509323d2cba670e5e23099322bbd3ad410d9e"
+checksum = "30a5b61b6f99af50df900d839b9440fa36709166449c7fa831169391bc5f44bc"
 dependencies = [
  "blake2b_simd",
  "ff",
@@ -7131,9 +7131,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_voting"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "456e4448916228dac8e0828c63ca6a341c53f2590aa0542c878f9e533c2ec55f"
+checksum = "7f78bb0f7c38d2c470f42ab454cd94054309d8d2e8315e7173ec3804d4bd81f3"
 dependencies = [
  "anyhow",
  "blake2b_simd",
@@ -7158,6 +7158,7 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
+ "sinsemilla",
  "subtle",
  "thiserror 2.0.18",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -136,7 +136,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -147,7 +147,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1310,7 +1310,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1537,7 +1537,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2426,7 +2426,7 @@ version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a1886916523694cd6ea3d175f03a1e5010699a2a4cc13696d83d7bea1d80638"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2769,7 +2769,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3858,7 +3858,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4387,7 +4387,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4562,7 +4562,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6128,7 +6128,7 @@ checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 [[package]]
 name = "vote-commitment-tree"
 version = "0.2.0"
-source = "git+https://github.com/valargroup/zcash_voting?rev=ee63626fa2c37c48014b19cac9b786a1fa420dfb#ee63626fa2c37c48014b19cac9b786a1fa420dfb"
+source = "git+https://github.com/valargroup/zcash_voting?rev=10d800a40b182072c8e9f4f533424d0e261787e7#10d800a40b182072c8e9f4f533424d0e261787e7"
 dependencies = [
  "anyhow",
  "ff",
@@ -6144,7 +6144,7 @@ dependencies = [
 [[package]]
 name = "vote-commitment-tree-client"
 version = "0.4.0"
-source = "git+https://github.com/valargroup/zcash_voting?rev=ee63626fa2c37c48014b19cac9b786a1fa420dfb#ee63626fa2c37c48014b19cac9b786a1fa420dfb"
+source = "git+https://github.com/valargroup/zcash_voting?rev=10d800a40b182072c8e9f4f533424d0e261787e7#10d800a40b182072c8e9f4f533424d0e261787e7"
 dependencies = [
  "base64",
  "ff",
@@ -6364,7 +6364,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7098,7 +7098,7 @@ dependencies = [
 [[package]]
 name = "zcash_voting"
 version = "0.8.1"
-source = "git+https://github.com/valargroup/zcash_voting?rev=ee63626fa2c37c48014b19cac9b786a1fa420dfb#ee63626fa2c37c48014b19cac9b786a1fa420dfb"
+source = "git+https://github.com/valargroup/zcash_voting?rev=10d800a40b182072c8e9f4f533424d0e261787e7#10d800a40b182072c8e9f4f533424d0e261787e7"
 dependencies = [
  "anyhow",
  "blake2b_simd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -136,7 +136,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -147,7 +147,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1196,7 +1196,7 @@ checksum = "dd5f2b7218a51c827a11d22d1439b598121fac94bf9b99452e4afffe512d78c9"
 dependencies = [
  "heck",
  "indexmap 2.14.0",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "proc-macro-crate",
  "proc-macro2",
  "quote",
@@ -1310,7 +1310,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1537,7 +1537,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2237,7 +2237,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -2426,7 +2426,7 @@ version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a1886916523694cd6ea3d175f03a1e5010699a2a4cc13696d83d7bea1d80638"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2769,7 +2769,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3446,7 +3446,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
  "heck",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "petgraph 0.8.3",
@@ -3465,7 +3465,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -3489,7 +3489,7 @@ dependencies = [
  "derive-deftly",
  "libc",
  "paste",
- "thiserror 2.0.18",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -3858,7 +3858,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4387,7 +4387,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4562,7 +4562,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6127,8 +6127,9 @@ checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "vote-commitment-tree"
-version = "0.2.0"
-source = "git+https://github.com/valargroup/zcash_voting?rev=0ab43e511b48866fa7511788e078a6e00e58a920#0ab43e511b48866fa7511788e078a6e00e58a920"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da7a7df678ac99da806f2b1a25c4074a21c653469f7532725af50aeebf36acc6"
 dependencies = [
  "anyhow",
  "ff",
@@ -6143,8 +6144,9 @@ dependencies = [
 
 [[package]]
 name = "vote-commitment-tree-client"
-version = "0.4.0"
-source = "git+https://github.com/valargroup/zcash_voting?rev=0ab43e511b48866fa7511788e078a6e00e58a920#0ab43e511b48866fa7511788e078a6e00e58a920"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d2b33754e263d55b684e486b396b2a06cead0ea4a754778b5b63064f13bd4f1"
 dependencies = [
  "base64",
  "ff",
@@ -6159,7 +6161,8 @@ dependencies = [
 [[package]]
 name = "voting-circuits"
 version = "0.5.0"
-source = "git+https://github.com/valargroup/voting-circuits.git?rev=4c94389f1caab3bba1853b8d3f0c84e308b5cef2#4c94389f1caab3bba1853b8d3f0c84e308b5cef2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a24eb3e3d2f7cf35c35703a4fff509323d2cba670e5e23099322bbd3ad410d9e"
 dependencies = [
  "blake2b_simd",
  "ff",
@@ -6364,7 +6367,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6380,7 +6383,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
 dependencies = [
  "windows-collections",
- "windows-core",
+ "windows-core 0.61.2",
  "windows-future",
  "windows-link 0.1.3",
  "windows-numerics",
@@ -6392,7 +6395,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
 dependencies = [
- "windows-core",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -6404,8 +6407,21 @@ dependencies = [
  "windows-implement",
  "windows-interface",
  "windows-link 0.1.3",
- "windows-result",
- "windows-strings",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
 ]
 
 [[package]]
@@ -6414,7 +6430,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
- "windows-core",
+ "windows-core 0.61.2",
  "windows-link 0.1.3",
  "windows-threading",
 ]
@@ -6459,7 +6475,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
- "windows-core",
+ "windows-core 0.61.2",
  "windows-link 0.1.3",
 ]
 
@@ -6473,12 +6489,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "windows-strings"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -7097,8 +7131,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_voting"
-version = "0.8.1"
-source = "git+https://github.com/valargroup/zcash_voting?rev=0ab43e511b48866fa7511788e078a6e00e58a920#0ab43e511b48866fa7511788e078a6e00e58a920"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456e4448916228dac8e0828c63ca6a341c53f2590aa0542c878f9e533c2ec55f"
 dependencies = [
  "anyhow",
  "blake2b_simd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -136,7 +136,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -147,7 +147,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1196,7 +1196,7 @@ checksum = "dd5f2b7218a51c827a11d22d1439b598121fac94bf9b99452e4afffe512d78c9"
 dependencies = [
  "heck",
  "indexmap 2.14.0",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "proc-macro-crate",
  "proc-macro2",
  "quote",
@@ -1310,7 +1310,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1537,7 +1537,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2237,7 +2237,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -2426,7 +2426,7 @@ version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a1886916523694cd6ea3d175f03a1e5010699a2a4cc13696d83d7bea1d80638"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2769,7 +2769,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3446,7 +3446,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
  "heck",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "log",
  "multimap",
  "petgraph 0.8.3",
@@ -3465,7 +3465,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -3858,7 +3858,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4387,7 +4387,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4562,7 +4562,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6128,8 +6128,7 @@ checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 [[package]]
 name = "vote-commitment-tree"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be25d43d8b918599f579168a7aa2c0a12b2557bdc641324510f0d5797b1d59ac"
+source = "git+https://github.com/valargroup/zcash_voting?rev=ee63626fa2c37c48014b19cac9b786a1fa420dfb#ee63626fa2c37c48014b19cac9b786a1fa420dfb"
 dependencies = [
  "anyhow",
  "ff",
@@ -6145,8 +6144,7 @@ dependencies = [
 [[package]]
 name = "vote-commitment-tree-client"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ad6904ca2fdff4e39cea4700e924227eda14fb123b4212f917d0aea2b0a39c8"
+source = "git+https://github.com/valargroup/zcash_voting?rev=ee63626fa2c37c48014b19cac9b786a1fa420dfb#ee63626fa2c37c48014b19cac9b786a1fa420dfb"
 dependencies = [
  "base64",
  "ff",
@@ -6160,9 +6158,8 @@ dependencies = [
 
 [[package]]
 name = "voting-circuits"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0436d69b5884ca107db3de1be5e3e92981a35cd15dbfc6919361316a5dfa8e89"
+version = "0.5.0"
+source = "git+https://github.com/valargroup/voting-circuits.git?rev=4c94389f1caab3bba1853b8d3f0c84e308b5cef2#4c94389f1caab3bba1853b8d3f0c84e308b5cef2"
 dependencies = [
  "blake2b_simd",
  "ff",
@@ -6171,6 +6168,7 @@ dependencies = [
  "halo2_poseidon",
  "halo2_proofs",
  "incrementalmerkletree",
+ "itertools 0.14.0",
  "lazy_static",
  "orchard",
  "pasta_curves",
@@ -6366,7 +6364,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6382,7 +6380,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
 dependencies = [
  "windows-collections",
- "windows-core 0.61.2",
+ "windows-core",
  "windows-future",
  "windows-link 0.1.3",
  "windows-numerics",
@@ -6394,7 +6392,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
 dependencies = [
- "windows-core 0.61.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -6406,21 +6404,8 @@ dependencies = [
  "windows-implement",
  "windows-interface",
  "windows-link 0.1.3",
- "windows-result 0.3.4",
- "windows-strings 0.4.2",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.62.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
-dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
- "windows-strings 0.5.1",
+ "windows-result",
+ "windows-strings",
 ]
 
 [[package]]
@@ -6429,7 +6414,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
- "windows-core 0.61.2",
+ "windows-core",
  "windows-link 0.1.3",
  "windows-threading",
 ]
@@ -6474,7 +6459,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
- "windows-core 0.61.2",
+ "windows-core",
  "windows-link 0.1.3",
 ]
 
@@ -6488,30 +6473,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-result"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
-dependencies = [
- "windows-link 0.2.1",
-]
-
-[[package]]
 name = "windows-strings"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
  "windows-link 0.1.3",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
-dependencies = [
- "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -7131,8 +7098,7 @@ dependencies = [
 [[package]]
 name = "zcash_voting"
 version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2345d90daf1c4c30c1e6276d0c3e1f7e7952d3923ed31abee22f3c7fa090dec"
+source = "git+https://github.com/valargroup/zcash_voting?rev=ee63626fa2c37c48014b19cac9b786a1fa420dfb#ee63626fa2c37c48014b19cac9b786a1fa420dfb"
 dependencies = [
  "anyhow",
  "blake2b_simd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,7 +84,7 @@ rust_decimal = { version = "1", default-features = false, features = ["c-repr"] 
 xz2 = { version = "0.1", features = ["static"] }
 
 # Voting
-zcash_voting = { version = "0.10.0", default-features = false, features = [
+zcash_voting = { version = "=0.10.1", default-features = false, features = [
     "client-pir",
     "client-tree-sync",
 ] }
@@ -92,7 +92,7 @@ zcash_keys = { version = "0.13", features = ["orchard"] }
 incrementalmerkletree = { version = "0.8", default-features = false }
 
 [dev-dependencies]
-zcash_voting = { version = "0.10.0", default-features = false, features = ["test-fixtures"] }
+zcash_voting = { version = "0.10.1", default-features = false, features = ["test-fixtures"] }
 
 [build-dependencies]
 bindgen = "0.72"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,7 +84,7 @@ rust_decimal = { version = "1", default-features = false, features = ["c-repr"] 
 xz2 = { version = "0.1", features = ["static"] }
 
 # Voting
-zcash_voting = { version = "=0.10.1", default-features = false, features = [
+zcash_voting = { version = "0.10.1", default-features = false, features = [
     "client-pir",
     "client-tree-sync",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,7 +84,7 @@ rust_decimal = { version = "1", default-features = false, features = ["c-repr"] 
 xz2 = { version = "0.1", features = ["static"] }
 
 # Voting
-zcash_voting = { git = "https://github.com/valargroup/zcash_voting", rev = "0ab43e511b48866fa7511788e078a6e00e58a920", default-features = false, features = [
+zcash_voting = { version = "0.9.0", default-features = false, features = [
     "client-pir",
     "client-tree-sync",
 ] }
@@ -92,7 +92,7 @@ zcash_keys = { version = "0.13", features = ["orchard"] }
 incrementalmerkletree = { version = "0.8", default-features = false }
 
 [dev-dependencies]
-zcash_voting = { git = "https://github.com/valargroup/zcash_voting", rev = "0ab43e511b48866fa7511788e078a6e00e58a920", default-features = false, features = ["test-fixtures"] }
+zcash_voting = { version = "0.9.0", default-features = false, features = ["test-fixtures"] }
 
 [build-dependencies]
 bindgen = "0.72"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,7 +84,7 @@ rust_decimal = { version = "1", default-features = false, features = ["c-repr"] 
 xz2 = { version = "0.1", features = ["static"] }
 
 # Voting
-zcash_voting = { git = "https://github.com/valargroup/zcash_voting", rev = "ee63626fa2c37c48014b19cac9b786a1fa420dfb", default-features = false, features = [
+zcash_voting = { git = "https://github.com/valargroup/zcash_voting", rev = "10d800a40b182072c8e9f4f533424d0e261787e7", default-features = false, features = [
     "client-pir",
     "client-tree-sync",
 ] }
@@ -92,7 +92,7 @@ zcash_keys = { version = "0.13", features = ["orchard"] }
 incrementalmerkletree = { version = "0.8", default-features = false }
 
 [dev-dependencies]
-zcash_voting = { git = "https://github.com/valargroup/zcash_voting", rev = "ee63626fa2c37c48014b19cac9b786a1fa420dfb", default-features = false, features = ["test-fixtures"] }
+zcash_voting = { git = "https://github.com/valargroup/zcash_voting", rev = "10d800a40b182072c8e9f4f533424d0e261787e7", default-features = false, features = ["test-fixtures"] }
 
 [build-dependencies]
 bindgen = "0.72"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,7 +84,7 @@ rust_decimal = { version = "1", default-features = false, features = ["c-repr"] 
 xz2 = { version = "0.1", features = ["static"] }
 
 # Voting
-zcash_voting = { git = "https://github.com/valargroup/zcash_voting", rev = "10d800a40b182072c8e9f4f533424d0e261787e7", default-features = false, features = [
+zcash_voting = { git = "https://github.com/valargroup/zcash_voting", rev = "0ab43e511b48866fa7511788e078a6e00e58a920", default-features = false, features = [
     "client-pir",
     "client-tree-sync",
 ] }
@@ -92,7 +92,7 @@ zcash_keys = { version = "0.13", features = ["orchard"] }
 incrementalmerkletree = { version = "0.8", default-features = false }
 
 [dev-dependencies]
-zcash_voting = { git = "https://github.com/valargroup/zcash_voting", rev = "10d800a40b182072c8e9f4f533424d0e261787e7", default-features = false, features = ["test-fixtures"] }
+zcash_voting = { git = "https://github.com/valargroup/zcash_voting", rev = "0ab43e511b48866fa7511788e078a6e00e58a920", default-features = false, features = ["test-fixtures"] }
 
 [build-dependencies]
 bindgen = "0.72"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,7 +84,7 @@ rust_decimal = { version = "1", default-features = false, features = ["c-repr"] 
 xz2 = { version = "0.1", features = ["static"] }
 
 # Voting
-zcash_voting = { version = "0.9.0", default-features = false, features = [
+zcash_voting = { version = "0.10.0", default-features = false, features = [
     "client-pir",
     "client-tree-sync",
 ] }
@@ -92,7 +92,7 @@ zcash_keys = { version = "0.13", features = ["orchard"] }
 incrementalmerkletree = { version = "0.8", default-features = false }
 
 [dev-dependencies]
-zcash_voting = { version = "0.9.0", default-features = false, features = ["test-fixtures"] }
+zcash_voting = { version = "0.10.0", default-features = false, features = ["test-fixtures"] }
 
 [build-dependencies]
 bindgen = "0.72"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,7 +84,7 @@ rust_decimal = { version = "1", default-features = false, features = ["c-repr"] 
 xz2 = { version = "0.1", features = ["static"] }
 
 # Voting
-zcash_voting = { version = "0.8.1", default-features = false, features = [
+zcash_voting = { git = "https://github.com/valargroup/zcash_voting", rev = "ee63626fa2c37c48014b19cac9b786a1fa420dfb", default-features = false, features = [
     "client-pir",
     "client-tree-sync",
 ] }
@@ -92,7 +92,7 @@ zcash_keys = { version = "0.13", features = ["orchard"] }
 incrementalmerkletree = { version = "0.8", default-features = false }
 
 [dev-dependencies]
-zcash_voting = { version = "0.8.1", default-features = false, features = ["test-fixtures"] }
+zcash_voting = { git = "https://github.com/valargroup/zcash_voting", rev = "ee63626fa2c37c48014b19cac9b786a1fa420dfb", default-features = false, features = ["test-fixtures"] }
 
 [build-dependencies]
 bindgen = "0.72"

--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -7,7 +7,7 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Changed
-- Bumped `zcash_voting` to `0.10.0` for the pre-launch voting SQLite schema
+- Pinned `zcash_voting` to `=0.10.1` for the pre-launch voting SQLite schema
   reset, crate-owned recovery store missing-row errors, required voting input
   validation, paginated vote commitment tree sync responses with per-block
   roots, and the shared Orchard note conversion used by

--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -7,7 +7,7 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Changed
-- Bumped `zcash_voting` to `0.8.1` for the pre-launch voting SQLite schema
+- Bumped `zcash_voting` to `0.9.0` for the pre-launch voting SQLite schema
   reset, crate-owned recovery store missing-row errors, required voting input
   validation, paginated vote commitment tree sync responses with per-block
   roots, and the shared Orchard note conversion used by

--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -7,7 +7,7 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Changed
-- Bumped `zcash_voting` to `0.9.0` for the pre-launch voting SQLite schema
+- Bumped `zcash_voting` to `0.10.0` for the pre-launch voting SQLite schema
   reset, crate-owned recovery store missing-row errors, required voting input
   validation, paginated vote commitment tree sync responses with per-block
   roots, and the shared Orchard note conversion used by


### PR DESCRIPTION
## Summary
- Use the published `zcash_voting 0.10.1` crate instead of the temporary git revision.
- Refresh `Cargo.lock` so `zcash_voting`, `vote-commitment-tree`, `vote-commitment-tree-client`, and `voting-circuits` resolve from crates.io.
- Update the Rust changelog dependency note to match the released crate version.

## Test plan
- `cargo metadata --locked --format-version 1 --no-deps`
- `cargo tree --locked -i zcash_voting`
- `cargo tree --locked -p zcash_voting`
- `cargo check --locked`
- `cargo test --locked voting:: --lib`