### PR TITLE
Fail unmined sent tx whose expiry has passed when expired_unmined lags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Changed
 - New wallets now use a recent tree state from the lightwalletd server as the wallet birthday, reducing unnecessary block scanning on first launch while retaining reorg safety. Falls back to the bundled checkpoint if the server is unreachable.
+- `ZcashTransaction.Overview.State.init` now accepts an optional `expiryHeight:` argument and treats an unmined transaction whose `expiryHeight` is at or below the supplied `currentHeight` as `.expired` even when the `expiredUnmined` column hasn't been flipped to `true`. This makes the Swift-side state-machine resilient to lagging or missed updates of that column (in particular: sent transactions that were unmined when the wallet migrated across a consensus-rule change, which previously stayed reported as `.pending` indefinitely). Existing call sites that don't pass `expiryHeight` keep their prior behaviour.
 
 # 2.6.0-alpha.5
 

--- a/Sources/ZcashLightClientKit/Entity/TransactionEntity.swift
+++ b/Sources/ZcashLightClientKit/Entity/TransactionEntity.swift
@@ -24,7 +24,8 @@ public enum ZcashTransaction {
             init(
                 currentHeight: BlockHeight,
                 minedHeight: BlockHeight?,
-                expiredUnmined: Bool?
+                expiredUnmined: Bool?,
+                expiryHeight: BlockHeight? = nil
             ) {
                 guard let expiredUnmined, !expiredUnmined else {
                     self = .expired
@@ -36,7 +37,13 @@ public enum ZcashTransaction {
                 } else if let minedHeight, (currentHeight - minedHeight) < ZcashSDK.defaultStaleTolerance {
                     self = .pending
                 } else if minedHeight == nil {
-                    self = .pending
+                    // Fallback for when `expired_unmined` lags: a tx whose expiry has passed
+                    // is physically unminable regardless of column state.
+                    if let expiryHeight, expiryHeight > 0, currentHeight >= expiryHeight {
+                        self = .expired
+                    } else {
+                        self = .pending
+                    }
                 } else {
                     self = .expired
                 }
@@ -245,7 +252,8 @@ public extension ZcashTransaction.Overview {
         State(
             currentHeight: currentHeight,
             minedHeight: minedHeight,
-            expiredUnmined: self.isExpiredUmined
+            expiredUnmined: self.isExpiredUmined,
+            expiryHeight: self.expiryHeight
         )
     }
 

--- a/Tests/OfflineTests/ZcashTransactionStateTests.swift
+++ b/Tests/OfflineTests/ZcashTransactionStateTests.swift
@@ -54,6 +54,59 @@ final class ZcashTransactionStateTests: XCTestCase {
         )
     }
 
+    func testUnminedPastExpiryIsExpiredWhenColumnNotYetUpdated() {
+        let currentHeight = 1_500_000
+
+        XCTAssertEqual(
+            ZcashTransaction.Overview.State(
+                currentHeight: currentHeight,
+                minedHeight: nil,
+                expiredUnmined: false,
+                expiryHeight: currentHeight - 1
+            ),
+            .expired
+        )
+
+        XCTAssertEqual(
+            ZcashTransaction.Overview.State(
+                currentHeight: currentHeight,
+                minedHeight: nil,
+                expiredUnmined: false,
+                expiryHeight: currentHeight
+            ),
+            .expired
+        )
+
+        XCTAssertEqual(
+            ZcashTransaction.Overview.State(
+                currentHeight: currentHeight,
+                minedHeight: nil,
+                expiredUnmined: false,
+                expiryHeight: currentHeight + 100
+            ),
+            .pending
+        )
+
+        XCTAssertEqual(
+            ZcashTransaction.Overview.State(
+                currentHeight: currentHeight,
+                minedHeight: nil,
+                expiredUnmined: false,
+                expiryHeight: nil
+            ),
+            .pending
+        )
+
+        XCTAssertEqual(
+            ZcashTransaction.Overview.State(
+                currentHeight: currentHeight,
+                minedHeight: nil,
+                expiredUnmined: false
+            ),
+            .pending
+        )
+    }
+
     func testMinedHeightAboveOrEqualToStaleConstantIsConfirmed() {
         let currentHeight = 1010
 


### PR DESCRIPTION
## What

`ZcashTransaction.Overview.State.init` currently returns `.expired` only when the Rust-side `expired_unmined` SQLite column has been flipped to `true`. If the column hasn't been updated yet — or fails to update at all across a consensus-rule change — an unmined tx whose expiry has already passed keeps being reported as `.pending` indefinitely.

This PR adds an optional `expiryHeight:` argument to `State.init` and, when present, treats an unmined tx with `currentHeight >= expiryHeight` as `.expired` regardless of the column value. `Overview.getState(for:)` passes its own `expiryHeight` through.

This brings the Swift SDK to parity with the Android SDK, which already does this — see [TransactionOverview.kt:107-115](https://github.com/Electric-Coin-Company/zcash-android-wallet-sdk/blob/main/sdk-lib/src/main/java/cash/z/ecc/android/sdk/model/TransactionOverview.kt#L107-L115):

```kotlin
} ?: expiryHeight?.let { expiryHeight ->
    if (expiryHeight.value == 0L || expiryHeight > chainTip) {
        Pending
    } else {
        Expired
    }
}
```

## Why

Repro from production (tracked internally as Linear [PRO-334](https://linear.app/zodl/issue/PRO-334/failed-txs-remain-stuck-on-sending-after-zodl-is-updated-to-hf), private link for downstream reference): a user sent a tx on a pre-HF version of a wallet client built against this SDK. The tx broadcast but never mined (consensus rules changed under it). After the user updated to a post-HF client version, the tx kept rendering as "Sending" in their Activity list indefinitely. The signed tx bytes are bound to the old consensus branch, so it's physically unminable post-HF, and `TxResubmissionAction` correctly refuses to resubmit (`expiryHeight > upTo` filter). Funds were never at risk — but the visible state was a lie, the user asked support to "revert" the perceived stuck spend, and a different user in the same boat could plausibly re-send and convince themselves they were double-spending.

The bug is small in code and entirely fixable inside `State.init` if the function knows the row's expiry height.

## Backward compatibility

`expiryHeight` is added with a default value of `nil`. Existing callers that don't pass it compile and behave exactly as before. The only internal call site (`Overview.getState(for:)`) is updated to pass its own `expiryHeight` through.

## Test plan

New test `testUnminedPastExpiryIsExpiredWhenColumnNotYetUpdated` covers:

- `expiryHeight` below tip + unmined + `expiredUnmined == false` → `.expired` (new behaviour)
- `expiryHeight == tip` (equality boundary) → `.expired`
- `expiryHeight` above tip → `.pending`
- `expiryHeight == nil` → `.pending`
- Missing `expiryHeight` argument entirely (existing callers) → `.pending` unchanged

All previously-passing tests (`testExpiredUnminedState`, `testConfirmationsBelowStaleConstantIsPending`, `testMinedHeightAboveOrEqualToStaleConstantIsConfirmed`) keep their existing behaviour and assertions.

## Downstream

A companion fix [zodl-inc/zodl-ios#1824](https://github.com/zodl-inc/zodl-ios/pull/1824) plumbs the same fallback at the app layer so users can be unblocked before this PR ships in a release. That PR will become redundant once this one is in a tagged release.