### PR TITLE
[MOB-1096] Retry Tor rust-layer errors instead of failing sync fatally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
+## Fixed
+- Tor-layer errors (`rustTorConnectToLightwalletd`, `rustTorLwdGetInfo`, `rustTorLwdSubmit`, `rustTorLwdFetchTransaction`, `rustTorLwdLatestBlockHeight`, `rustTorLwdGetTreeState`) are now classified as retryable service errors in `CompactBlockProcessor`. Previously these errors bypassed the service-error retry path and went straight to a fatal sync failure, so a transient Tor circuit/stream issue (e.g. "remote hostname lookup failure", "Failed to obtain exit circuit for ports", "Tor network protocol violation") required a full app restart to recover. They now trigger the same reset-and-retry behavior (including tearing down cached Tor connections via `service.closeConnections()`) as other transport errors, up to `ZcashSDK.serviceFailureRetries` times.
+
 # 2.6.0-alpha.6
 
 ## Added

--- a/Sources/ZcashLightClientKit/Block/CompactBlockProcessor.swift
+++ b/Sources/ZcashLightClientKit/Block/CompactBlockProcessor.swift
@@ -654,7 +654,10 @@ extension CompactBlockProcessor {
                     ZcashError.serviceLatestBlockHeightFailed, ZcashError.serviceBlockRangeFailed,
                     ZcashError.serviceSubmitFailed, ZcashError.serviceFetchTransactionFailed,
                     ZcashError.serviceFetchUTXOsFailed, ZcashError.serviceBlockStreamFailed,
-                    ZcashError.serviceSubtreeRootsStreamFailed: serviceError = true
+                    ZcashError.serviceSubtreeRootsStreamFailed,
+                    ZcashError.rustTorConnectToLightwalletd, ZcashError.rustTorLwdGetInfo,
+                    ZcashError.rustTorLwdSubmit, ZcashError.rustTorLwdFetchTransaction,
+                    ZcashError.rustTorLwdLatestBlockHeight, ZcashError.rustTorLwdGetTreeState: serviceError = true
                 default:
                     // Non-ZcashError exceptions are raw gRPC/transport failures that escaped without
                     // proper wrapping — treat them as service errors so the retry logic kicks in


### PR DESCRIPTION
## Summary
- Tor rust-layer errors (`rustTorConnectToLightwalletd`, `rustTorLwdGetInfo`, `rustTorLwdSubmit`, `rustTorLwdFetchTransaction`, `rustTorLwdLatestBlockHeight`, `rustTorLwdGetTreeState`) are `ZcashError` cases, so they fell through `CompactBlockProcessor`'s retry-classification switch to `serviceError = false` and went straight to a fatal `handleSyncFailure` — no retry, no reconnect.
- This is the most frequently reported issue in support (MOB-1096): errors like "remote hostname lookup failure", "Failed to obtain exit circuit for ports", and "Tor network protocol violation" require a full force-quit + relaunch to recover, sometimes losing in-progress send state.
- Fix: classify these Tor errors alongside the existing `service*Failed` cases, so they go through the same reset-and-retry path (which also tears down cached Tor connections via `service.closeConnections()`) up to `ZcashSDK.serviceFailureRetries` (3) times, instead of failing fatally on the first transient Tor hiccup.

## Test plan
- [x] `swift build` succeeds
- [x] `swift test --filter OfflineTests` — 473 tests pass
- [ ] Manual verification with a flaky/dropped Tor circuit (hard to simulate offline; relying on code review + existing retry-path coverage for other transport errors)