### PR TITLE
Update flags to init-local-ffi.sh to optimize build times 

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ The Rust code in `rust/` is compiled into the `libzcashlc` XCFramework. Two mode
 
 Scripts:
 
-- `./Scripts/init-local-ffi.sh` — one-time setup; default builds all 5 architectures and creates `LocalPackages/`. **`--macos-only`** builds only the macOS slice from your `rust/` (good for `swift build` / `swift test` on the Mac). Use `--cached` only when your branch has no FFI changes relative to the release. Use --macos-only to rebuild for fast local development.
+- `./Scripts/init-local-ffi.sh` — one-time setup; default builds all 5 architectures and creates `LocalPackages/`. Arm-only subsets (faster on Apple Silicon — they skip the x86_64 slices): **`--arm-macos`** (macOS slice only, good for `swift build` / `swift test` on the Mac), **`--arm-ios`** (iOS simulator + device slices), **`--arm-all`** (iOS simulator + device + macOS). Use `--cached` only when your branch has no FFI changes relative to the release.
 - `./Scripts/rebuild-local-ffi.sh [ios-sim|ios-device|macos]` — fast single-arch incremental rebuild after Rust edits. `ios-sim` is default.
 - `./Scripts/reset-local-ffi.sh` — remove `LocalPackages/` and switch back to the release binary.
 

--- a/Scripts/init-local-ffi.sh
+++ b/Scripts/init-local-ffi.sh
@@ -1,8 +1,18 @@
 #!/bin/bash
 # Initialize local FFI development environment
-# Usage: ./Scripts/init-local-ffi.sh [--cached|--macos-only]
-#   --cached      Download pre-built release instead of building from source
-#   --macos-only  Build only the macOS slice from your rust/ (fast; swift build / swift test on Mac)
+# Usage: ./Scripts/init-local-ffi.sh [option]
+#
+# Options:
+#   (no option)   Build the full XCFramework (all 5 architectures) from your rust/.
+#   --arm-macos   Build only the arm64 macOS slice (aarch64-apple-darwin).
+#   --arm-ios     Build only the arm64 iOS slices: simulator (aarch64-apple-ios-sim)
+#                 and device (aarch64-apple-ios).
+#   --arm-all     Build all arm64 slices: iOS simulator + device + macOS.
+#   --cached      Download the pre-built release XCFramework instead of building.
+#
+# The --arm-* options skip the x86_64 simulator/Mac slices, which you cannot run on
+# Apple Silicon anyway, so local iteration is faster. They always build the aarch64
+# targets regardless of host architecture.
 #
 # This creates LocalPackages/ with a locally-built xcframework.
 # Package.swift automatically detects LocalPackages/ and switches
@@ -18,23 +28,151 @@ if [[ -f "$HOME/.cargo/env" ]]; then
     source "$HOME/.cargo/env"
 fi
 
-USE_CACHED=false
-MACOS_ONLY=false
-if [[ "${1:-}" == "--cached" ]]; then
-    USE_CACHED=true
-elif [[ "${1:-}" == "--macos-only" ]]; then
-    MACOS_ONLY=true
-fi
-
 XCFRAMEWORK_DIR="LocalPackages/libzcashlc.xcframework"
 
