### PR TITLE
[MOB-1455] Implement migration and public SDK API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,17 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   consensus transaction via the welding's extract step (`migrationExtractBroadcastTx`) before
   broadcasting. The public `Synchronizer` API and the network broadcast composition follow in a
   later change.
+- Public Orchard → Ironwood migration API on the (async) `Synchronizer` protocol, all taking
+  `for account: AccountUUID`: `migrationState`, `migrationProgress`, `isNoteSplitNeeded`,
+  `prepareNoteSplit`, `submitNoteSplit`, `proposeMigrationTransfers`, `signAndStoreMigrationSchedule`,
+  `isSyncRequiredBeforeNextTransfer`, `executeNextPendingTransfer`, `hasOverdueTransfers`,
+  `hasInvalidTransfers`, `restartCurrentMigrationStep`, and `initializePostUpgrade`. The two
+  broadcasting methods (`submitNoteSplit`, `executeNextPendingTransfer`) sign (or load) the engine's
+  prepared transaction and broadcast it over the SDK's existing direct submission path, mapping the
+  outcome to `TransferResult`; `executeNextPendingTransfer` also records the result back with the
+  engine. `NetworkPrivacyOptions` is accepted but not yet honored (broadcast uses the configured
+  lightwalletd). Async-only for now — the `ClosureSynchronizer` / `CombineSynchronizer` adapters are
+  not yet updated.
 
 ## Changed
 - The Rust core now builds against the valargroup `librustzcash` fork under

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,13 +21,16 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `for account: AccountUUID`: `migrationState`, `migrationProgress`, `isNoteSplitNeeded`,
   `prepareNoteSplit`, `submitNoteSplit`, `proposeMigrationTransfers`, `signAndStoreMigrationSchedule`,
   `isSyncRequiredBeforeNextTransfer`, `executeNextPendingTransfer`, `hasOverdueTransfers`,
