### PR TITLE
[MOB-1339] Fix TxResubmissionAction first-cycle throttle + isolate per-candidate errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
+## Fixed
+- `TxResubmissionAction.latestResolvedTime` now seeds to the current wall-clock time at construction instead of `0`. The previous zero-init made the 5-minute throttle a no-op on the action's first invocation (`diff = now - 0` is ~56 years, well over the 300s threshold), so the action could re-broadcast a freshly-submitted transaction during the very first sync cycle of the session. The throttle now engages on first invocation as intended.
+- `TxResubmissionAction` now catches per-transaction submit errors inside the for-loop instead of around it. Previously, a throw on one candidate's encode or submit aborted the remaining candidates for the cycle while still advancing the throttle, hiding pending re-broadcasts until the next 5-minute window. Errors are also logged with the offending txid and the underlying cause.
+
 ## Changed
 - New wallets now use a recent tree state from the lightwalletd server as the wallet birthday, reducing unnecessary block scanning on first launch while retaining reorg safety. Falls back to the bundled checkpoint if the server is unreachable.
 - `ZcashTransaction.Overview.State.init` now accepts an optional `expiryHeight:` argument and treats an unmined transaction whose `expiryHeight` is at or below the supplied `currentHeight` as `.expired` even when the `expiredUnmined` column hasn't been flipped to `true`. This makes the Swift-side state-machine resilient to lagging or missed updates of that column (in particular: sent transactions that were unmined when the wallet migrated across a consensus-rule change, which previously stayed reported as `.pending` indefinitely). Existing call sites that don't pass `expiryHeight` keep their prior behaviour.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Fixed
 - `TxResubmissionAction.latestResolvedTime` now seeds to the current wall-clock time at construction instead of `0`. The previous zero-init made the 5-minute throttle a no-op on the action's first invocation (`diff = now - 0` is ~56 years, well over the 300s threshold), so the action could re-broadcast a freshly-submitted transaction during the very first sync cycle of the session. The throttle now engages on first invocation as intended.
-- `TxResubmissionAction` now catches per-transaction submit errors inside the for-loop instead of around it. Previously, a throw on one candidate's encode or submit aborted the remaining candidates for the cycle while still advancing the throttle, hiding pending re-broadcasts until the next 5-minute window. Errors are also logged with the offending txid and the underlying cause.
 
 ## Changed
 - New wallets now use a recent tree state from the lightwalletd server as the wallet birthday, reducing unnecessary block scanning on first launch while retaining reorg safety. Falls back to the bundled checkpoint if the server is unreachable.

--- a/Sources/ZcashLightClientKit/Block/Actions/TxResubmissionAction.swift
+++ b/Sources/ZcashLightClientKit/Block/Actions/TxResubmissionAction.swift
@@ -12,7 +12,7 @@ final class TxResubmissionAction {
         static let thresholdToTrigger = TimeInterval(300.0)
     }
     
-    var latestResolvedTime: TimeInterval = 0
+    var latestResolvedTime: TimeInterval = Date().timeIntervalSince1970
     let transactionRepository: TransactionRepository
     var transactionEncoder: TransactionEncoder
     let logger: Logger