-if [[ "$MACOS_ONLY" == "true" ]]; then
-    echo "Initializing local FFI for macOS only (single-arch from your rust/)..."
+usage() {
+    if [[ -n "${1:-}" ]]; then
+        echo "Error: $1" >&2
+        echo "" >&2
+    fi
+    cat >&2 << 'USAGEEOF'
+Usage: ./Scripts/init-local-ffi.sh [option]
+
+Options:
+  (no option)   Build the full XCFramework (all 5 architectures) from your rust/.
+  --arm-macos   Build only the arm64 macOS slice (aarch64-apple-darwin).
+  --arm-ios     Build only the arm64 iOS slices: simulator + device.
+  --arm-all     Build all arm64 slices: iOS simulator + device + macOS.
+  --cached      Download the pre-built release XCFramework instead of building.
+
+Creates LocalPackages/ with a locally-built xcframework. Package.swift detects
+LocalPackages/ and uses it instead of the released binary.
+USAGEEOF
+    exit 1
+}
+
+# Build an arm64-only xcframework containing exactly the requested slices, then
+# atomically swap it into place. Each argument is one of: ios-sim, ios-device, macos.
+#
+# The slices reuse the same LibraryIdentifiers as the full build (e.g.
+# macos-arm64_x86_64) but declare only arm64 in SupportedArchitectures, matching
+# what rebuild-local-ffi.sh produces, so the two tools stay interchangeable.
+build_arm_xcframework() {
+    local targets=("$@")
+
+    local temp_dir temp_xcfw
+    temp_dir=$(mktemp -d)
+    temp_xcfw="$temp_dir/libzcashlc.xcframework"
+    mkdir -p "$temp_xcfw"
+
+    # One JSON object per slice, accumulated for the xcframework Info.plist.
+    local libraries_json=""
+
+    local target
+    for target in "${targets[@]}"; do
+        local rust_target slice platform variant
+        case "$target" in
+            ios-sim)
+                rust_target="aarch64-apple-ios-sim"
+                slice="ios-arm64_x86_64-simulator"
+                platform="ios"
+                variant="simulator"
+                ;;
+            ios-device)
+                rust_target="aarch64-apple-ios"
+                slice="ios-arm64"
+                platform="ios"
+                variant=""
+                ;;
+            macos)
+                rust_target="aarch64-apple-darwin"
+                slice="macos-arm64_x86_64"
+                platform="macos"
+                variant=""
+                ;;
+            *)
+                echo "Internal error: unknown arm target '$target'" >&2
+                exit 1
+                ;;
+        esac
+
+        echo "Building $rust_target -> $slice ..."
+
+        # Ensure the Rust target is available (idempotent), then build it.
+        # cargo is incremental, so repeat builds after small edits are fast.
+        rustup target add "$rust_target"
+        cargo build --target "$rust_target" --release
+
+        # Populate the framework for this slice.
+        local framework="$temp_xcfw/$slice/libzcashlc.framework"
+        mkdir -p "$framework/Modules" "$framework/Headers"
+        cp "target/$rust_target/release/libzcashlc.a" "$framework/libzcashlc"
+        cp BuildSupport/module.modulemap "$framework/Modules/"
+        cp BuildSupport/platform-Info.plist "$framework/Info.plist"
+        if [[ -d "target/Headers" ]]; then
+            cp -R target/Headers/* "$framework/Headers/"
+        fi
+
+        # Assemble this slice's AvailableLibraries entry as JSON (arm64 only).
+        local variant_json=""
+        if [[ -n "$variant" ]]; then
+            variant_json=", \"SupportedPlatformVariant\": \"$variant\""
+        fi
+        local entry="{\"LibraryIdentifier\": \"$slice\", \"LibraryPath\": \"libzcashlc.framework\", \"SupportedArchitectures\": [\"arm64\"], \"SupportedPlatform\": \"$platform\"$variant_json}"
+        if [[ -n "$libraries_json" ]]; then
+            libraries_json="$libraries_json, $entry"
+        else
+            libraries_json="$entry"
+        fi
+    done
+
+    # Generate the xcframework Info.plist from JSON; plutil emits canonical XML
+    # and validates it in one step, so we avoid hand-writing plist whitespace.
+    printf '{"AvailableLibraries": [%s], "CFBundlePackageType": "XFWK", "XCFrameworkFormatVersion": "1.0"}' "$libraries_json" \
+        | plutil -convert xml1 -o "$temp_xcfw/Info.plist" -
+
+    # Atomically swap the freshly built xcframework into place.
     mkdir -p LocalPackages
-    # rebuild-local-ffi.sh requires this directory to exist; it replaces contents entirely.
-    mkdir -p "$XCFRAMEWORK_DIR"
-    ./Scripts/rebuild-local-ffi.sh macos
-elif [[ "$USE_CACHED" == "true" ]]; then
+    rm -rf "$XCFRAMEWORK_DIR"
+    mv "$temp_xcfw" "$XCFRAMEWORK_DIR"
+    rm -rf "$temp_dir"
+}
+
+# Parse the single optional flag.
+if [[ $# -gt 1 ]]; then
+    usage "Too many arguments; pass at most one option."
+fi
+
+BUILD_MODE="full"
+ARM_TARGETS=()
+case "${1:-}" in
+    "")
+        BUILD_MODE="full"
+        ;;
+    --cached)
+        BUILD_MODE="cached"
+        ;;
+    --arm-macos)
+        BUILD_MODE="arm"
+        ARM_TARGETS=(macos)
+        ;;
+    --arm-ios)
+        BUILD_MODE="arm"
+        ARM_TARGETS=(ios-sim ios-device)
+        ;;
+    --arm-all)
+        BUILD_MODE="arm"
+        ARM_TARGETS=(ios-sim ios-device macos)
+        ;;
+    *)
+        usage "Unknown option: $1"
+        ;;
+esac
+
+if [[ "$BUILD_MODE" == "arm" ]]; then
+    echo "Initializing local FFI for arm64 (${ARM_TARGETS[*]})..."
+    build_arm_xcframework "${ARM_TARGETS[@]}"
+elif [[ "$BUILD_MODE" == "cached" ]]; then
     echo "Downloading pre-built xcframework..."
     REPO="zcash/zcash-swift-wallet-sdk"
 
@@ -95,10 +233,12 @@ echo "Next steps:"
 echo "  1. Open ZcashSDK.xcworkspace in Xcode (or run: swift build)"
 echo "  2. The workspace scheme rebuilds FFI automatically on each build."
 echo "     If opening Package.swift directly, run ./Scripts/rebuild-local-ffi.sh after Rust changes."
-if [[ "$MACOS_ONLY" == "true" ]]; then
+if [[ "$BUILD_MODE" == "arm" ]]; then
     echo ""
-    echo "Note: --macos-only produced a single-slice XCFramework. For iOS Simulator or device,"
-    echo "      run ./Scripts/rebuild-local-ffi.sh ios-sim or ios-device, or full ./Scripts/init-local-ffi.sh for every arch."
+    echo "Note: this produced an arm64-only XCFramework (${ARM_TARGETS[*]})."
+    echo "      Building for an x86_64 simulator/Mac or a slice you didn't include will fail"
+    echo "      until you build it. Run ./Scripts/rebuild-local-ffi.sh <target> for a single"
+    echo "      arch, or ./Scripts/init-local-ffi.sh (no flags) for the full 5-architecture build."
 fi
 echo ""
 echo "To switch back to the release binary: rm -rf LocalPackages/"

--- a/docs/LOCAL_DEVELOPMENT.md
+++ b/docs/LOCAL_DEVELOPMENT.md
@@ -54,6 +54,16 @@ The `--cached` flag downloads a pre-built release instead of building from sourc
 
 **Warning:** Only use `--cached` if there have been no FFI changes on your branch since the last release. Using a stale pre-built binary with modified Swift bindings could cause silent data corruption and loss of funds. Additionally, `--cached` skips the Rust build entirely, so the first call to `rebuild-local-ffi.sh` will be a full (non-incremental) build.
 
+For faster iteration on Apple Silicon you can build only the arm64 slices you need, skipping the x86_64 simulator/Mac slices you can't run there anyway:
+
+```bash
+./Scripts/init-local-ffi.sh --arm-macos # macOS (swift build / swift test on the Mac)
+./Scripts/init-local-ffi.sh --arm-ios   # iOS simulator + device
+./Scripts/init-local-ffi.sh --arm-all   # iOS simulator + device + macOS
+```
+
+Building for a slice you didn't include will fail until you build it (via `rebuild-local-ffi.sh` or a full `init-local-ffi.sh`).
+
 ### Opening in Xcode
 
 You can open the project two ways:
@@ -99,14 +109,19 @@ If using Xcode, you may also need to reset package caches: File > Packages > Res
 One-time setup that creates the local development environment.
 
 ```bash
-./Scripts/init-local-ffi.sh          # Build from source (recommended)
-./Scripts/init-local-ffi.sh --cached # Download pre-built release
+./Scripts/init-local-ffi.sh             # Build from source, all 5 architectures (recommended)
+./Scripts/init-local-ffi.sh --arm-macos # arm64 macOS slice only
+./Scripts/init-local-ffi.sh --arm-ios   # arm64 iOS simulator + device slices
+./Scripts/init-local-ffi.sh --arm-all   # arm64 iOS simulator + device + macOS slices
+./Scripts/init-local-ffi.sh --cached    # Download pre-built release
 ```
 
 This script:
-- Builds the full XCFramework (all 5 architectures) or downloads a pre-built one
+- Builds the full XCFramework (all 5 architectures), an arm64-only subset (`--arm-*`, faster on Apple Silicon since it skips the x86_64 slices), or downloads a pre-built one
 - Creates `LocalPackages/` with an SPM wrapper package
 - `Package.swift` automatically detects `LocalPackages/` and switches to local mode
+
+The `--arm-*` flags always build the `aarch64-*` targets regardless of host architecture. They produce an XCFramework containing only the requested arm64 slices, so building for an x86_64 simulator/Mac (or a slice you didn't include) will fail until you build it — run `rebuild-local-ffi.sh <target>` or a full `init-local-ffi.sh` to add the missing slices. Any unrecognized flag prints usage and exits without building.
 
 ### `rebuild-local-ffi.sh`
 


### PR DESCRIPTION
## Summary

Adds three arm64-only build modes to `Scripts/init-local-ffi.sh` so local FFI iteration on Apple Silicon can skip the two slow x86_64 slices (which can't run there anyway).

| Flag | Builds | Slices |
|---|---|---|
| `--arm-macos` | `aarch64-apple-darwin` | 1 (`macos-arm64_x86_64`) |
| `--arm-ios` | `aarch64-apple-ios-sim`, `aarch64-apple-ios` | 2 |
| `--arm-all` | all three above | 3 |
| *(none)* | all 5 (unchanged, via `make xcframework`) | 3 universal |
| `--cached` | download release (unchanged) | — |

Multi-slice arm frameworks are assembled in-script and swapped in atomically. The `Info.plist` is generated via `plutil` using the same slice identifiers as the full build but arm64-only `SupportedArchitectures`, so output stays interchangeable with `rebuild-local-ffi.sh`.

## Also in this PR

- **Rename `--macos-only` → `--arm-macos`** (hard rename). Nothing external depends on the old flag — CI builds via `make macos` directly — so this is a clean rename. On Intel hosts `--arm-macos` now builds `aarch64-apple-darwin` where `--macos-only` built `x86_64-apple-darwin`, consistent with the "arm" naming.
- **Reject unknown/extra arguments** with a usage message and non-zero exit, instead of silently falling through to the full 5-architecture build.
- Update `CLAUDE.md` and `docs/LOCAL_DEVELOPMENT.md`; add a design spec under `docs/superpowers/specs/`.

## Verification

- `bash -n` clean; unknown flag and too-many-args → usage + exit 1 (no `LocalPackages/` created).
- `--arm-all` → valid 3-slice XCFramework; each slice's static lib confirmed **arm64**; every `SupportedArchitectures = [arm64]`; plist lint-clean and structurally identical to `BuildSupport/Info.plist`.
- `--arm-ios` → exactly 2 slices; `--arm-macos` → exactly 1 slice; both near-instant on a warm Cargo cache (incremental).
- `swift build` against the `--arm-macos` slice → **Build complete!**, exit 0 (only pre-existing SwiftProtobuf deprecation warnings).

## Note

No linked issue — this is a developer-tooling change to the local FFI build script. Flagging it since `CONTRIBUTING.md` normally asks that PRs reference an issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
