### PR TITLE
Rust: remove useless dead code annotation

### DIFF
--- a/rust/src/voting/helpers.rs
+++ b/rust/src/voting/helpers.rs
@@ -70,7 +70,6 @@ pub(super) fn open_wallet_db(
         .map_err(|e| anyhow!("failed to open wallet DB: {}", e))
 }
 
-#[allow(dead_code)]
 pub(super) fn round_phase_to_u32(phase: voting::storage::RoundPhase) -> u32 {
     use voting::storage::RoundPhase::*;
 
@@ -151,7 +150,6 @@ pub(super) fn derive_hotkey_side_inputs(
 // =============================================================================
 
 /// Convert a `voting::VotingHotkey` to the FFI representation.
-#[allow(dead_code)]
 pub(super) fn voting_hotkey_to_ffi(
     hotkey: voting::VotingHotkey,
 ) -> anyhow::Result<FfiVotingHotkey> {

--- a/rust/src/voting/json.rs
+++ b/rust/src/voting/json.rs
@@ -52,7 +52,6 @@ impl From<voting::NoteInfo> for JsonNoteInfo {
 }
 
 /// JSON-serializable VotingPczt.
-#[allow(dead_code)]
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct JsonVotingPczt {
     pub pczt_bytes: Vec<u8>,
@@ -135,7 +134,6 @@ impl From<JsonWitnessData> for voting::WitnessData {
 }
 
 /// JSON-serializable DelegationProofResult.
-#[allow(dead_code)]
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct JsonDelegationProofResult {
     pub proof: Vec<u8>,
@@ -181,7 +179,6 @@ impl From<voting::DelegationPirPrecomputeResult> for JsonDelegationPirPrecompute
 ///
 /// Omits the spend-auth randomizer `alpha`; the submission already carries
 /// `spend_auth_sig`, so callers do not need the signing secret after signing.
-#[allow(dead_code)]
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct JsonDelegationSubmission {
     pub rk: Vec<u8>,


### PR DESCRIPTION
The code is actually used