### PR TITLE
Depend on librustzcash feat/ironwood for Ironwood (NU6.3) tx-building support

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,5 @@
+# Ironwood (NU6.3) pre-release transaction-building support is gated behind this
+# unstable cfg in zcash/librustzcash's feat/ironwood branch (see Cargo.toml [patch.crates-io]
+# and ironwood-migration-execution.md). Remove once Ironwood stabilizes.
+[build]
+rustflags = ["--cfg", "zcash_unstable=\"nu6.3\""]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1517,8 +1517,7 @@ dependencies = [
 [[package]]
 name = "equihash"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "306286e8dcc39ab3dfceb74c792ce8baffdab90591321d3ffaae64829734c37f"
+source = "git+https://github.com/zcash/librustzcash?rev=676e8dd64f0b166ee3dcfaadafcc374e536693f6#676e8dd64f0b166ee3dcfaadafcc374e536693f6"
 dependencies = [
  "blake2b_simd",
  "corez",
@@ -1554,8 +1553,7 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d42773cb15447644d170be20231a3268600e0c4cea8987d013b93ac973d3cf7"
+source = "git+https://github.com/zcash/librustzcash?rev=676e8dd64f0b166ee3dcfaadafcc374e536693f6#676e8dd64f0b166ee3dcfaadafcc374e536693f6"
 dependencies = [
  "blake2b_simd",
 ]
@@ -1665,6 +1663,18 @@ name = "fluid-let"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "749cff877dc1af878a0b31a41dd221a753634401ea0ef2f87b62d3171522485a"
+
+[[package]]
+name = "flume"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "nanorand",
+ "spin",
+]
 
 [[package]]
 name = "fnv"
@@ -2527,7 +2537,7 @@ dependencies = [
  "log-panics",
  "nonempty",
  "once_cell",
- "orchard",
+ "orchard 0.15.0-pre.0",
  "pasta_curves",
  "pczt",
  "prost",
@@ -2705,6 +2715,15 @@ name = "multimap"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
+
+[[package]]
+name = "nanorand"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
+dependencies = [
+ "getrandom 0.2.17",
+]
 
 [[package]]
 name = "nom"
@@ -2961,6 +2980,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "orchard"
+version = "0.15.0-pre.0"
+source = "git+https://github.com/zcash/orchard?rev=2f322a220d2750c3fa752132f51594b8358f653f#2f322a220d2750c3fa752132f51594b8358f653f"
+dependencies = [
+ "aes",
+ "bitvec",
+ "blake2b_simd",
+ "corez",
+ "ff",
+ "fpe",
+ "getset",
+ "group",
+ "halo2_gadgets",
+ "halo2_poseidon",
+ "halo2_proofs",
+ "hex",
+ "incrementalmerkletree",
+ "lazy_static",
+ "memuse",
+ "nonempty",
+ "pasta_curves",
+ "rand 0.8.6",
+ "rand_core 0.6.4",
+ "reddsa",
+ "serde",
+ "sinsemilla",
+ "subtle",
+ "tracing",
+ "visibility",
+ "zcash_note_encryption",
+ "zcash_spec",
+ "zip32",
+]
+
+[[package]]
 name = "ordered-float"
 version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3078,8 +3132,7 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 [[package]]
 name = "pczt"
 version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4712bd8688e1d1aa0eb0e78dc5c846bc2d70dcd1de544ecf053516df174c4fcd"
+source = "git+https://github.com/zcash/librustzcash?rev=676e8dd64f0b166ee3dcfaadafcc374e536693f6#676e8dd64f0b166ee3dcfaadafcc374e536693f6"
 dependencies = [
  "blake2b_simd",
  "bls12_381",
@@ -3088,7 +3141,7 @@ dependencies = [
  "getset",
  "jubjub",
  "nonempty",
- "orchard",
+ "orchard 0.15.0-pre.0",
  "pasta_curves",
  "postcard",
  "rand_core 0.6.4",
@@ -4395,6 +4448,9 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
 
 [[package]]
 name = "spki"
@@ -6173,7 +6229,7 @@ dependencies = [
  "incrementalmerkletree",
  "itertools 0.14.0",
  "lazy_static",
- "orchard",
+ "orchard 0.14.0",
  "pasta_curves",
  "rand 0.8.6",
  "sinsemilla",
@@ -6831,8 +6887,7 @@ dependencies = [
 [[package]]
 name = "zcash_address"
 version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58342d0aaa8e2fa98849636f52800ac4bf020574c944c974742fc933db58cac2"
+source = "git+https://github.com/zcash/librustzcash?rev=676e8dd64f0b166ee3dcfaadafcc374e536693f6#676e8dd64f0b166ee3dcfaadafcc374e536693f6"
 dependencies = [
  "bech32",
  "bs58",
@@ -6845,8 +6900,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_backend"
 version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04583f0945d5ff80eee80c1844fb0af8b7cc46a0ac26d5e12c4ccd474bec0f03"
+source = "git+https://github.com/zcash/librustzcash?rev=676e8dd64f0b166ee3dcfaadafcc374e536693f6#676e8dd64f0b166ee3dcfaadafcc374e536693f6"
 dependencies = [
  "arti-client",
  "base64",
@@ -6855,9 +6909,9 @@ dependencies = [
  "bls12_381",
  "bs58",
  "byteorder",
- "crossbeam-channel",
  "document-features",
  "dynosaur",
+ "flume",
  "fs-mistrust",
  "futures-util",
  "getset",
@@ -6869,7 +6923,7 @@ dependencies = [
  "incrementalmerkletree",
  "memuse",
  "nonempty",
- "orchard",
+ "orchard 0.15.0-pre.0",
  "pasta_curves",
  "pczt",
  "percent-encoding",
@@ -6914,8 +6968,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_sqlite"
 version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a304b10b63df9df511ee198f9ffb14ccddd7a185e64fdb8bd65e8043c6e1258f"
+source = "git+https://github.com/zcash/librustzcash?rev=676e8dd64f0b166ee3dcfaadafcc374e536693f6#676e8dd64f0b166ee3dcfaadafcc374e536693f6"
 dependencies = [
  "bip32",
  "bitflags",
@@ -6928,7 +6981,7 @@ dependencies = [
  "jubjub",
  "maybe-rayon",
  "nonempty",
- "orchard",
+ "orchard 0.15.0-pre.0",
  "prost",
  "rand 0.8.6",
  "rand_core 0.6.4",
@@ -6961,8 +7014,7 @@ dependencies = [
 [[package]]
 name = "zcash_encoding"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1440921903cdb86133fb9e2fe800be488015db2939a30bedb413078a1acb0306"
+source = "git+https://github.com/zcash/librustzcash?rev=676e8dd64f0b166ee3dcfaadafcc374e536693f6#676e8dd64f0b166ee3dcfaadafcc374e536693f6"
 dependencies = [
  "corez",
  "hex",
@@ -6972,8 +7024,7 @@ dependencies = [
 [[package]]
 name = "zcash_keys"
 version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fbcdfbb5c8edb247439d72a397abaae9b7dd14a1c070e7e4fc3536924f9065f"
+source = "git+https://github.com/zcash/librustzcash?rev=676e8dd64f0b166ee3dcfaadafcc374e536693f6#676e8dd64f0b166ee3dcfaadafcc374e536693f6"
 dependencies = [
  "bech32",
  "bip32",
@@ -6986,7 +7037,7 @@ dependencies = [
  "group",
  "memuse",
  "nonempty",
- "orchard",
+ "orchard 0.15.0-pre.0",
  "rand_core 0.6.4",
  "sapling-crypto",
  "secrecy",
@@ -7015,8 +7066,7 @@ dependencies = [
 [[package]]
 name = "zcash_primitives"
 version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c69e07f5eb3f682a6467b4b08ee4956f1acd1e886d70b21c4766953b3a1beba2"
+source = "git+https://github.com/zcash/librustzcash?rev=676e8dd64f0b166ee3dcfaadafcc374e536693f6#676e8dd64f0b166ee3dcfaadafcc374e536693f6"
 dependencies = [
  "blake2b_simd",
  "block-buffer 0.11.0-rc.3",
@@ -7030,7 +7080,7 @@ dependencies = [
  "jubjub",
  "memuse",
  "nonempty",
- "orchard",
+ "orchard 0.15.0-pre.0",
  "rand_core 0.6.4",
  "redjubjub",
  "sapling-crypto",
@@ -7046,8 +7096,7 @@ dependencies = [
 [[package]]
 name = "zcash_proofs"
 version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3de6b0ca82e08a9d38b1121f87c5b180b5feac19fecba074cb582882210d2371"
+source = "git+https://github.com/zcash/librustzcash?rev=676e8dd64f0b166ee3dcfaadafcc374e536693f6#676e8dd64f0b166ee3dcfaadafcc374e536693f6"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -7068,8 +7117,7 @@ dependencies = [
 [[package]]
 name = "zcash_protocol"
 version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bec496a0bd62dae98c4b26f51c5dab112d0c5350bbc2ccfdfd05bb3454f714d"
+source = "git+https://github.com/zcash/librustzcash?rev=676e8dd64f0b166ee3dcfaadafcc374e536693f6#676e8dd64f0b166ee3dcfaadafcc374e536693f6"
 dependencies = [
  "corez",
  "document-features",
@@ -7107,8 +7155,7 @@ dependencies = [
 [[package]]
 name = "zcash_transparent"
 version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15df1908b428d4edeb7c7caae5692e05e2e92e5c38007a40b20ac098efdffd96"
+source = "git+https://github.com/zcash/librustzcash?rev=676e8dd64f0b166ee3dcfaadafcc374e536693f6#676e8dd64f0b166ee3dcfaadafcc374e536693f6"
 dependencies = [
  "bip32",
  "bs58",
@@ -7151,7 +7198,7 @@ dependencies = [
  "imt-tree",
  "incrementalmerkletree",
  "nonempty",
- "orchard",
+ "orchard 0.14.0",
  "pasta_curves",
  "pczt",
  "pir-client",
@@ -7247,8 +7294,7 @@ dependencies = [
 [[package]]
 name = "zip321"
 version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fef061351aa99792deb8f62b00426863a317ca2cb124c9de85550e3ef0f0f2f"
+source = "git+https://github.com/zcash/librustzcash?rev=676e8dd64f0b166ee3dcfaadafcc374e536693f6#676e8dd64f0b166ee3dcfaadafcc374e536693f6"
 dependencies = [
  "base64",
  "nom",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,10 @@ build = "rust/build.rs"
 [dependencies]
 
 # Zcash
-orchard = { version = "0.14", features = ["unstable-voting-circuits"] }
+# Ironwood (NU6.3): tracks the same git rev as [patch.crates-io] below directly,
+# since its version (0.15.0-pre.0) can't satisfy a "0.14" crates-io requirement.
+# "unstable-voting-circuits" dropped since it's only needed by the deferred voting feature.
+orchard = { git = "https://github.com/zcash/orchard", rev = "2f322a220d2750c3fa752132f51594b8358f653f" }
 pasta_curves = "0.5"
 ff = "0.13"
 sapling = { package = "sapling-crypto", version = "0.7", default-features = false }
@@ -84,12 +87,20 @@ rust_decimal = { version = "1", default-features = false, features = ["c-repr"] 
 xz2 = { version = "0.1", features = ["static"] }
 
 # Voting
+# Deferred while on the Ironwood (NU6.3) pre-release deps below: zcash_voting's
+# Ironwood-compatible branch only resolves against valargroup/librustzcash + their
+# orchard rev, which conflicts with the official zcash/librustzcash feat/ironwood
+# pins this branch uses. Open question for Kris/upstream — see
+# ironwood-migration-execution.md. `voting` feature is off by default until resolved.
 zcash_voting = { version = "0.11", default-features = false, features = [
     "client-pir",
     "client-tree-sync",
-] }
+], optional = true }
 zcash_keys = { version = "0.14", features = ["orchard"] }
 incrementalmerkletree = { version = "0.8", default-features = false }
+
+[features]
+voting = ["dep:zcash_voting"]
 
 [dev-dependencies]
 zcash_voting = { version = "0.11", default-features = false, features = ["test-fixtures"] }
@@ -98,6 +109,22 @@ zcash_voting = { version = "0.11", default-features = false, features = ["test-f
 bindgen = "0.72"
 cbindgen = "0.29"
 cc = "1.0"
+
+# Ironwood (NU6.3) pre-release support: pinned to zcash/librustzcash's feat/ironwood branch
+# instead of crates.io. This is the official org's active integration branch, not a
+# third-party fork — see ironwood-migration-execution.md for why. Unpin once these land
+# on crates.io as published pre-releases.
+[patch.crates-io]
+zcash_address = { git = "https://github.com/zcash/librustzcash", rev = "676e8dd64f0b166ee3dcfaadafcc374e536693f6" }
+zcash_client_backend = { git = "https://github.com/zcash/librustzcash", rev = "676e8dd64f0b166ee3dcfaadafcc374e536693f6" }
+zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash", rev = "676e8dd64f0b166ee3dcfaadafcc374e536693f6" }
+zcash_keys = { git = "https://github.com/zcash/librustzcash", rev = "676e8dd64f0b166ee3dcfaadafcc374e536693f6" }
+zcash_primitives = { git = "https://github.com/zcash/librustzcash", rev = "676e8dd64f0b166ee3dcfaadafcc374e536693f6" }
+zcash_proofs = { git = "https://github.com/zcash/librustzcash", rev = "676e8dd64f0b166ee3dcfaadafcc374e536693f6" }
+zcash_protocol = { git = "https://github.com/zcash/librustzcash", rev = "676e8dd64f0b166ee3dcfaadafcc374e536693f6" }
+zcash_transparent = { git = "https://github.com/zcash/librustzcash", rev = "676e8dd64f0b166ee3dcfaadafcc374e536693f6" }
+pczt = { git = "https://github.com/zcash/librustzcash", rev = "676e8dd64f0b166ee3dcfaadafcc374e536693f6" }
+orchard = { git = "https://github.com/zcash/orchard", rev = "2f322a220d2750c3fa752132f51594b8358f653f" }
 
 [lib]
 name = "zcashlc"

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -92,6 +92,8 @@ mod eip681;
 mod ffi;
 mod ironwood_migration;
 mod tor;
+// Deferred while on Ironwood (NU6.3) pre-release deps — see Cargo.toml [features] voting.
+#[cfg(feature = "voting")]
 mod voting;
 
 #[cfg(target_vendor = "apple")]
@@ -1332,7 +1334,7 @@ pub unsafe extern "C" fn zcashlc_rewind_to_height(
         let mut db_data = unsafe { wallet_db(db_data, db_data_len, network)? };
 
         let height = BlockHeight::from(height);
-        let result_height = db_data.rewind_to_height(height);
+        let result_height = db_data.truncate_to_height(height);
 
         result_height.map_or_else(
             |err| match err {
@@ -1837,6 +1839,11 @@ pub unsafe extern "C" fn zcashlc_put_utxo(
                 script_pubkey,
             ),
             Some(BlockHeight::from(height as u32)),
+            // This FFI call doesn't carry account context (same as before this API gained
+            // these fields) — left unset, consistent with prior behavior.
+            None,
+            None,
+            None,
         )
         .ok_or_else(|| {
             anyhow!(
@@ -2694,7 +2701,10 @@ pub unsafe extern "C" fn zcashlc_create_pczt_from_proposal(
             )
             .map_err(|e| anyhow!("Error creating PCZT from single-step proposal: {}", e))?;
 
-            Ok(ffi::BoxedSlice::some(pczt.serialize()))
+            Ok(ffi::BoxedSlice::some(
+                pczt.serialize()
+                    .map_err(|e| anyhow!("Error serializing PCZT: {:?}", e))?,
+            ))
         } else {
             Err(anyhow!(
                 "Multi-step proposals are not yet supported for PCZT generation."
@@ -2753,7 +2763,11 @@ pub unsafe extern "C" fn zcashlc_redact_pczt_for_signer(
             })
             .finish();
 
-        Ok(ffi::BoxedSlice::some(redacted_pczt.serialize()))
+        Ok(ffi::BoxedSlice::some(
+            redacted_pczt
+                .serialize()
+                .map_err(|e| anyhow!("Error serializing redacted PCZT: {:?}", e))?,
+        ))
     });
     unwrap_exc_or_null(res)
 }
@@ -2849,7 +2863,12 @@ pub unsafe extern "C" fn zcashlc_add_proofs_to_pczt(
 
         if prover.requires_orchard_proof() {
             prover = prover
-                .create_orchard_proof(&orchard::circuit::ProvingKey::build())
+                .create_orchard_proof(&orchard::circuit::ProvingKey::build(
+                    // Matches the PCZT extractor's own default for regular Orchard-pool
+                    // proving (see pczt's tx_extractor::orchard::verify_bundle); PostNu6_3
+                    // is reserved for the separate create_ironwood_proof path.
+                    orchard::circuit::OrchardCircuitVersion::FixedPostNu6_2,
+                ))
                 .map_err(|e| anyhow!("Failed to create Orchard proof for PCZT: {:?}", e))?;
         }
         assert!(!prover.requires_orchard_proof());
@@ -2878,7 +2897,11 @@ pub unsafe extern "C" fn zcashlc_add_proofs_to_pczt(
 
         let pczt_with_proofs = prover.finish();
 
-        Ok(ffi::BoxedSlice::some(pczt_with_proofs.serialize()))
+        Ok(ffi::BoxedSlice::some(
+            pczt_with_proofs
+                .serialize()
+                .map_err(|e| anyhow!("Error serializing PCZT with proofs: {:?}", e))?,
+        ))
     });
     unwrap_exc_or_null(res)
 }

--- a/rust/src/tor.rs
+++ b/rust/src/tor.rs
@@ -16,6 +16,7 @@ use zcash_client_backend::{
     tor::{Client, DormantMode},
     wallet::WalletTransparentOutput,
 };
+use zcash_client_sqlite::AccountUuid;
 use zcash_primitives::block::BlockHash;
 use zcash_protocol::{
     TxId,
@@ -204,7 +205,7 @@ impl LwdConn {
         address: TransparentAddress,
         start: Option<BlockHeight>,
         limit: Option<u32>,
-        mut f: impl FnMut(WalletTransparentOutput) -> anyhow::Result<()>,
+        mut f: impl FnMut(WalletTransparentOutput<AccountUuid>) -> anyhow::Result<()>,
     ) -> anyhow::Result<()> {
         let request = service::GetAddressUtxosArg {
             addresses: vec![address.encode(params)],
@@ -231,6 +232,11 @@ impl LwdConn {
                         Script(script::Code(result.script)),
                     ),
                     Some(BlockHeight::from(u32::try_from(result.height)?)),
+                    // This UTXO discovery call doesn't carry account context (same as
+                    // before this API gained these fields) — left unset.
+                    None,
+                    None,
+                    None,
                 )
                 .ok_or(anyhow!(
                     "Received UTXO that doesn't correspond to a valid P2PKH or P2SH address"


### PR DESCRIPTION
## Summary

- Wires `Cargo.toml`'s `[patch.crates-io]` + new `.cargo/config.toml` to `zcash/librustzcash`'s official `feat/ironwood` branch (pinned by commit sha) and the matching `zcash/orchard` rev, with the `--cfg zcash_unstable="nu6.3"` flag enabled. This is what gates `Builder::add_ironwood_output()`/`BuildConfig::Standard.ironwood_anchor` — the actual mechanism Orchard -> Ironwood migration transactions will be built with (confirmed by reading Valar's vizor-wallet reference implementation directly).
- `zcash_voting` is made optional behind a new off-by-default `voting` Cargo feature (`mod voting` gated accordingly). Its `orchard = "^0.14"` pin can't satisfy the Ironwood pre-release (`0.15.0-pre.0`) under semver, even on its newest published version — open question for upstream/Kris on whether `zcash_voting` can track the official `feat/ironwood` branch's orchard rev.
- Fixes the resulting upstream API drift in `rust/src/lib.rs` and `rust/src/tor.rs`: `rewind_to_height` -> `truncate_to_height` rename, `WalletTransparentOutput::from_parts` gained three `Option` args (left unset, consistent with prior behavior at these call sites), `Pczt::serialize()` now returns a `Result`, and `orchard::circuit::ProvingKey::build()` now requires an `OrchardCircuitVersion` (using `FixedPostNu6_2` to match the PCZT extractor's own default for regular Orchard-pool proving).

Stacked on #1791 — depends on its denomination-split planning work merging first.

This is dependency wiring only; no new transaction-building logic yet (that's the next PR in the migration series).

## Test plan

- [x] `cargo check` — zero errors, zero dependency-graph conflicts
- [ ] `cargo test`
- [ ] `swift build` / `swift test --filter OfflineTests`