-  `hasInvalidTransfers`, `restartCurrentMigrationStep`, and `initializePostUpgrade`. The two
-  broadcasting methods (`submitNoteSplit`, `executeNextPendingTransfer`) sign (or load) the engine's
-  prepared transaction and broadcast it over the SDK's existing direct submission path, mapping the
-  outcome to `TransferResult`; `executeNextPendingTransfer` also records the result back with the
-  engine. `NetworkPrivacyOptions` is accepted but not yet honored (broadcast uses the configured
-  lightwalletd). Async-only for now — the `ClosureSynchronizer` / `CombineSynchronizer` adapters are
-  not yet updated.
+  `hasInvalidTransfers`, `refreshStaleTransfers`, `restartCurrentMigrationStep`, and
+  `initializePostUpgrade`. The two broadcasting methods (`submitNoteSplit`,
+  `executeNextPendingTransfer`) sign (or load) the engine's prepared transaction, extract the
+  broadcast-ready consensus transaction from the signed PCZT (`migrationExtractBroadcastTx`), and
+  broadcast it over the SDK's existing direct submission path, mapping the outcome to
+  `TransferResult`; `executeNextPendingTransfer` also records the result back with the engine.
+  `refreshStaleTransfers` re-anchors/re-proves/re-signs stale scheduled transfers (pair with
+  `hasOverdueTransfers`). `NetworkPrivacyOptions` is accepted but not yet honored (broadcast uses the
+  configured lightwalletd). Async-only for now — the `ClosureSynchronizer` / `CombineSynchronizer`
+  adapters are not yet updated.
 
 ## Changed
 - The Rust core now builds against the valargroup `librustzcash` fork under

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -28,10 +28,11 @@ let outcome = await synchronizer.broadcaster.submit(
 
 ## Orchard → Ironwood migration API on `Synchronizer`
 
-The async `Synchronizer` protocol gains an Orchard → Ironwood migration surface (every method takes `for account: AccountUUID`): `migrationState`, `migrationProgress`, `isNoteSplitNeeded`, `prepareNoteSplit`, `submitNoteSplit`, `proposeMigrationTransfers`, `signAndStoreMigrationSchedule`, `isSyncRequiredBeforeNextTransfer`, `executeNextPendingTransfer`, `hasOverdueTransfers`, `hasInvalidTransfers`, `restartCurrentMigrationStep`, and `initializePostUpgrade`.
+The async `Synchronizer` protocol gains an Orchard → Ironwood migration surface (every method takes `for account: AccountUUID`): `migrationState`, `migrationProgress`, `isNoteSplitNeeded`, `prepareNoteSplit`, `submitNoteSplit`, `proposeMigrationTransfers`, `signAndStoreMigrationSchedule`, `isSyncRequiredBeforeNextTransfer`, `executeNextPendingTransfer`, `hasOverdueTransfers`, `hasInvalidTransfers`, `refreshStaleTransfers`, `restartCurrentMigrationStep`, and `initializePostUpgrade`.
 
 - If you provide your own type conforming to `Synchronizer`, you must implement these new methods. `SDKSynchronizer` already does, and the `ClosureSynchronizer` / `CombineSynchronizer` protocols are unchanged, so their adapters are unaffected.
-- `submitNoteSplit(proposal:spendingKey:options:for:)` and `executeNextPendingTransfer(options:for:)` broadcast the migration engine's pre-signed transaction over the SDK's existing direct submission path and return a `TransferResult`. The `options: NetworkPrivacyOptions` argument is accepted but ignored in this version (broadcast uses the already-configured lightwalletd).
+- `submitNoteSplit(proposal:spendingKey:options:for:)` and `executeNextPendingTransfer(options:for:)` broadcast the migration engine's pre-signed transaction over the SDK's existing direct submission path and return a `TransferResult`. Each first extracts the broadcast-ready consensus transaction from the engine's signed PCZT before submitting. The `options: NetworkPrivacyOptions` argument is accepted but ignored in this version (broadcast uses the already-configured lightwalletd).
+- `refreshStaleTransfers(spendingKey:for:)` re-anchors, re-proves and re-signs the active migration run's scheduled transfers when they have gone stale (anchor too old to broadcast), returning the number refreshed. Detect the need with `hasOverdueTransfers(for:)`.
 
 # Migrating from previous versions to 0.20.0-beta
 The `SDKSynchronizer` no longer uses `NotificationCenter` to send notifications.

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -26,6 +26,13 @@ let outcome = await synchronizer.broadcaster.submit(
 - The retry plan is recorded before any network attempt and stays recorded when `submit` returns `.cancelled` or `.timedOut`: background resubmission may still broadcast the transaction later. Treat those outcomes as "outcome unknown", not as "not sent".
 - `LightWalletEndpoint` now conforms to `Equatable`. If your app declared that conformance retroactively, remove your declaration.
 
+## Orchard → Ironwood migration API on `Synchronizer`
+
+The async `Synchronizer` protocol gains an Orchard → Ironwood migration surface (every method takes `for account: AccountUUID`): `migrationState`, `migrationProgress`, `isNoteSplitNeeded`, `prepareNoteSplit`, `submitNoteSplit`, `proposeMigrationTransfers`, `signAndStoreMigrationSchedule`, `isSyncRequiredBeforeNextTransfer`, `executeNextPendingTransfer`, `hasOverdueTransfers`, `hasInvalidTransfers`, `restartCurrentMigrationStep`, and `initializePostUpgrade`.
+
+- If you provide your own type conforming to `Synchronizer`, you must implement these new methods. `SDKSynchronizer` already does, and the `ClosureSynchronizer` / `CombineSynchronizer` protocols are unchanged, so their adapters are unaffected.
+- `submitNoteSplit(proposal:spendingKey:options:for:)` and `executeNextPendingTransfer(options:for:)` broadcast the migration engine's pre-signed transaction over the SDK's existing direct submission path and return a `TransferResult`. The `options: NetworkPrivacyOptions` argument is accepted but ignored in this version (broadcast uses the already-configured lightwalletd).
+
 # Migrating from previous versions to 0.20.0-beta
 The `SDKSynchronizer` no longer uses `NotificationCenter` to send notifications.
 Notifications are replaced with `Combine` publishers.

--- a/Sources/ZcashLightClientKit/Extensions/HexEncode.swift
+++ b/Sources/ZcashLightClientKit/Extensions/HexEncode.swift
@@ -25,6 +25,38 @@ extension Data {
     func hexEncodedString(options: HexEncodingOptions = []) -> String {
         z_hexEncodedString(data: self, options: options)
     }
+
+    /// Decodes a hex-encoded string into raw bytes. Returns `nil` for odd-length input or any
+    /// non-hex character. Accepts both upper- and lower-case digits.
+    init?(hexEncoded string: String) {
+        func decodeNibble(_ char: UInt16) -> UInt8? {
+            switch char {
+            case 0x30 ... 0x39:
+                return UInt8(char - 0x30)
+            case 0x41 ... 0x46:
+                return UInt8(char - 0x41 + 10)
+            case 0x61 ... 0x66:
+                return UInt8(char - 0x61 + 10)
+            default:
+                return nil
+            }
+        }
+
+        self.init(capacity: string.utf16.count / 2)
+        var even = true
+        var byte: UInt8 = 0
+        for char in string.utf16 {
+            guard let value = decodeNibble(char) else { return nil }
+            if even {
+                byte = value << 4
+            } else {
+                byte += value
+                self.append(byte)
+            }
+            even.toggle()
+        }
+        guard even else { return nil }
+    }
 }
 
 func z_hexEncodedString(data: Data, options: HexEncodingOptions = []) -> String {

--- a/Sources/ZcashLightClientKit/Model/Migration.swift
+++ b/Sources/ZcashLightClientKit/Model/Migration.swift
@@ -17,6 +17,18 @@ public struct MigrationProgress: Equatable, Codable {
     public let remainingOrchard: UInt64
     public let nextTransferReadyAtHeight: UInt32?
 
+    public init(
+        completedTransfers: UInt32,
+        totalTransfers: UInt32,
+        remainingOrchardZatoshi: UInt64,
+        nextTransferReadyAtHeight: UInt32?
+    ) {
+        self.completedTransfers = completedTransfers
+        self.totalTransfers = totalTransfers
+        self.remainingOrchardZatoshi = remainingOrchardZatoshi
+        self.nextTransferReadyAtHeight = nextTransferReadyAtHeight
+    }
+
     enum CodingKeys: String, CodingKey {
         case completedTransfers = "completed_transfers"
         case totalTransfers = "total_transfers"
@@ -33,6 +45,12 @@ public struct PreparedTx: Equatable, Codable {
     public let txid: String
     public let rawPczt: [UInt8]
 
+    public init(id: String, txid: String, rawTx: [UInt8]) {
+        self.id = id
+        self.txid = txid
+        self.rawTx = rawTx
+    }
+
     enum CodingKeys: String, CodingKey {
         case id
         case txid
@@ -44,6 +62,11 @@ public struct PreparedTx: Equatable, Codable {
 public struct NoteSplitProposal: Equatable, Codable {
     public let outputNotes: [UInt64]
     public let fee: UInt64
+
+    public init(outputNotes: [UInt64], fee: UInt64) {
+        self.outputNotes = outputNotes
+        self.fee = fee
+    }
 
     enum CodingKeys: String, CodingKey {
         case outputNotes = "output_notes"
@@ -60,6 +83,20 @@ public struct TransferProposal: Equatable, Codable {
     public let nextExecutableAfterHeight: UInt32
     public let expiryHeight: UInt32
 
+    public init(
+        id: String,
+        amountZatoshi: UInt64,
+        anchorHeight: UInt32,
+        nextExecutableAfterHeight: UInt32,
+        expiryHeight: UInt32
+    ) {
+        self.id = id
+        self.amountZatoshi = amountZatoshi
+        self.anchorHeight = anchorHeight
+        self.nextExecutableAfterHeight = nextExecutableAfterHeight
+        self.expiryHeight = expiryHeight
+    }
+
     enum CodingKeys: String, CodingKey {
         case id
         case amount
@@ -74,6 +111,11 @@ public struct MigrationSchedule: Equatable, Codable {
     public let transfers: [TransferProposal]
     public let estimatedDurationHours: UInt32
 
+    public init(transfers: [TransferProposal], estimatedDurationHours: UInt32) {
+        self.transfers = transfers
+        self.estimatedDurationHours = estimatedDurationHours
+    }
+
     enum CodingKeys: String, CodingKey {
         case transfers
         case estimatedDurationHours = "estimated_duration_hours"
@@ -85,6 +127,11 @@ public struct MigrationSchedule: Equatable, Codable {
 public struct NetworkPrivacyOptions: Equatable, Codable {
     public let useTor: Bool
     public let submissionEndpoint: String?
+
+    public init(useTor: Bool, submissionEndpoint: String?) {
+        self.useTor = useTor
+        self.submissionEndpoint = submissionEndpoint
+    }
 
     enum CodingKeys: String, CodingKey {
         case useTor = "use_tor"

--- a/Sources/ZcashLightClientKit/Model/Migration.swift
+++ b/Sources/ZcashLightClientKit/Model/Migration.swift
@@ -20,12 +20,12 @@ public struct MigrationProgress: Equatable, Codable {
     public init(
         completedTransfers: UInt32,
         totalTransfers: UInt32,
-        remainingOrchardZatoshi: UInt64,
+        remainingOrchard: UInt64,
         nextTransferReadyAtHeight: UInt32?
     ) {
         self.completedTransfers = completedTransfers
         self.totalTransfers = totalTransfers
-        self.remainingOrchardZatoshi = remainingOrchardZatoshi
+        self.remainingOrchard = remainingOrchard
         self.nextTransferReadyAtHeight = nextTransferReadyAtHeight
     }
 
@@ -45,10 +45,10 @@ public struct PreparedTx: Equatable, Codable {
     public let txid: String
     public let rawPczt: [UInt8]
 
-    public init(id: String, txid: String, rawTx: [UInt8]) {
+    public init(id: String, txid: String, rawPczt: [UInt8]) {
         self.id = id
         self.txid = txid
-        self.rawTx = rawTx
+        self.rawPczt = rawPczt
     }
 
     enum CodingKeys: String, CodingKey {
@@ -85,13 +85,13 @@ public struct TransferProposal: Equatable, Codable {
 
     public init(
         id: String,
-        amountZatoshi: UInt64,
+        amount: UInt64,
         anchorHeight: UInt32,
         nextExecutableAfterHeight: UInt32,
         expiryHeight: UInt32
     ) {
         self.id = id
-        self.amountZatoshi = amountZatoshi
+        self.amount = amount
         self.anchorHeight = anchorHeight
         self.nextExecutableAfterHeight = nextExecutableAfterHeight
         self.expiryHeight = expiryHeight

--- a/Sources/ZcashLightClientKit/Synchronizer.swift
+++ b/Sources/ZcashLightClientKit/Synchronizer.swift
@@ -561,6 +561,69 @@ public protocol Synchronizer: AnyObject {
     /// Use this to implement custom broadcast strategies such as submitting
     /// to multiple lightwalletd servers in parallel.
     var broadcaster: Broadcaster { get }
+
+    // MARK: - Ironwood migration
+
+    /// The current Orchard -> Ironwood migration state for `account`.
+    func migrationState(for account: AccountUUID) async throws -> MigrationState
+
+    /// Live migration progress for the progress UI, or `nil` when no migration is in progress.
+    func migrationProgress(for account: AccountUUID) async throws -> MigrationProgress?
+
+    /// Whether the account's Orchard notes must be split before migration can proceed.
+    func isNoteSplitNeeded(for account: AccountUUID) async throws -> Bool
+
+    /// The proposed note split (per-note output values and the prep-transaction fee).
+    func prepareNoteSplit(for account: AccountUUID) async throws -> NoteSplitProposal
+
+    /// Signs the note-split transaction for `proposal` and broadcasts it. After this returns
+    /// `.success`, the migration state advances to `.splitPendingConfirmation`; the app should poll
+    /// ``migrationState(for:)`` for confirmation.
+    /// - Parameter options: network-privacy preferences. Accepted but ignored in v1.
+    func submitNoteSplit(
+        proposal: NoteSplitProposal,
+        spendingKey: UnifiedSpendingKey,
+        options: NetworkPrivacyOptions,
+        for account: AccountUUID
+    ) async throws -> TransferResult
+
+    /// The full migration schedule for the spendable Orchard balance, presented to the user for a
+    /// one-time confirmation.
+    func proposeMigrationTransfers(for account: AccountUUID) async throws -> MigrationSchedule
+
+    /// Pre-signs and persists every transfer in the confirmed `schedule`.
+    func signAndStoreMigrationSchedule(
+        _ schedule: MigrationSchedule,
+        spendingKey: UnifiedSpendingKey,
+        for account: AccountUUID
+    ) async throws
+
+    /// Whether the wallet must sync before the next transfer can be broadcast (a previous transfer
+    /// produced change back to Orchard that must be observed first).
+    func isSyncRequiredBeforeNextTransfer(for account: AccountUUID) async throws -> Bool
+
+    /// Broadcasts the next height-due pre-signed transfer, records the outcome with the engine, and
+    /// returns it — or `nil` when no transfer is currently due. The transfer is already signed, so no
+    /// spending key is required. Intended to be called from the app's background scheduler; the app
+    /// must not sync in the same background session as this call.
+    /// - Parameter options: network-privacy preferences. Accepted but ignored in v1.
+    func executeNextPendingTransfer(
+        options: NetworkPrivacyOptions,
+        for account: AccountUUID
+    ) async throws -> TransferResult?
+
+    /// Whether any scheduled transfer is past the height at which it should have been broadcast.
+    func hasOverdueTransfers(for account: AccountUUID) async throws -> Bool
+
+    /// Whether the migration is in an invalid state (spendable Orchard remains but nothing covers it).
+    func hasInvalidTransfers(for account: AccountUUID) async throws -> Bool
+
+    /// Recovers from a `.requiresAttention` state by re-proposing the current migration step, returning
+    /// the fresh schedule.
+    func restartCurrentMigrationStep(for account: AccountUUID) async throws -> MigrationSchedule
+
+    /// One-time initialization to run after the wallet upgrades to an Ironwood-capable build.
+    func initializePostUpgrade(for account: AccountUUID) async throws
 }
 
 /// Error thrown by the default `Synchronizer.getTreeState(height:)` implementation

--- a/Sources/ZcashLightClientKit/Synchronizer.swift
+++ b/Sources/ZcashLightClientKit/Synchronizer.swift
@@ -618,6 +618,11 @@ public protocol Synchronizer: AnyObject {
     /// Whether the migration is in an invalid state (spendable Orchard remains but nothing covers it).
     func hasInvalidTransfers(for account: AccountUUID) async throws -> Bool
 
+    /// Re-anchors, re-proves and re-signs the active migration run's scheduled transfers when they have
+    /// gone stale (their anchor is too old to broadcast), returning the number of transfers refreshed.
+    /// Detect the need with ``hasOverdueTransfers(for:)``.
+    func refreshStaleTransfers(spendingKey: UnifiedSpendingKey, for account: AccountUUID) async throws -> UInt32
+
     /// Recovers from a `.requiresAttention` state by re-proposing the current migration step, returning
     /// the fresh schedule.
     func restartCurrentMigrationStep(for account: AccountUUID) async throws -> MigrationSchedule

--- a/Sources/ZcashLightClientKit/Synchronizer/SDKSynchronizer.swift
+++ b/Sources/ZcashLightClientKit/Synchronizer/SDKSynchronizer.swift
@@ -543,7 +543,7 @@ public class SDKSynchronizer: Synchronizer {
             usk: spendingKey,
             for: account
         )
-        return try await broadcastMigrationTx(prepared)
+        return try await broadcastMigrationTx(prepared, for: account)
     }
 
     public func proposeMigrationTransfers(for account: AccountUUID) async throws -> MigrationSchedule {
@@ -574,7 +574,7 @@ public class SDKSynchronizer: Synchronizer {
         guard let prepared = try await initializer.rustBackend.migrationNextDueTransfer(for: account) else {
             return nil
         }
-        let result = try await broadcastMigrationTx(prepared)
+        let result = try await broadcastMigrationTx(prepared, for: account)
         try await initializer.rustBackend.migrationRecordTransferResult(
             transferId: prepared.id,
             result: result,
@@ -583,21 +583,27 @@ public class SDKSynchronizer: Synchronizer {
         return result
     }
 
-    /// Broadcasts a crate-prepared migration transaction through the SDK's old direct submit path
-    /// (`transactionEncoder.submit`, not the broadcaster) and maps the outcome to a `TransferResult`,
+    /// Extracts the broadcast-ready consensus transaction from the crate-prepared, signed PCZT
+    /// (`PreparedTx.rawPczt`), broadcasts it through the SDK's old direct submit path
+    /// (`transactionEncoder.submit`, not the broadcaster), and maps the outcome to a `TransferResult`,
     /// mirroring `submitTransactions`' error handling.
     ///
     /// `invalidNote` / `expired` are intentionally not inferred from submit errors here — the
     /// migration engine owns deep invalidity: after broadcast, `migrationHasInvalidTransfers` /
     /// re-querying `migrationState` surfaces `.requiresAttention`, and `restartCurrentMigrationStep`
     /// recovers. So the Swift side maps obvious network outcomes and lets the engine reconcile.
-    private func broadcastMigrationTx(_ prepared: PreparedTx) async throws -> TransferResult {
+    private func broadcastMigrationTx(_ prepared: PreparedTx, for account: AccountUUID) async throws -> TransferResult {
+        // `PreparedTx.rawPczt` is a serialized PCZT, not a broadcastable transaction: extract the
+        // consensus transaction bytes first. An extract failure propagates (it is a crate/local error,
+        // not a network outcome) rather than being mapped to a `TransferResult`.
+        let txBytes = try await initializer.rustBackend.migrationExtractBroadcastTx(pczt: prepared.rawPczt, for: account)
+
         // `PreparedTx.txid` is the crate's display-order hex txid; `EncodedTransaction.transactionId`
         // and `isTransactionKnownToServer` need internal-order bytes, so decode then reverse.
         // TODO: [MOB-1455] honor NetworkPrivacyOptions (Tor / secondary endpoint). v1 broadcasts over
         // the SDK's already-configured service.
         let txIdData = Data(hexEncoded: prepared.txid).map { Data($0.reversed()) } ?? Data()
-        let encoded = EncodedTransaction(transactionId: txIdData, raw: Data(prepared.rawTx))
+        let encoded = EncodedTransaction(transactionId: txIdData, raw: Data(txBytes))
 
         do {
             try await transactionEncoder.submit(transaction: encoded)
@@ -620,6 +626,10 @@ public class SDKSynchronizer: Synchronizer {
 
     public func hasInvalidTransfers(for account: AccountUUID) async throws -> Bool {
         try await initializer.rustBackend.migrationHasInvalidTransfers(for: account)
+    }
+
+    public func refreshStaleTransfers(spendingKey: UnifiedSpendingKey, for account: AccountUUID) async throws -> UInt32 {
+        try await initializer.rustBackend.migrationRefreshStaleTransfers(usk: spendingKey, for: account)
     }
 
     public func restartCurrentMigrationStep(for account: AccountUUID) async throws -> MigrationSchedule {

--- a/Sources/ZcashLightClientKit/Synchronizer/SDKSynchronizer.swift
+++ b/Sources/ZcashLightClientKit/Synchronizer/SDKSynchronizer.swift
@@ -513,6 +513,123 @@ public class SDKSynchronizer: Synchronizer {
         })
     }
 
+    // MARK: - Ironwood migration
+
+    public func migrationState(for account: AccountUUID) async throws -> MigrationState {
+        try await initializer.rustBackend.migrationState(for: account)
+    }
+
+    public func migrationProgress(for account: AccountUUID) async throws -> MigrationProgress? {
+        try await initializer.rustBackend.migrationProgress(for: account)
+    }
+
+    public func isNoteSplitNeeded(for account: AccountUUID) async throws -> Bool {
+        try await initializer.rustBackend.migrationIsNoteSplitNeeded(for: account)
+    }
+
+    public func prepareNoteSplit(for account: AccountUUID) async throws -> NoteSplitProposal {
+        try await initializer.rustBackend.migrationPrepareNoteSplit(for: account)
+    }
+
+    public func submitNoteSplit(
+        proposal: NoteSplitProposal,
+        spendingKey: UnifiedSpendingKey,
+        options: NetworkPrivacyOptions,
+        for account: AccountUUID
+    ) async throws -> TransferResult {
+        // `options` is accepted but ignored in v1 (see `broadcastMigrationTx`).
+        let prepared = try await initializer.rustBackend.migrationSignNoteSplit(
+            proposal: proposal,
+            usk: spendingKey,
+            for: account
+        )
+        return try await broadcastMigrationTx(prepared)
+    }
+
+    public func proposeMigrationTransfers(for account: AccountUUID) async throws -> MigrationSchedule {
+        try await initializer.rustBackend.migrationProposeTransfers(for: account)
+    }
+
+    public func signAndStoreMigrationSchedule(
+        _ schedule: MigrationSchedule,
+        spendingKey: UnifiedSpendingKey,
+        for account: AccountUUID
+    ) async throws {
+        try await initializer.rustBackend.migrationSignAndStore(
+            schedule: schedule,
+            usk: spendingKey,
+            for: account
+        )
+    }
+
+    public func isSyncRequiredBeforeNextTransfer(for account: AccountUUID) async throws -> Bool {
+        try await initializer.rustBackend.migrationIsSyncRequired(for: account)
+    }
+
+    public func executeNextPendingTransfer(
+        options: NetworkPrivacyOptions,
+        for account: AccountUUID
+    ) async throws -> TransferResult? {
+        // `options` is accepted but ignored in v1 (see `broadcastMigrationTx`).
+        guard let prepared = try await initializer.rustBackend.migrationNextDueTransfer(for: account) else {
+            return nil
+        }
+        let result = try await broadcastMigrationTx(prepared)
+        try await initializer.rustBackend.migrationRecordTransferResult(
+            transferId: prepared.id,
+            result: result,
+            for: account
+        )
+        return result
+    }
+
+    /// Broadcasts a crate-prepared migration transaction through the SDK's old direct submit path
+    /// (`transactionEncoder.submit`, not the broadcaster) and maps the outcome to a `TransferResult`,
+    /// mirroring `submitTransactions`' error handling.
+    ///
+    /// `invalidNote` / `expired` are intentionally not inferred from submit errors here — the
+    /// migration engine owns deep invalidity: after broadcast, `migrationHasInvalidTransfers` /
+    /// re-querying `migrationState` surfaces `.requiresAttention`, and `restartCurrentMigrationStep`
+    /// recovers. So the Swift side maps obvious network outcomes and lets the engine reconcile.
+    private func broadcastMigrationTx(_ prepared: PreparedTx) async throws -> TransferResult {
+        // `PreparedTx.txid` is the crate's display-order hex txid; `EncodedTransaction.transactionId`
+        // and `isTransactionKnownToServer` need internal-order bytes, so decode then reverse.
+        // TODO: [MOB-1455] honor NetworkPrivacyOptions (Tor / secondary endpoint). v1 broadcasts over
+        // the SDK's already-configured service.
+        let txIdData = Data(hexEncoded: prepared.txid).map { Data($0.reversed()) } ?? Data()
+        let encoded = EncodedTransaction(transactionId: txIdData, raw: Data(prepared.rawTx))
+
+        do {
+            try await transactionEncoder.submit(transaction: encoded)
+            return .success(txid: prepared.txid)
+        } catch ZcashError.serviceSubmitFailed {
+            return .networkError(retryable: true)
+        } catch TransactionEncoderError.submitError {
+            // Trust the network over the submit-side error: if the server already has this tx, the
+            // broadcast already landed. Mirror `submitTransactions`' isTransactionKnownToServer check.
+            if await transactionEncoder.isTransactionKnownToServer(txId: txIdData) {
+                return .success(txid: prepared.txid)
+            }
+            return .networkError(retryable: false)
+        }
+    }
+
+    public func hasOverdueTransfers(for account: AccountUUID) async throws -> Bool {
+        try await initializer.rustBackend.migrationHasOverdueTransfers(for: account)
+    }
+
+    public func hasInvalidTransfers(for account: AccountUUID) async throws -> Bool {
+        try await initializer.rustBackend.migrationHasInvalidTransfers(for: account)
+    }
+
+    public func restartCurrentMigrationStep(for account: AccountUUID) async throws -> MigrationSchedule {
+        try await initializer.rustBackend.migrationRestartStep(for: account)
+    }
+
+    public func initializePostUpgrade(for account: AccountUUID) async throws {
+        try await initializer.rustBackend.migrationInitializePostUpgrade(for: account)
+    }
+
     public func createPCZTFromProposal(accountUUID: AccountUUID, proposal: Proposal) async throws -> Pczt {
         try await initializer.rustBackend.createPCZTFromProposal(
             accountUUID: accountUUID,

--- a/Tests/OfflineTests/DataHexEncodedTests.swift
+++ b/Tests/OfflineTests/DataHexEncodedTests.swift
@@ -1,0 +1,42 @@
+//
+//  DataHexEncodedTests.swift
+//  ZcashLightClientKit
+//
+//  Tests for the internal `Data(hexEncoded:)` initializer used by the Ironwood migration
+//  broadcast composites to turn the crate's hex `PreparedTx.txid` into bytes.
+//
+
+import XCTest
+@testable import ZcashLightClientKit
+
+final class DataHexEncodedTests: XCTestCase {
+    func testDecodesLowercaseHex() {
+        let data = Data(hexEncoded: "deadbeef")
+        XCTAssertEqual(data, Data([0xde, 0xad, 0xbe, 0xef]))
+    }
+
+    func testDecodesUppercaseHex() {
+        let data = Data(hexEncoded: "DEADBEEF")
+        XCTAssertEqual(data, Data([0xde, 0xad, 0xbe, 0xef]))
+    }
+
+    func testDecodesEmptyStringToEmptyData() {
+        let data = Data(hexEncoded: "")
+        XCTAssertEqual(data, Data())
+    }
+
+    func testReturnsNilForOddLengthString() {
+        XCTAssertNil(Data(hexEncoded: "abc"))
+    }
+
+    func testReturnsNilForNonHexCharacters() {
+        XCTAssertNil(Data(hexEncoded: "zz"))
+        XCTAssertNil(Data(hexEncoded: "12g4"))
+    }
+
+    func testRoundTripsWithHexEncodedString() {
+        let bytes = Data([0x00, 0x01, 0x5c, 0xf9, 0xff])
+        let decoded = Data(hexEncoded: bytes.hexEncodedString())
+        XCTAssertEqual(decoded, bytes)
+    }
+}

--- a/Tests/OfflineTests/MigrationSynchronizerTests.swift
+++ b/Tests/OfflineTests/MigrationSynchronizerTests.swift
@@ -1,0 +1,395 @@
+//
+//  MigrationSynchronizerTests.swift
+//  OfflineTests
+//
+//  Unit tests for the public Orchard -> Ironwood migration API on `SDKSynchronizer`: the two
+//  broadcast composites (submitNoteSplit / executeNextPendingTransfer) and the thin delegations to
+//  the rust backend welding. The composites are driven against a `ZcashRustBackendWeldingMock` (the
+//  sign / next-due / record building blocks) and a `StubTransactionEncoder` (the old direct submit
+//  path). End-to-end propose/sign/submit needs a seeded, synced DB and is out of scope here.
+//
+
+import XCTest
+@testable import TestUtils
+@testable import ZcashLightClientKit
+
+final class MigrationSynchronizerTests: ZcashTestCase {
+    private let account = AccountUUID(id: [UInt8](repeating: 7, count: 16))
+    private let options = NetworkPrivacyOptions(useTor: false, submissionEndpoint: nil)
+
+    private enum TestError: Error {
+        case boom
+    }
+
+    // MARK: - submitNoteSplit
+
+    func testSubmitNoteSplitSignsAndSubmitsThenReturnsSuccess() async throws {
+        let prepared = makePreparedTx()
+        let rustBackend = ZcashRustBackendWeldingMock()
+        rustBackend.migrationSignNoteSplitProposalUskForReturnValue = prepared
+        let encoder = StubTransactionEncoder(createdTransactions: [])
+        let synchronizer = try makeSynchronizer(transactionEncoder: encoder, rustBackend: rustBackend)
+
+        let proposal = NoteSplitProposal(outputNotes: [100, 200], fee: 10)
+        let result = try await synchronizer.submitNoteSplit(
+            proposal: proposal,
+            spendingKey: TestsData(networkType: .testnet).spendingKey,
+            options: options,
+            for: account
+        )
+
+        XCTAssertEqual(result, .success(txid: prepared.txid))
+        XCTAssertEqual(rustBackend.migrationSignNoteSplitProposalUskForReceivedArguments?.proposal, proposal)
+        XCTAssertEqual(rustBackend.migrationSignNoteSplitProposalUskForReceivedArguments?.account, account)
+        XCTAssertEqual(encoder.submittedTransactions.map(\.raw), [Data(prepared.rawTx)])
+        XCTAssertEqual(encoder.submittedTransactions.first?.transactionId, expectedSubmittedTxId(prepared))
+    }
+
+    func testSubmitNoteSplitMapsGrpcFailureToRetryableNetworkError() async throws {
+        let prepared = makePreparedTx()
+        let rustBackend = ZcashRustBackendWeldingMock()
+        rustBackend.migrationSignNoteSplitProposalUskForReturnValue = prepared
+        let encoder = StubTransactionEncoder(createdTransactions: [])
+        encoder.submitError = ZcashError.serviceSubmitFailed(.timeOut)
+        let synchronizer = try makeSynchronizer(transactionEncoder: encoder, rustBackend: rustBackend)
+
+        let result = try await synchronizer.submitNoteSplit(
+            proposal: NoteSplitProposal(outputNotes: [100], fee: 10),
+            spendingKey: TestsData(networkType: .testnet).spendingKey,
+            options: options,
+            for: account
+        )
+
+        XCTAssertEqual(result, .networkError(retryable: true))
+    }
+
+    func testSubmitNoteSplitMapsKnownToServerSubmitErrorToSuccess() async throws {
+        let prepared = makePreparedTx()
+        let rustBackend = ZcashRustBackendWeldingMock()
+        rustBackend.migrationSignNoteSplitProposalUskForReturnValue = prepared
+        let encoder = StubTransactionEncoder(createdTransactions: [])
+        encoder.submitError = TransactionEncoderError.submitError(code: -1, message: "already in mempool")
+        encoder.knownToServerTxIds = [expectedSubmittedTxId(prepared)]
+        let synchronizer = try makeSynchronizer(transactionEncoder: encoder, rustBackend: rustBackend)
+
+        let result = try await synchronizer.submitNoteSplit(
+            proposal: NoteSplitProposal(outputNotes: [100], fee: 10),
+            spendingKey: TestsData(networkType: .testnet).spendingKey,
+            options: options,
+            for: account
+        )
+
+        XCTAssertEqual(result, .success(txid: prepared.txid))
+    }
+
+    func testSubmitNoteSplitMapsUnknownSubmitErrorToNonRetryableNetworkError() async throws {
+        let prepared = makePreparedTx()
+        let rustBackend = ZcashRustBackendWeldingMock()
+        rustBackend.migrationSignNoteSplitProposalUskForReturnValue = prepared
+        let encoder = StubTransactionEncoder(createdTransactions: [])
+        encoder.submitError = TransactionEncoderError.submitError(code: -1, message: "rejected")
+        let synchronizer = try makeSynchronizer(transactionEncoder: encoder, rustBackend: rustBackend)
+
+        let result = try await synchronizer.submitNoteSplit(
+            proposal: NoteSplitProposal(outputNotes: [100], fee: 10),
+            spendingKey: TestsData(networkType: .testnet).spendingKey,
+            options: options,
+            for: account
+        )
+
+        XCTAssertEqual(result, .networkError(retryable: false))
+    }
+
+    func testSubmitNoteSplitPropagatesSigningErrorWithoutSubmitting() async throws {
+        let rustBackend = ZcashRustBackendWeldingMock()
+        rustBackend.migrationSignNoteSplitProposalUskForThrowableError = TestError.boom
+        let encoder = StubTransactionEncoder(createdTransactions: [])
+        let synchronizer = try makeSynchronizer(transactionEncoder: encoder, rustBackend: rustBackend)
+
+        do {
+            _ = try await synchronizer.submitNoteSplit(
+                proposal: NoteSplitProposal(outputNotes: [100], fee: 10),
+                spendingKey: TestsData(networkType: .testnet).spendingKey,
+                options: options,
+                for: account
+            )
+            XCTFail("Expected submitNoteSplit to propagate the signing error")
+        } catch {
+            // expected
+        }
+
+        XCTAssertTrue(encoder.submittedTransactions.isEmpty)
+    }
+
+    // MARK: - executeNextPendingTransfer
+
+    func testExecuteNextPendingTransferReturnsNilWhenNoneDue() async throws {
+        let rustBackend = ZcashRustBackendWeldingMock()
+        rustBackend.migrationNextDueTransferForReturnValue = nil
+        let encoder = StubTransactionEncoder(createdTransactions: [])
+        let synchronizer = try makeSynchronizer(transactionEncoder: encoder, rustBackend: rustBackend)
+
+        let result = try await synchronizer.executeNextPendingTransfer(options: options, for: account)
+
+        XCTAssertNil(result)
+        XCTAssertTrue(encoder.submittedTransactions.isEmpty)
+        XCTAssertFalse(rustBackend.migrationRecordTransferResultTransferIdResultForCalled)
+    }
+
+    func testExecuteNextPendingTransferSubmitsAndRecordsSuccess() async throws {
+        let prepared = makePreparedTx(id: "transfer-7")
+        let rustBackend = ZcashRustBackendWeldingMock()
+        rustBackend.migrationNextDueTransferForReturnValue = prepared
+        rustBackend.migrationRecordTransferResultTransferIdResultForClosure = { _, _, _ in }
+        let encoder = StubTransactionEncoder(createdTransactions: [])
+        let synchronizer = try makeSynchronizer(transactionEncoder: encoder, rustBackend: rustBackend)
+
+        let result = try await synchronizer.executeNextPendingTransfer(options: options, for: account)
+
+        XCTAssertEqual(result, .success(txid: prepared.txid))
+        XCTAssertEqual(encoder.submittedTransactions.map(\.raw), [Data(prepared.rawTx)])
+        let recorded = rustBackend.migrationRecordTransferResultTransferIdResultForReceivedArguments
+        XCTAssertEqual(recorded?.transferId, prepared.id)
+        XCTAssertEqual(recorded?.result, .success(txid: prepared.txid))
+        XCTAssertEqual(recorded?.account, account)
+    }
+
+    func testExecuteNextPendingTransferRecordsRetryableNetworkErrorOnGrpcFailure() async throws {
+        let prepared = makePreparedTx(id: "transfer-8")
+        let rustBackend = ZcashRustBackendWeldingMock()
+        rustBackend.migrationNextDueTransferForReturnValue = prepared
+        rustBackend.migrationRecordTransferResultTransferIdResultForClosure = { _, _, _ in }
+        let encoder = StubTransactionEncoder(createdTransactions: [])
+        encoder.submitError = ZcashError.serviceSubmitFailed(.timeOut)
+        let synchronizer = try makeSynchronizer(transactionEncoder: encoder, rustBackend: rustBackend)
+
+        let result = try await synchronizer.executeNextPendingTransfer(options: options, for: account)
+
+        XCTAssertEqual(result, .networkError(retryable: true))
+        XCTAssertEqual(
+            rustBackend.migrationRecordTransferResultTransferIdResultForReceivedArguments?.result,
+            .networkError(retryable: true)
+        )
+    }
+
+    func testExecuteNextPendingTransferDoesNotRecordWhenNextDueThrows() async throws {
+        let rustBackend = ZcashRustBackendWeldingMock()
+        rustBackend.migrationNextDueTransferForThrowableError = TestError.boom
+        let encoder = StubTransactionEncoder(createdTransactions: [])
+        let synchronizer = try makeSynchronizer(transactionEncoder: encoder, rustBackend: rustBackend)
+
+        do {
+            _ = try await synchronizer.executeNextPendingTransfer(options: options, for: account)
+            XCTFail("Expected executeNextPendingTransfer to propagate the next-due error")
+        } catch {
+            // expected
+        }
+
+        XCTAssertFalse(rustBackend.migrationRecordTransferResultTransferIdResultForCalled)
+        XCTAssertTrue(encoder.submittedTransactions.isEmpty)
+    }
+
+    // MARK: - Delegations
+
+    func testMigrationStateDelegatesToRustBackend() async throws {
+        let rustBackend = ZcashRustBackendWeldingMock()
+        rustBackend.migrationStateForReturnValue = .readyToPropose
+        let synchronizer = try makeSynchronizer(rustBackend: rustBackend)
+
+        let result = try await synchronizer.migrationState(for: account)
+
+        XCTAssertEqual(result, .readyToPropose)
+        XCTAssertEqual(rustBackend.migrationStateForReceivedAccount, account)
+    }
+
+    func testMigrationProgressDelegatesToRustBackend() async throws {
+        let progress = MigrationProgress(
+            completedTransfers: 1,
+            totalTransfers: 3,
+            remainingOrchardZatoshi: 1000,
+            nextTransferReadyAtHeight: 42
+        )
+        let rustBackend = ZcashRustBackendWeldingMock()
+        rustBackend.migrationProgressForReturnValue = progress
+        let synchronizer = try makeSynchronizer(rustBackend: rustBackend)
+
+        let result = try await synchronizer.migrationProgress(for: account)
+
+        XCTAssertEqual(result, progress)
+        XCTAssertEqual(rustBackend.migrationProgressForReceivedAccount, account)
+    }
+
+    func testIsNoteSplitNeededDelegatesToRustBackend() async throws {
+        let rustBackend = ZcashRustBackendWeldingMock()
+        rustBackend.migrationIsNoteSplitNeededForReturnValue = true
+        let synchronizer = try makeSynchronizer(rustBackend: rustBackend)
+
+        let result = try await synchronizer.isNoteSplitNeeded(for: account)
+
+        XCTAssertTrue(result)
+        XCTAssertEqual(rustBackend.migrationIsNoteSplitNeededForReceivedAccount, account)
+    }
+
+    func testPrepareNoteSplitDelegatesToRustBackend() async throws {
+        let proposal = NoteSplitProposal(outputNotes: [10, 20], fee: 5)
+        let rustBackend = ZcashRustBackendWeldingMock()
+        rustBackend.migrationPrepareNoteSplitForReturnValue = proposal
+        let synchronizer = try makeSynchronizer(rustBackend: rustBackend)
+
+        let result = try await synchronizer.prepareNoteSplit(for: account)
+
+        XCTAssertEqual(result, proposal)
+        XCTAssertEqual(rustBackend.migrationPrepareNoteSplitForReceivedAccount, account)
+    }
+
+    func testProposeMigrationTransfersDelegatesToRustBackend() async throws {
+        let schedule = MigrationSchedule(transfers: [], estimatedDurationHours: 7)
+        let rustBackend = ZcashRustBackendWeldingMock()
+        rustBackend.migrationProposeTransfersForReturnValue = schedule
+        let synchronizer = try makeSynchronizer(rustBackend: rustBackend)
+
+        let result = try await synchronizer.proposeMigrationTransfers(for: account)
+
+        XCTAssertEqual(result, schedule)
+        XCTAssertEqual(rustBackend.migrationProposeTransfersForReceivedAccount, account)
+    }
+
+    func testSignAndStoreMigrationScheduleDelegatesToRustBackend() async throws {
+        let schedule = MigrationSchedule(transfers: [], estimatedDurationHours: 7)
+        let rustBackend = ZcashRustBackendWeldingMock()
+        rustBackend.migrationSignAndStoreScheduleUskForClosure = { _, _, _ in }
+        let synchronizer = try makeSynchronizer(rustBackend: rustBackend)
+
+        try await synchronizer.signAndStoreMigrationSchedule(
+            schedule,
+            spendingKey: TestsData(networkType: .testnet).spendingKey,
+            for: account
+        )
+
+        let args = rustBackend.migrationSignAndStoreScheduleUskForReceivedArguments
+        XCTAssertEqual(args?.schedule, schedule)
+        XCTAssertEqual(args?.account, account)
+    }
+
+    func testIsSyncRequiredBeforeNextTransferDelegatesToRustBackend() async throws {
+        let rustBackend = ZcashRustBackendWeldingMock()
+        rustBackend.migrationIsSyncRequiredForReturnValue = true
+        let synchronizer = try makeSynchronizer(rustBackend: rustBackend)
+
+        let result = try await synchronizer.isSyncRequiredBeforeNextTransfer(for: account)
+
+        XCTAssertTrue(result)
+        XCTAssertEqual(rustBackend.migrationIsSyncRequiredForReceivedAccount, account)
+    }
+
+    func testHasOverdueTransfersDelegatesToRustBackend() async throws {
+        let rustBackend = ZcashRustBackendWeldingMock()
+        rustBackend.migrationHasOverdueTransfersForReturnValue = true
+        let synchronizer = try makeSynchronizer(rustBackend: rustBackend)
+
+        let result = try await synchronizer.hasOverdueTransfers(for: account)
+
+        XCTAssertTrue(result)
+        XCTAssertEqual(rustBackend.migrationHasOverdueTransfersForReceivedAccount, account)
+    }
+
+    func testHasInvalidTransfersDelegatesToRustBackend() async throws {
+        let rustBackend = ZcashRustBackendWeldingMock()
+        rustBackend.migrationHasInvalidTransfersForReturnValue = true
+        let synchronizer = try makeSynchronizer(rustBackend: rustBackend)
+
+        let result = try await synchronizer.hasInvalidTransfers(for: account)
+
+        XCTAssertTrue(result)
+        XCTAssertEqual(rustBackend.migrationHasInvalidTransfersForReceivedAccount, account)
+    }
+
+    func testRestartCurrentMigrationStepDelegatesToRustBackend() async throws {
+        let schedule = MigrationSchedule(transfers: [], estimatedDurationHours: 2)
+        let rustBackend = ZcashRustBackendWeldingMock()
+        rustBackend.migrationRestartStepForReturnValue = schedule
+        let synchronizer = try makeSynchronizer(rustBackend: rustBackend)
+
+        let result = try await synchronizer.restartCurrentMigrationStep(for: account)
+
+        XCTAssertEqual(result, schedule)
+        XCTAssertEqual(rustBackend.migrationRestartStepForReceivedAccount, account)
+    }
+
+    func testInitializePostUpgradeDelegatesToRustBackend() async throws {
+        let rustBackend = ZcashRustBackendWeldingMock()
+        rustBackend.migrationInitializePostUpgradeForClosure = { _ in }
+        let synchronizer = try makeSynchronizer(rustBackend: rustBackend)
+
+        try await synchronizer.initializePostUpgrade(for: account)
+
+        XCTAssertTrue(rustBackend.migrationInitializePostUpgradeForCalled)
+        XCTAssertEqual(rustBackend.migrationInitializePostUpgradeForReceivedAccount, account)
+    }
+
+    // MARK: - Helpers
+
+    private func makeSynchronizer(rustBackend: ZcashRustBackendWelding) throws -> SDKSynchronizer {
+        try makeSynchronizer(
+            transactionEncoder: StubTransactionEncoder(createdTransactions: []),
+            rustBackend: rustBackend
+        )
+    }
+
+    private func makePreparedTx(
+        id: String = "transfer-1",
+        txid: String = "0a0b0c0d",
+        rawTx: [UInt8] = [0x01, 0x02, 0x03, 0x04]
+    ) -> PreparedTx {
+        PreparedTx(id: id, txid: txid, rawTx: rawTx)
+    }
+
+    /// The internal-byte-order txid the broadcast helper is expected to derive from `prepared.txid`
+    /// (decode the crate's display-order hex, then reverse).
+    private func expectedSubmittedTxId(_ prepared: PreparedTx) -> Data {
+        Data(Data(hexEncoded: prepared.txid)!.reversed())
+    }
+
+    private func makeSynchronizer(
+        transactionEncoder: TransactionEncoder,
+        rustBackend: ZcashRustBackendWelding
+    ) throws -> SDKSynchronizer {
+        let serviceMock = LightWalletServiceMock()
+        let transactionRepository = TransactionRepositoryMock()
+
+        mockContainer.mock(type: ZcashRustBackendWelding.self, isSingleton: true) { _ in rustBackend }
+        mockContainer.mock(type: LightWalletService.self, isSingleton: true) { _ in serviceMock }
+        mockContainer.mock(type: TransactionRepository.self, isSingleton: true) { _ in transactionRepository }
+        mockContainer.mock(type: Logger.self, isSingleton: true) { _ in submissionLifecycleLogger() }
+
+        let initializer = Initializer(
+            container: mockContainer,
+            cacheDbURL: nil,
+            fsBlockDbRoot: testTempDirectory,
+            generalStorageURL: testGeneralStorageDirectory,
+            dataDbURL: try __dataDbURL(),
+            torDirURL: try __torDirURL(),
+            endpoint: LightWalletEndpointBuilder.default,
+            network: ZcashNetworkBuilder.network(for: .testnet),
+            spendParamsURL: try __spendParamsURL(),
+            outputParamsURL: try __outputParamsURL(),
+            saplingParamsSourceURL: SaplingParamsSourceURL.tests,
+            isTorEnabled: false,
+            isExchangeRateEnabled: false
+        )
+
+        let blockProcessor = CompactBlockProcessor(
+            initializer: initializer,
+            walletBirthdayProvider: { initializer.walletBirthday }
+        )
+
+        return SDKSynchronizer(
+            status: .unprepared,
+            initializer: initializer,
+            transactionEncoder: transactionEncoder,
+            transactionRepository: transactionRepository,
+            blockProcessor: blockProcessor,
+            syncSessionTicker: .live
+        )
+    }
+}

--- a/Tests/OfflineTests/MigrationSynchronizerTests.swift
+++ b/Tests/OfflineTests/MigrationSynchronizerTests.swift
@@ -5,8 +5,8 @@
 //  Unit tests for the public Orchard -> Ironwood migration API on `SDKSynchronizer`: the two
 //  broadcast composites (submitNoteSplit / executeNextPendingTransfer) and the thin delegations to
 //  the rust backend welding. The composites are driven against a `ZcashRustBackendWeldingMock` (the
-//  sign / next-due / record building blocks) and a `StubTransactionEncoder` (the old direct submit
-//  path). End-to-end propose/sign/submit needs a seeded, synced DB and is out of scope here.
+//  sign / next-due / extract / record building blocks) and a `StubTransactionEncoder` (the old direct
+//  submit path). End-to-end propose/sign/submit needs a seeded, synced DB and is out of scope here.
 //
 
 import XCTest
@@ -16,6 +16,10 @@ import XCTest
 final class MigrationSynchronizerTests: ZcashTestCase {
     private let account = AccountUUID(id: [UInt8](repeating: 7, count: 16))
     private let options = NetworkPrivacyOptions(useTor: false, submissionEndpoint: nil)
+    /// The consensus tx bytes the welding's `migrationExtractBroadcastTx` returns. Deliberately
+    /// distinct from any `PreparedTx.rawPczt` so the submit assertions verify that the *extracted*
+    /// bytes are broadcast, not the PCZT itself.
+    private let extractedTxBytes: [UInt8] = [0xAA, 0xBB, 0xCC]
 
     private enum TestError: Error {
         case boom
@@ -27,6 +31,7 @@ final class MigrationSynchronizerTests: ZcashTestCase {
         let prepared = makePreparedTx()
         let rustBackend = ZcashRustBackendWeldingMock()
         rustBackend.migrationSignNoteSplitProposalUskForReturnValue = prepared
+        rustBackend.migrationExtractBroadcastTxPcztForReturnValue = extractedTxBytes
         let encoder = StubTransactionEncoder(createdTransactions: [])
         let synchronizer = try makeSynchronizer(transactionEncoder: encoder, rustBackend: rustBackend)
 
@@ -41,7 +46,10 @@ final class MigrationSynchronizerTests: ZcashTestCase {
         XCTAssertEqual(result, .success(txid: prepared.txid))
         XCTAssertEqual(rustBackend.migrationSignNoteSplitProposalUskForReceivedArguments?.proposal, proposal)
         XCTAssertEqual(rustBackend.migrationSignNoteSplitProposalUskForReceivedArguments?.account, account)
-        XCTAssertEqual(encoder.submittedTransactions.map(\.raw), [Data(prepared.rawTx)])
+        // The signed PCZT is extracted before broadcast, and the *extracted* bytes are what get submitted.
+        XCTAssertEqual(rustBackend.migrationExtractBroadcastTxPcztForReceivedArguments?.pczt, prepared.rawPczt)
+        XCTAssertEqual(rustBackend.migrationExtractBroadcastTxPcztForReceivedArguments?.account, account)
+        XCTAssertEqual(encoder.submittedTransactions.map(\.raw), [Data(extractedTxBytes)])
         XCTAssertEqual(encoder.submittedTransactions.first?.transactionId, expectedSubmittedTxId(prepared))
     }
 
@@ -49,6 +57,7 @@ final class MigrationSynchronizerTests: ZcashTestCase {
         let prepared = makePreparedTx()
         let rustBackend = ZcashRustBackendWeldingMock()
         rustBackend.migrationSignNoteSplitProposalUskForReturnValue = prepared
+        rustBackend.migrationExtractBroadcastTxPcztForReturnValue = extractedTxBytes
         let encoder = StubTransactionEncoder(createdTransactions: [])
         encoder.submitError = ZcashError.serviceSubmitFailed(.timeOut)
         let synchronizer = try makeSynchronizer(transactionEncoder: encoder, rustBackend: rustBackend)
@@ -67,6 +76,7 @@ final class MigrationSynchronizerTests: ZcashTestCase {
         let prepared = makePreparedTx()
         let rustBackend = ZcashRustBackendWeldingMock()
         rustBackend.migrationSignNoteSplitProposalUskForReturnValue = prepared
+        rustBackend.migrationExtractBroadcastTxPcztForReturnValue = extractedTxBytes
         let encoder = StubTransactionEncoder(createdTransactions: [])
         encoder.submitError = TransactionEncoderError.submitError(code: -1, message: "already in mempool")
         encoder.knownToServerTxIds = [expectedSubmittedTxId(prepared)]
@@ -86,6 +96,7 @@ final class MigrationSynchronizerTests: ZcashTestCase {
         let prepared = makePreparedTx()
         let rustBackend = ZcashRustBackendWeldingMock()
         rustBackend.migrationSignNoteSplitProposalUskForReturnValue = prepared
+        rustBackend.migrationExtractBroadcastTxPcztForReturnValue = extractedTxBytes
         let encoder = StubTransactionEncoder(createdTransactions: [])
         encoder.submitError = TransactionEncoderError.submitError(code: -1, message: "rejected")
         let synchronizer = try makeSynchronizer(transactionEncoder: encoder, rustBackend: rustBackend)
@@ -121,6 +132,29 @@ final class MigrationSynchronizerTests: ZcashTestCase {
         XCTAssertTrue(encoder.submittedTransactions.isEmpty)
     }
 
+    func testSubmitNoteSplitPropagatesExtractErrorWithoutSubmitting() async throws {
+        let prepared = makePreparedTx()
+        let rustBackend = ZcashRustBackendWeldingMock()
+        rustBackend.migrationSignNoteSplitProposalUskForReturnValue = prepared
+        rustBackend.migrationExtractBroadcastTxPcztForThrowableError = TestError.boom
+        let encoder = StubTransactionEncoder(createdTransactions: [])
+        let synchronizer = try makeSynchronizer(transactionEncoder: encoder, rustBackend: rustBackend)
+
+        do {
+            _ = try await synchronizer.submitNoteSplit(
+                proposal: NoteSplitProposal(outputNotes: [100], fee: 10),
+                spendingKey: TestsData(networkType: .testnet).spendingKey,
+                options: options,
+                for: account
+            )
+            XCTFail("Expected submitNoteSplit to propagate the extract error")
+        } catch {
+            // expected
+        }
+
+        XCTAssertTrue(encoder.submittedTransactions.isEmpty)
+    }
+
     // MARK: - executeNextPendingTransfer
 
     func testExecuteNextPendingTransferReturnsNilWhenNoneDue() async throws {
@@ -140,6 +174,7 @@ final class MigrationSynchronizerTests: ZcashTestCase {
         let prepared = makePreparedTx(id: "transfer-7")
         let rustBackend = ZcashRustBackendWeldingMock()
         rustBackend.migrationNextDueTransferForReturnValue = prepared
+        rustBackend.migrationExtractBroadcastTxPcztForReturnValue = extractedTxBytes
         rustBackend.migrationRecordTransferResultTransferIdResultForClosure = { _, _, _ in }
         let encoder = StubTransactionEncoder(createdTransactions: [])
         let synchronizer = try makeSynchronizer(transactionEncoder: encoder, rustBackend: rustBackend)
@@ -147,7 +182,9 @@ final class MigrationSynchronizerTests: ZcashTestCase {
         let result = try await synchronizer.executeNextPendingTransfer(options: options, for: account)
 
         XCTAssertEqual(result, .success(txid: prepared.txid))
-        XCTAssertEqual(encoder.submittedTransactions.map(\.raw), [Data(prepared.rawTx)])
+        XCTAssertEqual(rustBackend.migrationExtractBroadcastTxPcztForReceivedArguments?.pczt, prepared.rawPczt)
+        XCTAssertEqual(rustBackend.migrationExtractBroadcastTxPcztForReceivedArguments?.account, account)
+        XCTAssertEqual(encoder.submittedTransactions.map(\.raw), [Data(extractedTxBytes)])
         let recorded = rustBackend.migrationRecordTransferResultTransferIdResultForReceivedArguments
         XCTAssertEqual(recorded?.transferId, prepared.id)
         XCTAssertEqual(recorded?.result, .success(txid: prepared.txid))
@@ -158,6 +195,7 @@ final class MigrationSynchronizerTests: ZcashTestCase {
         let prepared = makePreparedTx(id: "transfer-8")
         let rustBackend = ZcashRustBackendWeldingMock()
         rustBackend.migrationNextDueTransferForReturnValue = prepared
+        rustBackend.migrationExtractBroadcastTxPcztForReturnValue = extractedTxBytes
         rustBackend.migrationRecordTransferResultTransferIdResultForClosure = { _, _, _ in }
         let encoder = StubTransactionEncoder(createdTransactions: [])
         encoder.submitError = ZcashError.serviceSubmitFailed(.timeOut)
@@ -189,6 +227,25 @@ final class MigrationSynchronizerTests: ZcashTestCase {
         XCTAssertTrue(encoder.submittedTransactions.isEmpty)
     }
 
+    func testExecuteNextPendingTransferDoesNotRecordWhenExtractThrows() async throws {
+        let prepared = makePreparedTx(id: "transfer-9")
+        let rustBackend = ZcashRustBackendWeldingMock()
+        rustBackend.migrationNextDueTransferForReturnValue = prepared
+        rustBackend.migrationExtractBroadcastTxPcztForThrowableError = TestError.boom
+        let encoder = StubTransactionEncoder(createdTransactions: [])
+        let synchronizer = try makeSynchronizer(transactionEncoder: encoder, rustBackend: rustBackend)
+
+        do {
+            _ = try await synchronizer.executeNextPendingTransfer(options: options, for: account)
+            XCTFail("Expected executeNextPendingTransfer to propagate the extract error")
+        } catch {
+            // expected
+        }
+
+        XCTAssertFalse(rustBackend.migrationRecordTransferResultTransferIdResultForCalled)
+        XCTAssertTrue(encoder.submittedTransactions.isEmpty)
+    }
+
     // MARK: - Delegations
 
     func testMigrationStateDelegatesToRustBackend() async throws {
@@ -206,7 +263,7 @@ final class MigrationSynchronizerTests: ZcashTestCase {
         let progress = MigrationProgress(
             completedTransfers: 1,
             totalTransfers: 3,
-            remainingOrchardZatoshi: 1000,
+            remainingOrchard: 1000,
             nextTransferReadyAtHeight: 42
         )
         let rustBackend = ZcashRustBackendWeldingMock()
@@ -304,6 +361,20 @@ final class MigrationSynchronizerTests: ZcashTestCase {
         XCTAssertEqual(rustBackend.migrationHasInvalidTransfersForReceivedAccount, account)
     }
 
+    func testRefreshStaleTransfersDelegatesToRustBackend() async throws {
+        let rustBackend = ZcashRustBackendWeldingMock()
+        rustBackend.migrationRefreshStaleTransfersUskForReturnValue = 3
+        let synchronizer = try makeSynchronizer(rustBackend: rustBackend)
+        let spendingKey = TestsData(networkType: .testnet).spendingKey
+
+        let result = try await synchronizer.refreshStaleTransfers(spendingKey: spendingKey, for: account)
+
+        XCTAssertEqual(result, 3)
+        let args = rustBackend.migrationRefreshStaleTransfersUskForReceivedArguments
+        XCTAssertEqual(args?.usk, spendingKey)
+        XCTAssertEqual(args?.account, account)
+    }
+
     func testRestartCurrentMigrationStepDelegatesToRustBackend() async throws {
         let schedule = MigrationSchedule(transfers: [], estimatedDurationHours: 2)
         let rustBackend = ZcashRustBackendWeldingMock()
@@ -339,9 +410,9 @@ final class MigrationSynchronizerTests: ZcashTestCase {
     private func makePreparedTx(
         id: String = "transfer-1",
         txid: String = "0a0b0c0d",
-        rawTx: [UInt8] = [0x01, 0x02, 0x03, 0x04]
+        rawPczt: [UInt8] = [0x01, 0x02, 0x03, 0x04]
     ) -> PreparedTx {
-        PreparedTx(id: id, txid: txid, rawTx: rawTx)
+        PreparedTx(id: id, txid: txid, rawPczt: rawPczt)
     }
 
     /// The internal-byte-order txid the broadcast helper is expected to derive from `prepared.txid`

--- a/Tests/TestUtils/Sourcery/GeneratedMocks/AutoMockable.generated.swift
+++ b/Tests/TestUtils/Sourcery/GeneratedMocks/AutoMockable.generated.swift
@@ -2906,6 +2906,30 @@ class SynchronizerMock: Synchronizer {
         }
     }
 
+    // MARK: - refreshStaleTransfers
+
+    var refreshStaleTransfersSpendingKeyForThrowableError: Error?
+    var refreshStaleTransfersSpendingKeyForCallsCount = 0
+    var refreshStaleTransfersSpendingKeyForCalled: Bool {
+        return refreshStaleTransfersSpendingKeyForCallsCount > 0
+    }
+    var refreshStaleTransfersSpendingKeyForReceivedArguments: (spendingKey: UnifiedSpendingKey, account: AccountUUID)?
+    var refreshStaleTransfersSpendingKeyForReturnValue: UInt32!
+    var refreshStaleTransfersSpendingKeyForClosure: ((UnifiedSpendingKey, AccountUUID) async throws -> UInt32)?
+
+    func refreshStaleTransfers(spendingKey: UnifiedSpendingKey, for account: AccountUUID) async throws -> UInt32 {
+        if let error = refreshStaleTransfersSpendingKeyForThrowableError {
+            throw error
+        }
+        refreshStaleTransfersSpendingKeyForCallsCount += 1
+        refreshStaleTransfersSpendingKeyForReceivedArguments = (spendingKey: spendingKey, account: account)
+        if let closure = refreshStaleTransfersSpendingKeyForClosure {
+            return try await closure(spendingKey, account)
+        } else {
+            return refreshStaleTransfersSpendingKeyForReturnValue
+        }
+    }
+
     // MARK: - restartCurrentMigrationStep
 
     var restartCurrentMigrationStepForThrowableError: Error?

--- a/Tests/TestUtils/Sourcery/GeneratedMocks/AutoMockable.generated.swift
+++ b/Tests/TestUtils/Sourcery/GeneratedMocks/AutoMockable.generated.swift
@@ -2647,6 +2647,308 @@ class SynchronizerMock: Synchronizer {
         try await deleteAccountClosure!(accountUUID)
     }
 
+    // MARK: - migrationState
+
+    var migrationStateForThrowableError: Error?
+    var migrationStateForCallsCount = 0
+    var migrationStateForCalled: Bool {
+        return migrationStateForCallsCount > 0
+    }
+    var migrationStateForReceivedAccount: AccountUUID?
+    var migrationStateForReturnValue: MigrationState!
+    var migrationStateForClosure: ((AccountUUID) async throws -> MigrationState)?
+
+    func migrationState(for account: AccountUUID) async throws -> MigrationState {
+        if let error = migrationStateForThrowableError {
+            throw error
+        }
+        migrationStateForCallsCount += 1
+        migrationStateForReceivedAccount = account
+        if let closure = migrationStateForClosure {
+            return try await closure(account)
+        } else {
+            return migrationStateForReturnValue
+        }
+    }
+
+    // MARK: - migrationProgress
+
+    var migrationProgressForThrowableError: Error?
+    var migrationProgressForCallsCount = 0
+    var migrationProgressForCalled: Bool {
+        return migrationProgressForCallsCount > 0
+    }
+    var migrationProgressForReceivedAccount: AccountUUID?
+    var migrationProgressForReturnValue: MigrationProgress?
+    var migrationProgressForClosure: ((AccountUUID) async throws -> MigrationProgress?)?
+
+    func migrationProgress(for account: AccountUUID) async throws -> MigrationProgress? {
+        if let error = migrationProgressForThrowableError {
+            throw error
+        }
+        migrationProgressForCallsCount += 1
+        migrationProgressForReceivedAccount = account
+        if let closure = migrationProgressForClosure {
+            return try await closure(account)
+        } else {
+            return migrationProgressForReturnValue
+        }
+    }
+
+    // MARK: - isNoteSplitNeeded
+
+    var isNoteSplitNeededForThrowableError: Error?
+    var isNoteSplitNeededForCallsCount = 0
+    var isNoteSplitNeededForCalled: Bool {
+        return isNoteSplitNeededForCallsCount > 0
+    }
+    var isNoteSplitNeededForReceivedAccount: AccountUUID?
+    var isNoteSplitNeededForReturnValue: Bool!
+    var isNoteSplitNeededForClosure: ((AccountUUID) async throws -> Bool)?
+
+    func isNoteSplitNeeded(for account: AccountUUID) async throws -> Bool {
+        if let error = isNoteSplitNeededForThrowableError {
+            throw error
+        }
+        isNoteSplitNeededForCallsCount += 1
+        isNoteSplitNeededForReceivedAccount = account
+        if let closure = isNoteSplitNeededForClosure {
+            return try await closure(account)
+        } else {
+            return isNoteSplitNeededForReturnValue
+        }
+    }
+
+    // MARK: - prepareNoteSplit
+
+    var prepareNoteSplitForThrowableError: Error?
+    var prepareNoteSplitForCallsCount = 0
+    var prepareNoteSplitForCalled: Bool {
+        return prepareNoteSplitForCallsCount > 0
+    }
+    var prepareNoteSplitForReceivedAccount: AccountUUID?
+    var prepareNoteSplitForReturnValue: NoteSplitProposal!
+    var prepareNoteSplitForClosure: ((AccountUUID) async throws -> NoteSplitProposal)?
+
+    func prepareNoteSplit(for account: AccountUUID) async throws -> NoteSplitProposal {
+        if let error = prepareNoteSplitForThrowableError {
+            throw error
+        }
+        prepareNoteSplitForCallsCount += 1
+        prepareNoteSplitForReceivedAccount = account
+        if let closure = prepareNoteSplitForClosure {
+            return try await closure(account)
+        } else {
+            return prepareNoteSplitForReturnValue
+        }
+    }
+
+    // MARK: - submitNoteSplit
+
+    var submitNoteSplitProposalSpendingKeyOptionsForThrowableError: Error?
+    var submitNoteSplitProposalSpendingKeyOptionsForCallsCount = 0
+    var submitNoteSplitProposalSpendingKeyOptionsForCalled: Bool {
+        return submitNoteSplitProposalSpendingKeyOptionsForCallsCount > 0
+    }
+    var submitNoteSplitProposalSpendingKeyOptionsForReceivedArguments: (proposal: NoteSplitProposal, spendingKey: UnifiedSpendingKey, options: NetworkPrivacyOptions, account: AccountUUID)?
+    var submitNoteSplitProposalSpendingKeyOptionsForReturnValue: TransferResult!
+    var submitNoteSplitProposalSpendingKeyOptionsForClosure: ((NoteSplitProposal, UnifiedSpendingKey, NetworkPrivacyOptions, AccountUUID) async throws -> TransferResult)?
+
+    func submitNoteSplit(proposal: NoteSplitProposal, spendingKey: UnifiedSpendingKey, options: NetworkPrivacyOptions, for account: AccountUUID) async throws -> TransferResult {
+        if let error = submitNoteSplitProposalSpendingKeyOptionsForThrowableError {
+            throw error
+        }
+        submitNoteSplitProposalSpendingKeyOptionsForCallsCount += 1
+        submitNoteSplitProposalSpendingKeyOptionsForReceivedArguments = (proposal: proposal, spendingKey: spendingKey, options: options, account: account)
+        if let closure = submitNoteSplitProposalSpendingKeyOptionsForClosure {
+            return try await closure(proposal, spendingKey, options, account)
+        } else {
+            return submitNoteSplitProposalSpendingKeyOptionsForReturnValue
+        }
+    }
+
+    // MARK: - proposeMigrationTransfers
+
+    var proposeMigrationTransfersForThrowableError: Error?
+    var proposeMigrationTransfersForCallsCount = 0
+    var proposeMigrationTransfersForCalled: Bool {
+        return proposeMigrationTransfersForCallsCount > 0
+    }
+    var proposeMigrationTransfersForReceivedAccount: AccountUUID?
+    var proposeMigrationTransfersForReturnValue: MigrationSchedule!
+    var proposeMigrationTransfersForClosure: ((AccountUUID) async throws -> MigrationSchedule)?
+
+    func proposeMigrationTransfers(for account: AccountUUID) async throws -> MigrationSchedule {
+        if let error = proposeMigrationTransfersForThrowableError {
+            throw error
+        }
+        proposeMigrationTransfersForCallsCount += 1
+        proposeMigrationTransfersForReceivedAccount = account
+        if let closure = proposeMigrationTransfersForClosure {
+            return try await closure(account)
+        } else {
+            return proposeMigrationTransfersForReturnValue
+        }
+    }
+
+    // MARK: - signAndStoreMigrationSchedule
+
+    var signAndStoreMigrationScheduleSpendingKeyForThrowableError: Error?
+    var signAndStoreMigrationScheduleSpendingKeyForCallsCount = 0
+    var signAndStoreMigrationScheduleSpendingKeyForCalled: Bool {
+        return signAndStoreMigrationScheduleSpendingKeyForCallsCount > 0
+    }
+    var signAndStoreMigrationScheduleSpendingKeyForReceivedArguments: (schedule: MigrationSchedule, spendingKey: UnifiedSpendingKey, account: AccountUUID)?
+    var signAndStoreMigrationScheduleSpendingKeyForClosure: ((MigrationSchedule, UnifiedSpendingKey, AccountUUID) async throws -> Void)?
+
+    func signAndStoreMigrationSchedule(_ schedule: MigrationSchedule, spendingKey: UnifiedSpendingKey, for account: AccountUUID) async throws {
+        if let error = signAndStoreMigrationScheduleSpendingKeyForThrowableError {
+            throw error
+        }
+        signAndStoreMigrationScheduleSpendingKeyForCallsCount += 1
+        signAndStoreMigrationScheduleSpendingKeyForReceivedArguments = (schedule: schedule, spendingKey: spendingKey, account: account)
+        try await signAndStoreMigrationScheduleSpendingKeyForClosure!(schedule, spendingKey, account)
+    }
+
+    // MARK: - isSyncRequiredBeforeNextTransfer
+
+    var isSyncRequiredBeforeNextTransferForThrowableError: Error?
+    var isSyncRequiredBeforeNextTransferForCallsCount = 0
+    var isSyncRequiredBeforeNextTransferForCalled: Bool {
+        return isSyncRequiredBeforeNextTransferForCallsCount > 0
+    }
+    var isSyncRequiredBeforeNextTransferForReceivedAccount: AccountUUID?
+    var isSyncRequiredBeforeNextTransferForReturnValue: Bool!
+    var isSyncRequiredBeforeNextTransferForClosure: ((AccountUUID) async throws -> Bool)?
+
+    func isSyncRequiredBeforeNextTransfer(for account: AccountUUID) async throws -> Bool {
+        if let error = isSyncRequiredBeforeNextTransferForThrowableError {
+            throw error
+        }
+        isSyncRequiredBeforeNextTransferForCallsCount += 1
+        isSyncRequiredBeforeNextTransferForReceivedAccount = account
+        if let closure = isSyncRequiredBeforeNextTransferForClosure {
+            return try await closure(account)
+        } else {
+            return isSyncRequiredBeforeNextTransferForReturnValue
+        }
+    }
+
+    // MARK: - executeNextPendingTransfer
+
+    var executeNextPendingTransferOptionsForThrowableError: Error?
+    var executeNextPendingTransferOptionsForCallsCount = 0
+    var executeNextPendingTransferOptionsForCalled: Bool {
+        return executeNextPendingTransferOptionsForCallsCount > 0
+    }
+    var executeNextPendingTransferOptionsForReceivedArguments: (options: NetworkPrivacyOptions, account: AccountUUID)?
+    var executeNextPendingTransferOptionsForReturnValue: TransferResult?
+    var executeNextPendingTransferOptionsForClosure: ((NetworkPrivacyOptions, AccountUUID) async throws -> TransferResult?)?
+
+    func executeNextPendingTransfer(options: NetworkPrivacyOptions, for account: AccountUUID) async throws -> TransferResult? {
+        if let error = executeNextPendingTransferOptionsForThrowableError {
+            throw error
+        }
+        executeNextPendingTransferOptionsForCallsCount += 1
+        executeNextPendingTransferOptionsForReceivedArguments = (options: options, account: account)
+        if let closure = executeNextPendingTransferOptionsForClosure {
+            return try await closure(options, account)
+        } else {
+            return executeNextPendingTransferOptionsForReturnValue
+        }
+    }
+
+    // MARK: - hasOverdueTransfers
+
+    var hasOverdueTransfersForThrowableError: Error?
+    var hasOverdueTransfersForCallsCount = 0
+    var hasOverdueTransfersForCalled: Bool {
+        return hasOverdueTransfersForCallsCount > 0
+    }
+    var hasOverdueTransfersForReceivedAccount: AccountUUID?
+    var hasOverdueTransfersForReturnValue: Bool!
+    var hasOverdueTransfersForClosure: ((AccountUUID) async throws -> Bool)?
+
+    func hasOverdueTransfers(for account: AccountUUID) async throws -> Bool {
+        if let error = hasOverdueTransfersForThrowableError {
+            throw error
+        }
+        hasOverdueTransfersForCallsCount += 1
+        hasOverdueTransfersForReceivedAccount = account
+        if let closure = hasOverdueTransfersForClosure {
+            return try await closure(account)
+        } else {
+            return hasOverdueTransfersForReturnValue
+        }
+    }
+
+    // MARK: - hasInvalidTransfers
+
+    var hasInvalidTransfersForThrowableError: Error?
+    var hasInvalidTransfersForCallsCount = 0
+    var hasInvalidTransfersForCalled: Bool {
+        return hasInvalidTransfersForCallsCount > 0
+    }
+    var hasInvalidTransfersForReceivedAccount: AccountUUID?
+    var hasInvalidTransfersForReturnValue: Bool!
+    var hasInvalidTransfersForClosure: ((AccountUUID) async throws -> Bool)?
+
+    func hasInvalidTransfers(for account: AccountUUID) async throws -> Bool {
+        if let error = hasInvalidTransfersForThrowableError {
+            throw error
+        }
+        hasInvalidTransfersForCallsCount += 1
+        hasInvalidTransfersForReceivedAccount = account
+        if let closure = hasInvalidTransfersForClosure {
+            return try await closure(account)
+        } else {
+            return hasInvalidTransfersForReturnValue
+        }
+    }
+
+    // MARK: - restartCurrentMigrationStep
+
+    var restartCurrentMigrationStepForThrowableError: Error?
+    var restartCurrentMigrationStepForCallsCount = 0
+    var restartCurrentMigrationStepForCalled: Bool {
+        return restartCurrentMigrationStepForCallsCount > 0
+    }
+    var restartCurrentMigrationStepForReceivedAccount: AccountUUID?
+    var restartCurrentMigrationStepForReturnValue: MigrationSchedule!
+    var restartCurrentMigrationStepForClosure: ((AccountUUID) async throws -> MigrationSchedule)?
+
+    func restartCurrentMigrationStep(for account: AccountUUID) async throws -> MigrationSchedule {
+        if let error = restartCurrentMigrationStepForThrowableError {
+            throw error
+        }
+        restartCurrentMigrationStepForCallsCount += 1
+        restartCurrentMigrationStepForReceivedAccount = account
+        if let closure = restartCurrentMigrationStepForClosure {
+            return try await closure(account)
+        } else {
+            return restartCurrentMigrationStepForReturnValue
+        }
+    }
+
+    // MARK: - initializePostUpgrade
+
+    var initializePostUpgradeForThrowableError: Error?
+    var initializePostUpgradeForCallsCount = 0
+    var initializePostUpgradeForCalled: Bool {
+        return initializePostUpgradeForCallsCount > 0
+    }
+    var initializePostUpgradeForReceivedAccount: AccountUUID?
+    var initializePostUpgradeForClosure: ((AccountUUID) async throws -> Void)?
+
+    func initializePostUpgrade(for account: AccountUUID) async throws {
+        if let error = initializePostUpgradeForThrowableError {
+            throw error
+        }
+        initializePostUpgradeForCallsCount += 1
+        initializePostUpgradeForReceivedAccount = account
+        try await initializePostUpgradeForClosure!(account)
+    }
+
 }
 class TransactionRepositoryMock: TransactionRepository {
 

--- a/Tests/TestUtils/SubmissionTestDoubles.swift
+++ b/Tests/TestUtils/SubmissionTestDoubles.swift
@@ -226,6 +226,11 @@ final class StubTransactionEncoder: TransactionEncoder {
     private(set) var receivedFetchTxIds: [Data]?
     private(set) var submittedTransactions: [EncodedTransaction] = []
 
+    /// When set, `submit(transaction:)` records the transaction and then throws this error.
+    var submitError: Error?
+    /// `isTransactionKnownToServer(txId:)` returns `true` for txids in this set.
+    var knownToServerTxIds: Set<Data> = []
+
     init(createdTransactions: [ZcashTransaction.Overview]) {
         self.createdTransactions = createdTransactions
     }
@@ -265,10 +270,13 @@ final class StubTransactionEncoder: TransactionEncoder {
 
     func submit(transaction: EncodedTransaction) async throws {
         submittedTransactions.append(transaction)
+        if let submitError {
+            throw submitError
+        }
     }
 
     func isTransactionKnownToServer(txId: Data) async -> Bool {
-        false
+        knownToServerTxIds.contains(txId)
     }
 
     func fetchTransactionsForTxIds(_ txIds: [Data]) async throws -> [ZcashTransaction.Overview] {

--- a/docs/handoffs/ZODL-ironwood-migration-api.md
+++ b/docs/handoffs/ZODL-ironwood-migration-api.md
@@ -1,0 +1,141 @@
+# Handoff — ZODL app: adopt the updated SDK Ironwood migration API
+
+**Audience:** whoever integrates the Orchard → Ironwood migration API in the ZODL app.
+**Driver:** the SDK welding tier pivoted to the `zodl_ironwood_migration` crate `main` (PCZT pivot +
+canonical `zcash_protocol` types), and the SDK orchestration layer adopted it on branch
+`michal/MOB-1455-2-ironwood-migration-sdk-impl` (ticket MOB-1455). This handoff lists the *app-facing*
+deltas.
+
+The migration API is **pre-release** (it has never shipped in a tagged SDK version), so the items
+below are corrections to the in-flight surface — not breaking changes against a release you already
+depend on. They matter only if your integration was written against an earlier draft of this API.
+
+---
+
+## TL;DR — what changes in ZODL
+
+1. **Two field renames on returned models (read sites):**
+   - `MigrationProgress.remainingOrchardZatoshi` → **`remainingOrchard`** (`UInt64`, unchanged type)
+   - `TransferProposal.amountZatoshi` → **`amount`** (`UInt64`, unchanged type)
+2. **One new (optional) recovery method:** `refreshStaleTransfers(spendingKey:for:) async throws -> UInt32`.
+3. **No behavioral change you must handle:** broadcasting is now internally *extract-then-submit*, but
+   that is entirely inside the SDK. You keep calling `submitNoteSplit` / `executeNextPendingTransfer`
+   exactly as before.
+
+If your ZODL code never reads `remainingOrchardZatoshi` / `amountZatoshi` and you do not need the new
+recovery method, **no change is required.**
+
+---
+
+## 1. Field renames (the only likely code change)
+
+The crate moved to canonical `zcash_protocol` types. The **wire format is unchanged** (plain `u64`);
+only the Swift property names changed.
+
+| Old | New | Type | Where you read it |
+|---|---|---|---|
+| `MigrationProgress.remainingOrchardZatoshi` | `MigrationProgress.remainingOrchard` | `UInt64` | progress UI; also inside `MigrationState.inProgress(_)` |
+| `TransferProposal.amountZatoshi` | `TransferProposal.amount` | `UInt64` | the migration-schedule confirmation UI (`MigrationSchedule.transfers`) |
+
+Grep your app for `remainingOrchardZatoshi` and `amountZatoshi` and rename.
+
+`PreparedTx.rawTx` was also renamed to `PreparedTx.rawPczt`, but **the public `Synchronizer` API never
+returns a `PreparedTx`** (broadcasting is internal), so ZODL almost certainly does not reference it.
+Listed only for completeness.
+
+Everything else is unchanged: `MigrationState`, `AttentionReason`, `TransferResult`,
+`NetworkPrivacyOptions`, `NoteSplitProposal`, `MigrationSchedule`, and all other field names / enum
+cases keep their names.
+
+## 2. New method — `refreshStaleTransfers`
+
+```swift
+func refreshStaleTransfers(spendingKey: UnifiedSpendingKey, for account: AccountUUID) async throws -> UInt32
+```
+
+Re-anchors, re-proves and re-signs the active migration run's scheduled transfers when they have gone
+stale (their anchor is too old to broadcast). Returns the number of transfers refreshed. Pair it with
+the existing `hasOverdueTransfers(for:)` detector:
+
+```swift
+if try await synchronizer.hasOverdueTransfers(for: account) {
+    let refreshed = try await synchronizer.refreshStaleTransfers(spendingKey: usk, for: account)
+    // …then resume executing due transfers…
+}
+```
+
+This is a lighter recovery than `restartCurrentMigrationStep(for:)` (which re-proposes a whole new
+schedule). Adopting it is optional.
+
+## 3. Broadcasting is now extract-then-submit (internal — no action needed)
+
+`PreparedTx.rawPczt` is a serialized PCZT, not a broadcastable transaction. The SDK now extracts the
+consensus transaction from the signed PCZT before submitting it. This is fully encapsulated inside
+`submitNoteSplit(...)` and `executeNextPendingTransfer(...)` — your call sites and their
+`TransferResult` handling are unchanged.
+
+---
+
+## Full public API reference (async `Synchronizer`, current shape)
+
+All methods take `for account: AccountUUID`. Async-only — the `ClosureSynchronizer` /
+`CombineSynchronizer` adapters do **not** expose migration (out of scope for this version).
+
+```swift
+// State / progress
+func migrationState(for: AccountUUID) async throws -> MigrationState
+func migrationProgress(for: AccountUUID) async throws -> MigrationProgress?
+
+// Note split
+func isNoteSplitNeeded(for: AccountUUID) async throws -> Bool
+func prepareNoteSplit(for: AccountUUID) async throws -> NoteSplitProposal
+func submitNoteSplit(proposal: NoteSplitProposal, spendingKey: UnifiedSpendingKey,
+                     options: NetworkPrivacyOptions, for: AccountUUID) async throws -> TransferResult
+
+// Schedule
+func proposeMigrationTransfers(for: AccountUUID) async throws -> MigrationSchedule
+func signAndStoreMigrationSchedule(_ schedule: MigrationSchedule, spendingKey: UnifiedSpendingKey,
+                                   for: AccountUUID) async throws
+
+// Execution
+func isSyncRequiredBeforeNextTransfer(for: AccountUUID) async throws -> Bool
+func executeNextPendingTransfer(options: NetworkPrivacyOptions, for: AccountUUID) async throws -> TransferResult?
+
+// Detection / recovery
+func hasOverdueTransfers(for: AccountUUID) async throws -> Bool
+func hasInvalidTransfers(for: AccountUUID) async throws -> Bool
+func refreshStaleTransfers(spendingKey: UnifiedSpendingKey, for: AccountUUID) async throws -> UInt32   // NEW
+func restartCurrentMigrationStep(for: AccountUUID) async throws -> MigrationSchedule
+
+// Lifecycle
+func initializePostUpgrade(for: AccountUUID) async throws
+```
+
+### Model field names (final)
+
+```swift
+MigrationProgress { completedTransfers: UInt32, totalTransfers: UInt32,
+                    remainingOrchard: UInt64, nextTransferReadyAtHeight: UInt32? }
+TransferProposal  { id: String, amount: UInt64, anchorHeight: UInt32,
+                    nextExecutableAfterHeight: UInt32, expiryHeight: UInt32 }
+MigrationSchedule { transfers: [TransferProposal], estimatedDurationHours: UInt32 }
+NoteSplitProposal { outputNotes: [UInt64], fee: UInt64 }
+NetworkPrivacyOptions { useTor: Bool, submissionEndpoint: String? }
+MigrationState  = .notStarted | .splitPendingConfirmation | .readyToPropose
+                | .inProgress(MigrationProgress) | .requiresAttention(AttentionReason) | .complete
+AttentionReason = .invalidTransfer(transferId: String) | .transferExpired | .syncRequiredBeforeNext
+TransferResult  = .success(txid: String) | .networkError(retryable: Bool) | .invalidNote | .expired
+```
+
+## Caveats to keep in mind
+
+- **`NetworkPrivacyOptions` is accepted but ignored in this version.** Broadcast uses the SDK's
+  already-configured lightwalletd. Keep passing it (the parameter is required); Tor / secondary-endpoint
+  honoring will come later.
+- **On-device proving cost (SDK-side, may affect UX).** The crate's PCZT pipeline builds Orchard +
+  Ironwood proving keys and proves on device, which adds time/size to `submitNoteSplit` /
+  `signAndStoreMigrationSchedule` / `refreshStaleTransfers`. Budget for it in spinners / background
+  task time limits. (The persisted-PCZT model also leaves the door open to moving signing to an
+  external signer later; not exposed yet.)
+- **End-to-end broadcast is not yet verified on a seeded/synced wallet** — the SDK side is compile- and
+  offline-test verified. Coordinate a staging round-trip before relying on it in production.

--- a/docs/superpowers/specs/2026-06-30-ironwood-crate-pivot-sdk-adoption-design.md
+++ b/docs/superpowers/specs/2026-06-30-ironwood-crate-pivot-sdk-adoption-design.md
@@ -1,0 +1,157 @@
+# Design — Adopt the crate PCZT pivot in the SDK orchestration layer
+
+**Date:** 2026-06-30
+**Branch:** `michal/MOB-1455-2-ironwood-migration-sdk-impl` (current).
+**Ticket:** MOB-1455.
+**Source handoff:** "SDK-impl/orchestration changes after the crate PCZT pivot" (inline, from the
+FFI/welding branch `michal/MOB-1455-ironwood-migration-prototype-ffi`).
+**Supersedes:** the broadcast/rename portions of
+`2026-06-30-ironwood-migration-public-api-design.md` (written against the pre-pivot model — it shows
+direct `rawTx` submission and old field names). That doc is kept as historical context.
+
+## Problem — the branch does not compile
+
+The welding tier was updated to the crate's `main` (PCZT pivot) in commit `86450d54`, renaming the
+public model **properties** and **CodingKeys** (`rawTx → rawPczt`, `amountZatoshi → amount`,
+`remainingOrchardZatoshi → remainingOrchard`) and adding two welding methods
+(`migrationExtractBroadcastTx`, `migrationRefreshStaleTransfers`, error codes ZRUST0107/0108). That
+tier is complete and offline-tested.
+
+But the public-API layer added afterward (commits `6d12b2ec`, `2ac31c14`) was written against the
+**pre-pivot** model. The result is an inconsistent tree that cannot build:
+
+1. **`Model/Migration.swift`** — the public memberwise inits use the **old** parameter labels and
+   assign to **non-existent** properties: `MigrationProgress.init(… remainingOrchardZatoshi:)` does
+   `self.remainingOrchardZatoshi = …` (property is `remainingOrchard`); `PreparedTx.init(… rawTx:)`
+   does `self.rawTx = …` (property is `rawPczt`); `TransferProposal.init(… amountZatoshi:)` does
+   `self.amountZatoshi = …` (property is `amount`). Three compile errors.
+2. **`SDKSynchronizer.broadcastMigrationTx`** — reads `prepared.rawTx` (non-existent) and submits it
+   directly. Both a compile error and the wrong behavior: per the handoff §1, `rawPczt` is a
+   **serialized PCZT**, not a broadcastable tx; it must be run through `migrationExtractBroadcastTx`
+   first.
+3. **Test files disagree.** `MigrationModelTests.swift` already uses the new init labels
+   (`PreparedTx(… rawPczt:)`, `MigrationProgress(… remainingOrchard:)`), while
+   `MigrationSynchronizerTests.swift` uses the old labels (`rawTx:`, `remainingOrchardZatoshi:`) and
+   asserts the submitted bytes equal `prepared.rawTx`. Both cannot hold.
+
+The handoff §3 dictates the resolution: the **new** names win.
+
+## Goal
+
+Make the orchestration layer consistent with the pivoted welding tier: finish the field renames,
+adopt the extract-then-submit broadcast flow, surface the one orphan welding method, get the package
++ OfflineTests green, and hand the public-API delta to the ZODL app.
+
+## Decisions
+
+1. **New names win** (handoff §3) — fix the three inits in `Migration.swift` to the new parameter
+   labels (`rawPczt:`, `amount:`, `remainingOrchard:`) and correct the body assignments. This makes
+   the already-correct `MigrationModelTests.swift` compile.
+2. **Extract-then-submit** (handoff §1) — `broadcastMigrationTx` gains a `for account:` parameter and,
+   before submitting, calls
+   `initializer.rustBackend.migrationExtractBroadcastTx(pczt: prepared.rawPczt, for: account)` to get
+   the consensus tx bytes; those bytes (not the PCZT) are what gets submitted. An extract failure
+   **propagates** (it is a local/crate error — `ZcashError.rustMigrationExtractBroadcastTx` — not a
+   network outcome, so it is not mapped to `.networkError`). Both composites already have `account`
+   in scope and pass it through.
+3. **Surface `refreshStaleTransfers` publicly** (user-confirmed) — add
+   `refreshStaleTransfers(spendingKey:for:) async throws -> UInt32` to the `Synchronizer` protocol +
+   `SDKSynchronizer` as a thin delegation to `migrationRefreshStaleTransfers`. It is the only welding
+   method with no consumer; it is a standalone recovery op (re-anchor + re-prove + re-sign the active
+   run's stale transfers) that pairs with the existing `hasOverdueTransfers(for:)` detector. Naming
+   drops the `migration` prefix to match the sibling delegations (`hasOverdueTransfers`,
+   `restartCurrentMigrationStep`). Uses `spendingKey:` per the SDK convention (locked decision #5 of
+   the public-API design).
+4. **No new behavior beyond the above** (handoff §5) — error marshaling, numeric wire format, and the
+   14 pre-existing welding methods are unchanged. `NetworkPrivacyOptions` stays accepted-but-ignored
+   in v1. Closure/Combine adapters and voting remain out of scope.
+
+## Changes (file by file)
+
+### `Sources/ZcashLightClientKit/Model/Migration.swift`
+Fix the three public inits (labels + body assignments):
+- `MigrationProgress.init(completedTransfers:totalTransfers:remainingOrchard:nextTransferReadyAtHeight:)`
+- `PreparedTx.init(id:txid:rawPczt:)`
+- `TransferProposal.init(id:amount:anchorHeight:nextExecutableAfterHeight:expiryHeight:)`
+
+### `Sources/ZcashLightClientKit/Synchronizer.swift`
+- Add to the `// MARK: - Ironwood migration` section:
+  ```swift
+  /// Re-anchors, re-proves and re-signs the active migration run's scheduled transfers when they
+  /// have gone stale (their anchor is too old to broadcast). Returns the number of transfers
+  /// refreshed. Detect the need with ``hasOverdueTransfers(for:)``.
+  func refreshStaleTransfers(spendingKey: UnifiedSpendingKey, for account: AccountUUID) async throws -> UInt32
+  ```
+  Placed in the recovery cluster (next to `hasOverdueTransfers` / `restartCurrentMigrationStep`).
+
+### `Sources/ZcashLightClientKit/Synchronizer/SDKSynchronizer.swift`
+- `broadcastMigrationTx(_ prepared: PreparedTx, for account: AccountUUID)`: extract first, then submit
+  the extracted bytes. Update both call sites (`submitNoteSplit`, `executeNextPendingTransfer`) to
+  `broadcastMigrationTx(prepared, for: account)`.
+- Add the `refreshStaleTransfers` delegation:
+  ```swift
+  public func refreshStaleTransfers(spendingKey: UnifiedSpendingKey, for account: AccountUUID) async throws -> UInt32 {
+      try await initializer.rustBackend.migrationRefreshStaleTransfers(usk: spendingKey, for: account)
+  }
+  ```
+
+### `Tests/TestUtils/Sourcery/GeneratedMocks/AutoMockable.generated.swift`
+Regenerated (Sourcery 2.3.0) so `SynchronizerMock` gains `refreshStaleTransfers`. Not hand-edited.
+
+### `Tests/OfflineTests/MigrationSynchronizerTests.swift`
+- `makePreparedTx(… rawTx:)` → `rawPczt:`; `MigrationProgress(… remainingOrchardZatoshi:)` →
+  `remainingOrchard:`.
+- Every composite test that reaches broadcast sets a **distinct** extract return value
+  (`rustBackend.migrationExtractBroadcastTxPcztForReturnValue = extracted`) and asserts the submitted
+  raw equals `Data(extracted)` (not `Data(prepared.rawPczt)`), plus that extract received
+  `(prepared.rawPczt, account)`. This is what verifies the pivot.
+- New test: extract throws → neither `submit` nor `migrationRecordTransferResult` is called, error
+  propagates.
+- New delegation test: `refreshStaleTransfers` delegates to `migrationRefreshStaleTransfers` and
+  passes `(spendingKey, account)`, returning the count.
+
+### `CHANGELOG.md`
+Add `refreshStaleTransfers` to the public-API "Added" bullet; tweak the broadcast sentence to mention
+the extract step. (The welding bullet already lists rawPczt + extract + stale-transfer refresh.)
+
+### `MIGRATING.md`
+Add `refreshStaleTransfers` to the migration-API method list under the existing "Orchard → Ironwood
+migration API on `Synchronizer`" section.
+
+### `docs/handoffs/ZODL-ironwood-migration-api.md` (new)
+The ZODL-facing public-API delta (see below).
+
+## Public-API delta for ZODL
+
+The migration API is **pre-release** (unreleased), so these are not breaking changes against any
+shipped tag — they are corrections to the in-flight surface ZODL is integrating against.
+
+- **Renamed reads:** `MigrationProgress.remainingOrchardZatoshi → remainingOrchard`,
+  `TransferProposal.amountZatoshi → amount`. ZODL reads both (progress UI, schedule confirmation).
+- **`PreparedTx.rawTx → rawPczt`** — almost certainly invisible to ZODL: the public `Synchronizer`
+  API never returns a `PreparedTx` (the composites return `TransferResult`); broadcasting is fully
+  internal to the SDK. Listed for completeness.
+- **New additive method:** `refreshStaleTransfers(spendingKey:for:) -> UInt32`. Optional to adopt;
+  pair with `hasOverdueTransfers(for:)`.
+- **Behavioral (transparent to ZODL):** broadcasting is now internally extract-then-submit. ZODL keeps
+  calling `submitNoteSplit` / `executeNextPendingTransfer` unchanged.
+
+## Testing & verification (TDD where it pays)
+
+The model/synchronizer tests already encode the contract; TDD here = fix the tests to the new shape
+first (they fail to compile / fail assertions against the current tree), then make them green.
+
+- Build the package and run **OfflineTests** via the Xcode MCP (per global tooling rule). If Swift
+  macros aren't trusted, **stop and ask** — do not bypass.
+- Targeted suites: `MigrationSynchronizerTests`, `MigrationModelTests`, `MigrationFFITests`.
+- Swift style: explicit type names (no `.init()`), no semicolons, injected `Logger`, string
+  interpolation. Commit messages `[MOB-1455] …` on the current branch.
+
+## Out of scope / deferred (→ final report)
+
+- End-to-end broadcast against a seeded/synced DB (handoff §4 runtime caveats: on-device proving cost,
+  circuit-version pairing, `extract_broadcast_tx` round-trip, pre-issue-#1 DB rename). Compile +
+  mock-level offline only here.
+- `NetworkPrivacyOptions` (Tor / secondary endpoint) honoring.
+- txid byte-order assumption in `broadcastMigrationTx` (unchanged from the prior design).
+- Closure/Combine adapters; voting re-enable.

--- a/docs/superpowers/specs/2026-06-30-ironwood-migration-public-api-design.md
+++ b/docs/superpowers/specs/2026-06-30-ironwood-migration-public-api-design.md
@@ -1,0 +1,275 @@
+# Design — Public Ironwood migration API on `Synchronizer`
+
+**Date:** 2026-06-30
+**Branch:** `michal/MOB-1455-2-ironwood-migration-sdk-impl` (current — note: differs from the handoff's
+named branch `michal/MOB-1455-ironwood-migration-prototype-ffi`; we implement on the current branch per
+instruction).
+**Ticket:** MOB-1455.
+**Source handoff:** `../IOS-SDK-PUBLIC-API-HANDOFF.md`.
+
+## Goal
+
+Expose the app-facing Orchard→Ironwood migration API on the **async** `Synchronizer` protocol and its
+concrete `SDKSynchronizer`, built on the already-complete welding tier. The surface is a close port of the
+Kotlin `OrchardMigrationSdk`: **11 thin delegations** to `initializer.rustBackend` plus **2 broadcast
+composites** that submit the crate's pre-signed transactions through the SDK's **old direct send path**
+(`transactionEncoder.submit(transaction:)`).
+
+This session adds **only** the public `Synchronizer`-level API and the two composites. The welding tier
+(FFI, `ZcashRustBackendWelding` migration methods, `Model/Migration.swift`, error codes ZRUST0093-0106) is
+done and is not modified.
+
+## Locked decisions (from handoff, confirmed with user)
+
+1. **Flat on `Synchronizer`** — methods go directly on the protocol, not a dedicated sub-object.
+2. **async-only for v1** — add to the async `Synchronizer` protocol + `SDKSynchronizer` only. Do **not**
+   touch the `ClosureSynchronizer` / `CombineSynchronizer` protocols or their adapters
+   (`ClosureSDKSynchronizer` / `CombineSDKSynchronizer`). They are independent protocols, so leaving them
+   alone is sufficient and they keep compiling.
+3. **Broadcast via the OLD direct path** — submit `PreparedTx.rawTx` straight through
+   `transactionEncoder.submit(transaction:)`. Leave `SDKBroadcaster`, `Broadcaster`, `SubmitPlanStore`,
+   `TxResubmissionAction` untouched.
+4. **`NetworkPrivacyOptions`: accept but defer** — keep `options: NetworkPrivacyOptions` in the broadcasting
+   signatures, but ignore it in v1 (no per-call Tor / secondary endpoint). Marker at the call site:
+   `// TODO: [MOB-1455] honor NetworkPrivacyOptions (Tor / secondary endpoint)`.
+5. **Signing methods take `spendingKey: UnifiedSpendingKey`** — matches the SDK convention
+   (`createProposedTransactions(proposal:spendingKey:)`), unlike the Kotlin draft which hides keys.
+6. **No FFI, model, or error-code changes** — the welding already provides everything.
+
+## Public API — 13 methods
+
+Added to the `Synchronizer` protocol under a new `// MARK: - Ironwood migration` section and implemented in
+`SDKSynchronizer`. All take `for account: AccountUUID` because the welding methods do.
+
+```swift
+// MARK: - Ironwood migration
+
+func migrationState(for account: AccountUUID) async throws -> MigrationState
+func migrationProgress(for account: AccountUUID) async throws -> MigrationProgress?
+func isNoteSplitNeeded(for account: AccountUUID) async throws -> Bool
+func prepareNoteSplit(for account: AccountUUID) async throws -> NoteSplitProposal
+func submitNoteSplit(
+    proposal: NoteSplitProposal,
+    spendingKey: UnifiedSpendingKey,
+    options: NetworkPrivacyOptions,
+    for account: AccountUUID
+) async throws -> TransferResult                                                   // COMPOSITE (4a)
+func proposeMigrationTransfers(for account: AccountUUID) async throws -> MigrationSchedule
+func signAndStoreMigrationSchedule(
+    _ schedule: MigrationSchedule,
+    spendingKey: UnifiedSpendingKey,
+    for account: AccountUUID
+) async throws
+func isSyncRequiredBeforeNextTransfer(for account: AccountUUID) async throws -> Bool
+func executeNextPendingTransfer(
+    options: NetworkPrivacyOptions,
+    for account: AccountUUID
+) async throws -> TransferResult?                                                  // COMPOSITE (4b)
+func hasOverdueTransfers(for account: AccountUUID) async throws -> Bool
+func hasInvalidTransfers(for account: AccountUUID) async throws -> Bool
+func restartCurrentMigrationStep(for account: AccountUUID) async throws -> MigrationSchedule
+func initializePostUpgrade(for account: AccountUUID) async throws
+```
+
+### Delegation mapping (11 methods)
+
+Each delegate calls `initializer.rustBackend.*` directly and returns its result:
+
+| Public method | rustBackend welding method |
+|---|---|
+| `migrationState(for:)` | `migrationState(for:)` |
+| `migrationProgress(for:)` | `migrationProgress(for:)` |
+| `isNoteSplitNeeded(for:)` | `migrationIsNoteSplitNeeded(for:)` |
+| `prepareNoteSplit(for:)` | `migrationPrepareNoteSplit(for:)` |
+| `proposeMigrationTransfers(for:)` | `migrationProposeTransfers(for:)` |
+| `signAndStoreMigrationSchedule(_:spendingKey:for:)` | `migrationSignAndStore(schedule:usk:for:)` |
+| `isSyncRequiredBeforeNextTransfer(for:)` | `migrationIsSyncRequired(for:)` |
+| `hasOverdueTransfers(for:)` | `migrationHasOverdueTransfers(for:)` |
+| `hasInvalidTransfers(for:)` | `migrationHasInvalidTransfers(for:)` |
+| `restartCurrentMigrationStep(for:)` | `migrationRestartStep(for:)` |
+| `initializePostUpgrade(for:)` | `migrationInitializePostUpgrade(for:)` |
+
+**No `throwIfUnprepared()` guard** on the delegations. This matches the nearest analog — the rustBackend
+delegations `createPCZTFromProposal` / `redactPCZTForSigner` / `addProofsToPCZT` delegate straight to
+`initializer.rustBackend` without guarding. (`proposeTransfer` / `proposeShielding` guard because they are
+`transactionEncoder` operations that require `prepare()`.) The migration methods are DB-bound rustBackend
+operations and will fail naturally if the data DB is uninitialized.
+
+The welding methods `migrationSignNoteSplit`, `migrationNextDueTransfer`, `migrationRecordTransferResult`
+stay internal — they are the building blocks the two composites use (the Kotlin SDK does not surface them).
+
+## The two composites + shared submit helper
+
+Both composites live in `SDKSynchronizer`, where `transactionEncoder` (a `private var`) is reachable. The
+crate already built and signed the transaction; the Swift side only **broadcasts the raw bytes** and maps
+the outcome to a `TransferResult`.
+
+### Private submit helper
+
+Mirrors the existing `submitTransactions` error handling (`SDKSynchronizer.swift:485-513`):
+
+```swift
+private func broadcastMigrationTx(_ prepared: PreparedTx) async throws -> TransferResult {
+    // PreparedTx.txid is the crate's hex txid string (display byte order); EncodedTransaction and
+    // isTransactionKnownToServer need internal-order Data, so decode + reverse. See "txid handling".
+    let txIdData = Data(hexEncoded: prepared.txid).map { Data($0.reversed()) } ?? Data()
+    let encoded = EncodedTransaction(transactionId: txIdData, raw: Data(prepared.rawTx))
+
+    // TODO: [MOB-1455] honor NetworkPrivacyOptions (Tor / secondary endpoint). v1 broadcasts over the
+    // SDK's already-configured service via the old direct path.
+    do {
+        try await transactionEncoder.submit(transaction: encoded)
+        return .success(txid: prepared.txid)
+    } catch ZcashError.serviceSubmitFailed {
+        return .networkError(retryable: true)
+    } catch TransactionEncoderError.submitError {
+        // Trust the network over the submit-side error: if the server already has this tx, the
+        // broadcast landed. Mirror submitTransactions' isTransactionKnownToServer upgrade.
+        if await transactionEncoder.isTransactionKnownToServer(txId: txIdData) {
+            return .success(txid: prepared.txid)
+        }
+        // Conservative for v1. We do NOT infer invalidNote / expired from submit errors — the engine
+        // owns deep invalidity: after broadcast, migrationHasInvalidTransfers / re-querying
+        // migrationState surfaces RequiresAttention, and restartCurrentMigrationStep recovers.
+        return .networkError(retryable: false)
+    }
+    // Any other error propagates (mirrors submitTransactions, which only special-cases the two cases
+    // above and lets everything else throw).
+}
+```
+
+### 4a. `submitNoteSplit`
+
+```swift
+let prepared = try await initializer.rustBackend.migrationSignNoteSplit(
+    proposal: proposal, usk: spendingKey, for: account
+)
+return try await broadcastMigrationTx(prepared)
+// State advances to SplitPendingConfirmation; the app polls migrationState. No record step.
+```
+
+### 4b. `executeNextPendingTransfer`
+
+```swift
+guard let prepared = try await initializer.rustBackend.migrationNextDueTransfer(for: account) else {
+    return nil
+}
+let result = try await broadcastMigrationTx(prepared)
+try await initializer.rustBackend.migrationRecordTransferResult(
+    transferId: prepared.id, result: result, for: account
+)
+return result
+```
+
+No `spendingKey` — the transfer is pre-signed. Called from the app's BGTaskScheduler task; the app must not
+sync in the same background session as this call (an app-side contract, not enforced here).
+
+## txid handling (resolves a handoff gap)
+
+The handoff sketched `EncodedTransaction(transactionId: preparedTx.txId, ...)`, but the actual model is
+`PreparedTx { id: String, txid: String, rawTx: [UInt8] }` — `txid` is a hex **String**, while
+`EncodedTransaction.transactionId` and `isTransactionKnownToServer(txId:)` need `Data`. The repo has only
+`Data → hex` (`hexEncodedString()`), no `hex → Data`. Resolution:
+
+- Add an internal `init?(hexEncoded:)` to `Data` in `Extensions/HexEncode.swift` (decodes a hex string to
+  bytes; returns `nil` for odd length / non-hex).
+- In the helper, decode `prepared.txid` then **reverse** to internal byte order. Rationale: the SDK's
+  `Data.toHexStringTxId()` is `hexEncodedString().toTxIdString()` where `toTxIdString()` reverses
+  internal→display; Zcash `TxId` displays in reversed byte order, so a crate-emitted display txid maps to
+  internal-order `Data` by decode-then-reverse.
+- `TransferResult.success(txid:)` passes `prepared.txid` **verbatim** — the engine records and matches that
+  exact string, so it must not be transformed.
+
+**Risk / scope:** the reversed-order assumption is unverified against the `zodl_ironwood_migration` crate
+(end-to-end broadcast is deferred — see Deferred). It affects only the `isTransactionKnownToServer`
+optimization and the Tor circuit grouping key; a wrong guess degrades the "already landed" upgrade to the
+conservative `.networkError(retryable: false)`, never a correctness bug. Flagged with a code comment.
+
+## Error mapping summary
+
+| Submit outcome | `TransferResult` |
+|---|---|
+| success | `.success(txid: prepared.txid)` |
+| `ZcashError.serviceSubmitFailed` (gRPC/network) | `.networkError(retryable: true)` |
+| `TransactionEncoderError.submitError` + server knows txid | `.success(txid: prepared.txid)` |
+| `TransactionEncoderError.submitError` + server doesn't know | `.networkError(retryable: false)` |
+| any other error | propagates (thrown) |
+
+`invalidNote` / `expired` are intentionally never produced from submit errors — the migration engine's
+reconciliation owns deep invalidity.
+
+## Testing (TDD, OfflineTests)
+
+New file `Tests/OfflineTests/MigrationSynchronizerTests.swift`, subclassing `ZcashTestCase`, with a local
+`makeSynchronizer(transactionEncoder:rustBackend:)` helper mirroring `BroadcasterTests` (registers mocks in
+`mockContainer`, builds an `Initializer(isTorEnabled: false)`, returns an `SDKSynchronizer`). The composites
+are driven against `ZcashRustBackendWeldingMock` (for the three building-block methods) and an enhanced
+`StubTransactionEncoder` (for submit outcomes).
+
+**`submitNoteSplit`:**
+- success — `migrationSignNoteSplit` returns a `PreparedTx`, `submit` succeeds → `.success(txid:)`; assert
+  the backend received `(proposal, usk, account)` and the encoder received
+  `EncodedTransaction(raw: Data(prepared.rawTx))`.
+- gRPC failure — `submit` throws `ZcashError.serviceSubmitFailed` → `.networkError(retryable: true)`.
+- submitError + known-to-server — `submit` throws `TransactionEncoderError.submitError`, txid in the stub's
+  known set → `.success(txid:)`.
+- submitError + unknown — → `.networkError(retryable: false)`.
+- sign throws — `migrationSignNoteSplit` throws → `submitNoteSplit` propagates; `submit` not called.
+
+**`executeNextPendingTransfer`:**
+- no due transfer — `migrationNextDueTransfer` returns `nil` → returns `nil`; `submit` and
+  `migrationRecordTransferResult` not called.
+- success — returns `.success(txid:)`; assert `migrationRecordTransferResult` received
+  `(prepared.id, .success(txid:), account)`.
+- gRPC failure — returns `.networkError(retryable: true)`; assert that exact result was recorded.
+- nextDue throws — propagates; `migrationRecordTransferResult` not called.
+
+`StubTransactionEncoder` (in `Tests/TestUtils/SubmissionTestDoubles.swift`) gains two behavior-preserving
+knobs: `var submitError: Error?` (thrown by `submit` after it records the transaction) and
+`var knownToServerTxIds: Set<Data>` (returned by `isTransactionKnownToServer`). Defaults (`nil`, empty)
+preserve current behavior, so `BroadcasterTests` — which uses its own private stub anyway — is unaffected.
+
+Note: `ZcashRustBackendWeldingMock.migrationRecordTransferResult` force-unwraps its closure, so tests that
+reach the record step set `migrationRecordTransferResultTransferIdResultForClosure = { _, _, _ in }` and
+read `...ReceivedArguments` for assertions.
+
+## Mock regeneration
+
+Adding methods to the `Synchronizer` protocol breaks `SynchronizerMock` (it conforms to `Synchronizer`)
+until regenerated. Run `Tests/TestUtils/Sourcery/generateMocks.sh` (Sourcery **2.3.0** — installed and
+verified). Do not hand-edit generated code. Confirm `SynchronizerMock` gains the 13 methods and the target
+compiles.
+
+## Files touched
+
+- `Sources/ZcashLightClientKit/Synchronizer.swift` — +13 protocol declarations (new MARK section).
+- `Sources/ZcashLightClientKit/Synchronizer/SDKSynchronizer.swift` — +13 implementations (11 delegations,
+  2 composites, 1 private `broadcastMigrationTx` helper).
+- `Sources/ZcashLightClientKit/Extensions/HexEncode.swift` — internal `Data(hexEncoded:)` initializer.
+- `Tests/TestUtils/SubmissionTestDoubles.swift` — extend `StubTransactionEncoder` (2 knobs).
+- `Tests/TestUtils/Sourcery/GeneratedMocks/AutoMockable.generated.swift` — regenerated.
+- `Tests/OfflineTests/MigrationSynchronizerTests.swift` — new test file.
+- `CHANGELOG.md` — new public API entry.
+- `MIGRATING.md` — document the new migration surface.
+
+## Do NOT touch
+
+`SDKBroadcaster.swift`, `Broadcaster.swift`, `SubmitPlanStore.swift`, `TxResubmissionAction.swift`; the
+welding (`rust/src/migration.rs`, the `migration*` methods, `Model/Migration.swift`, error codes); voting;
+`ClosureSynchronizer` / `CombineSynchronizer` protocols + adapters.
+
+## Build / verify / conventions
+
+- Build and run **OfflineTests** via the Xcode MCP (OfflineTests scheme). `LocalPackages/` is present
+  (local FFI mode). If Swift macros aren't trusted, **stop and ask the user** (do not bypass).
+- Swift style: explicit type names (no `.init()` shorthand), no semicolons, prefer `OSAllocatedUnfairLock`,
+  injected `Logger` only, string interpolation not `+`.
+- Commit messages: `[MOB-1455] <title>`. Commit to the current branch.
+
+## Deferred — carried to the final report
+
+- **End-to-end broadcast is untested** offline (the welding tier is compile-verified). OfflineTests cover
+  the glue with mocks; real propose/sign/submit needs a seeded/synced DB or Darkside-style fixture.
+- **`NetworkPrivacyOptions`** (Tor / secondary endpoint) accepted but ignored.
+- **txid byte order** unverified against the crate (see txid handling).
+- **Closure/Combine adapters** and **voting** re-enable remain out of scope.


### PR DESCRIPTION
Adds the app-facing Orchard → Ironwood migration API on the async `Synchronizer`, built on top of the welding tier delivered by the base branch.

> **Base branch:** this PR targets its parent `michal/MOB-1455-ironwood-migration-prototype-ffi`, so the diff is **only the SDK-impl / orchestration layer**. The FFI, the `ZcashRustBackendWelding` migration methods, the `Model/Migration.swift` types, and the rust error codes all come from the base branch and are intentionally **not** part of this diff.

## Public `Synchronizer` migration API

14 methods (each takes `for account: AccountUUID`), declared on the async `Synchronizer` protocol and implemented in `SDKSynchronizer`:

- **State / progress:** `migrationState`, `migrationProgress`
- **Note split:** `isNoteSplitNeeded`, `prepareNoteSplit`, `submitNoteSplit` *(composite)*
- **Schedule:** `proposeMigrationTransfers`, `signAndStoreMigrationSchedule`
- **Execution:** `isSyncRequiredBeforeNextTransfer`, `executeNextPendingTransfer` *(composite)*
- **Detection / recovery:** `hasOverdueTransfers`, `hasInvalidTransfers`, `refreshStaleTransfers`, `restartCurrentMigrationStep`
- **Lifecycle:** `initializePostUpgrade`

Most are thin delegations to the rust backend welding; the two composites add the broadcast step.

## Broadcast composites — extract‑then‑submit

`submitNoteSplit` and `executeNextPendingTransfer` sign (or load) the engine's prepared transaction, **extract the broadcast‑ready consensus transaction from the signed PCZT** (`migrationExtractBroadcastTx`), submit it over the SDK's existing direct submission path, and map the outcome to a `TransferResult`. `executeNextPendingTransfer` also records the result back with the engine. `NetworkPrivacyOptions` is accepted but not yet honored (broadcast uses the already‑configured lightwalletd).

## Crate PCZT‑pivot adoption

The final commit reconciles this layer with the base branch's PCZT pivot:

- Model field renames adopted at the public surface: `PreparedTx.rawPczt`, `TransferProposal.amount`, `MigrationProgress.remainingOrchard` (wire format unchanged).
- The broadcast helper now extracts the consensus tx from the signed PCZT before submitting.
- `refreshStaleTransfers(spendingKey:for:)` surfaced as a public recovery op (re‑anchor / re‑prove / re‑sign stale transfers), pairing with `hasOverdueTransfers`.

## Supporting changes

- `Data(hexEncoded:)` initializer in `Extensions/HexEncode.swift` (+ `DataHexEncodedTests`) — decodes the crate's hex txid into the internal byte order needed by `EncodedTransaction` / `isTransactionKnownToServer`.
- `StubTransactionEncoder` gains two behavior‑preserving test knobs (`submitError`, `knownToServerTxIds`).
- Regenerated `SynchronizerMock` (Sourcery 2.3.0).

## Testing

`OfflineTests`: **431/431 pass** (37 migration tests), driving the composites against `ZcashRustBackendWeldingMock` + `StubTransactionEncoder`. End‑to‑end propose/sign/submit needs a seeded, synced wallet DB and is out of scope here.

## Docs

- `CHANGELOG.md`, `MIGRATING.md` — the new public migration surface.
- `docs/handoffs/ZODL-ironwood-migration-api.md` — public‑API delta handoff for the ZODL app (two field renames + the new `refreshStaleTransfers`; broadcast change is internal/transparent).
- Design specs under `docs/superpowers/specs/`.

## Out of scope / deferred

- `NetworkPrivacyOptions` (Tor / secondary endpoint) honoring.
- `ClosureSynchronizer` / `CombineSynchronizer` adapters — async‑only for now.
- End‑to‑end broadcast on a real fixture; on‑device proving cost; the txid byte‑order assumption in the broadcast helper.

Refs MOB-1455.