@@ -44,18 +44,17 @@ extension TxResubmissionAction: Action {
                 
                 // the last time resubmission was triggered is more than 5 minutes ago so try again
                 if diff > Constants.thresholdToTrigger {
-                    // resubmission
-                    do {
-                        for transaction in transactions {
+                    for transaction in transactions {
+                        do {
                             logger.info("TxResubmissionAction trying to resubmit transaction \(transaction.rawID.toHexStringTxId()).")
                             let encodedTransaction = try transaction.encodedTransaction()
-                            
+
                             try await transactionEncoder.submit(transaction: encodedTransaction)
+                        } catch {
+                            logger.error("TxResubmissionAction failed to resubmit \(transaction.rawID.toHexStringTxId()): \(error)")
                         }
-                    } catch {
-                        logger.error("TxResubmissionAction failed to resubmit candidates.")
                     }
-                    
+
                     latestResolvedTime = Date().timeIntervalSince1970
                 }
             }

--- a/Tests/OfflineTests/CompactBlockProcessorActions/TxResubmissionActionTests.swift
+++ b/Tests/OfflineTests/CompactBlockProcessorActions/TxResubmissionActionTests.swift
@@ -63,7 +63,11 @@ final class TxResubmissionActionTests: ZcashTestCase {
             SubmitPlanExecutor(endpointSubmitter: self.endpointSubmitter, logger: submissionLifecycleLogger())
         }
 
-        return TxResubmissionAction(container: mockContainer)
+        let action = TxResubmissionAction(container: mockContainer)
+        // Push the throttle back so tests exercise the resubmit branch.
+        // The first-invocation throttle is covered by its own test.
+        action.latestResolvedTime = 0
+        return action
     }
 
     private func makeContext() -> ActionContextMock {
@@ -210,6 +214,24 @@ final class TxResubmissionActionTests: ZcashTestCase {
 
         let remaining = await submitPlanStore.allPlannedTransactionIds()
         XCTAssertTrue(remaining.isEmpty)
+    }
+
+    func testFreshActionThrottlesFirstInvocation() async throws {
+        let rawID = Data(repeating: 0x0F, count: 32)
+        let candidate = makeOverview(rawID: rawID)
+        let action = setupAction(candidates: [candidate])
+        // Undo the test-only push: a freshly constructed action should not
+        // resubmit on its first invocation, even when candidates are present.
+        action.latestResolvedTime = Date().timeIntervalSince1970
+        transactionRepository.findRawIDClosure = { _ in candidate }
+
+        _ = try await action.run(with: makeContext()) { _ in }
+
+        XCTAssertTrue(
+            transactionEncoder.submittedTransactions.isEmpty,
+            "Fresh action must not resubmit before the throttle window elapses"
+        )
+        XCTAssertTrue(endpointSubmitter.recordedSubmissions().isEmpty)
     }
 
     func testUnknownRepositoryErrorKeepsPlanDuringPruning() async throws {


### PR DESCRIPTION
Linear: [MOB-1339](https://linear.app/zodl/issue/MOB-1339)

Two scoped fixes to `TxResubmissionAction` that close an SDK-internal race producing redundant re-broadcasts of just-submitted user transactions. Companion hotfix PR #1759 (merged) closes the user-visible `.submitFailure` surface via server-verification.

## Bug 1 — Throttle is a no-op on first invocation

`TxResubmissionAction.latestResolvedTime` is meant to throttle the action so it doesn't re-broadcast unmined txs more often than every 5 minutes. The field was initialised to `0`, so on the action's first run `diff = now - 0 ≈ 1.78 billion seconds` — overwhelmingly above the 300s threshold. The throttle was a no-op on the very first invocation, which is exactly when a freshly-submitted user transaction is most likely to appear in `findForResubmission`'s result set. The action then re-broadcasts the just-submitted tx; the resulting server error gets swallowed by the action's `catch`, but lightwalletd has still seen the redundant submit.

### Fix
```diff
-    var latestResolvedTime: TimeInterval = 0
+    var latestResolvedTime: TimeInterval = Date().timeIntervalSince1970
```
The throttle gate now engages on first invocation. The action skips the first sync cycle's resubmit, sees the user's submit complete normally, and proceeds with the next 5-minute window as designed.

**Trade-off:** a wallet that starts up with a genuinely-stuck pending tx from a previous session waits ~5 minutes for the first re-broadcast attempt. Acceptable — the manual "Refresh Transaction Data" UI path (`Synchronizer.enhanceTransactionBy`) remains available, and the alternative (the documented race) is worse.

## Bug 2 — One candidate's failure abort the whole loop

The resubmission `for`-loop was wrapped in a single `do/catch` around the whole loop, not per-iteration. A throw on one candidate's `encodedTransaction()` or `submit()` aborted the remaining candidates while still advancing `latestResolvedTime`, so any pending re-broadcasts got hidden until the next 5-minute window.

### Fix
Per-candidate `do/catch` inside the loop (in this PR's final shape, this dovetails with main's `resubmit(transaction:)` helper introduced in #1757 — the per-tx error handling lives at the same boundary, just one level of indirection cleaner). A throw on one candidate now logs (with the offending txid and underlying error) and continues to the next candidate.

## Files
- **Modified**: `Sources/ZcashLightClientKit/Block/Actions/TxResubmissionAction.swift`
- **Modified**: `CHANGELOG.md` — Unreleased / Fixed entries.

## What this PR does *not* do
- Does **not** address the user-visible `.submitFailure` surface from the race. That originates in `SDKSynchronizer.submitTransactions`'s catch block, not in the resubmit-action, and is handled in #1759 via server-verification when a submit returns a non-zero error code.
- Does **not** persist any state across SDK restarts. The throttle is per-process; on a cold start the throttle is freshly engaged.