### PR TITLE
Mark GitHub releases as pre-releases for SemVer pre-release versions

### DIFF
--- a/Scripts/prepare-release.sh
+++ b/Scripts/prepare-release.sh
@@ -9,6 +9,9 @@
 #   4. Writes release info to BuildSupport/products/release.env
 #   5. Outputs the values needed for Package.swift
 #
+# Versions with a SemVer pre-release suffix (e.g. 2.6.0-alpha.1, 2.7.0-rc.2)
+# are detected automatically and the GitHub release is marked as a pre-release.
+#
 # After running this script:
 #   1. Update Package.swift with the URL and checksum
 #   2. Commit the Package.swift change
@@ -49,7 +52,16 @@ REPO="zcash/zcash-swift-wallet-sdk"
 PRODUCTS_DIR="BuildSupport/products"
 ZIP_FILE="libzcashlc.xcframework.zip"
 
+# SemVer: a hyphen in the version (e.g. 2.6.0-alpha.1) marks a pre-release
+PRERELEASE_FLAG=()
+if [[ "$VERSION" == *-* ]]; then
+    PRERELEASE_FLAG=(--prerelease)
+fi
+
 echo "=== Preparing release ${VERSION} ==="
+if [[ ${#PRERELEASE_FLAG[@]} -gt 0 ]]; then
+    echo "Pre-release suffix detected. The GitHub release will be marked as a pre-release."
+fi
 echo ""
 
 # Check for uncommitted changes (skip in non-interactive mode, e.g. CI)
@@ -110,7 +122,8 @@ else
         --repo "$REPO" \
         --title "$VERSION" \
         --notes "Zcash Light Client SDK ${VERSION}" \
-        --draft
+        --draft \
+        "${PRERELEASE_FLAG[@]}"
 fi
 
 RELEASE_URL="https://github.com/${REPO}/releases/tag/${VERSION}"

--- a/Scripts/prepare-release.sh
+++ b/Scripts/prepare-release.sh
@@ -116,6 +116,13 @@ if gh release view "$VERSION" --repo "$REPO" &>/dev/null; then
         "$PRODUCTS_DIR/$ZIP_FILE" \
         --repo "$REPO" \
         --clobber
+    # gh release upload can only replace assets, not release properties, so an
+    # existing release (e.g. one created before pre-release detection existed)
+    # needs an explicit edit to gain the pre-release bit.
+    if [[ ${#PRERELEASE_FLAG[@]} -gt 0 ]]; then
+        echo "Marking existing release ${VERSION} as a pre-release."
+        gh release edit "$VERSION" --repo "$REPO" "${PRERELEASE_FLAG[@]}"
+    fi
 else
     gh release create "$VERSION" \
         "$PRODUCTS_DIR/$ZIP_FILE" \

--- a/Scripts/release.sh
+++ b/Scripts/release.sh
@@ -17,6 +17,9 @@
 #              (e.g., 'origin' or 'upstream')
 #   <version>  The version to release (e.g., '2.5.0')
 #
+# Versions with a SemVer pre-release suffix (e.g. 2.6.0-alpha.1, 2.7.0-rc.2)
+# are detected automatically and the GitHub release is marked as a pre-release.
+#
 # Prerequisites:
 #   - gh CLI installed and authenticated
 #   - Rust toolchain with all Apple targets
@@ -58,7 +61,16 @@ fi
 REPO="zcash/zcash-swift-wallet-sdk"
 PRODUCTS_DIR="BuildSupport/products"
 
+# SemVer: a hyphen in the version (e.g. 2.6.0-alpha.1) marks a pre-release
+PRERELEASE_FLAG=()
+if [[ "$VERSION" == *-* ]]; then
+    PRERELEASE_FLAG=(--prerelease)
+fi
+
 echo "=== SDK Release ${VERSION} ==="
+if [[ ${#PRERELEASE_FLAG[@]} -gt 0 ]]; then
+    echo "Pre-release suffix detected. The GitHub release will be marked as a pre-release."
+fi
 echo ""
 
 # Verify clean working directory
@@ -148,7 +160,7 @@ if [[ ! $REPLY =~ ^[Yy]$ ]]; then
     echo "Release paused. To resume manually:"
     echo "  git tag -s ${VERSION} -m \"Release ${VERSION}\""
     echo "  git push ${UPSTREAM_REMOTE} ${CURRENT_BRANCH} ${VERSION}"
-    echo "  gh release edit ${VERSION} --repo ${REPO} --draft=false"
+    echo "  gh release edit ${VERSION} --repo ${REPO} --draft=false${PRERELEASE_FLAG:+ ${PRERELEASE_FLAG[*]}}"
     exit 0
 fi
 
@@ -162,11 +174,15 @@ git push "$UPSTREAM_REMOTE" "$CURRENT_BRANCH" "$VERSION"
 
 echo ""
 echo "=== Step 6/6: Publishing release ==="
-gh release edit "$VERSION" --repo "$REPO" --draft=false
+gh release edit "$VERSION" --repo "$REPO" --draft=false "${PRERELEASE_FLAG[@]}"
 
 echo ""
 echo "=========================================="
-echo "  Release ${VERSION} complete!"
+if [[ ${#PRERELEASE_FLAG[@]} -gt 0 ]]; then
+    echo "  Pre-release ${VERSION} complete!"
+else
+    echo "  Release ${VERSION} complete!"
+fi
 echo "=========================================="
 echo ""
 echo "  GitHub Release: https://github.com/${REPO}/releases/tag/${VERSION}"

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -25,4 +25,7 @@ Steps:
 - Use `./Scripts/release.sh <remote> <version>` for a fully automated release, or
 - Use `./Scripts/prepare-release.sh <version>` for a semi-automated process with manual steps
 
+Versions with a SemVer pre-release suffix (e.g. `2.6.0-alpha.1`) are detected automatically
+and the GitHub release is marked as a pre-release.
+
 See the scripts themselves for detailed usage instructions.


### PR DESCRIPTION
Part of #1745.

## Summary

Releasing a version like `2.6.0-alpha.6` currently creates a normal GitHub release, and someone has to tick the "pre-release" checkbox in the UI by hand (the existing `2.6.0-alpha.*` releases were marked that way manually). This PR makes the release scripts do it automatically.

- `Scripts/prepare-release.sh` detects a SemVer pre-release suffix (any hyphen in the version, e.g. `2.6.0-alpha.1`, `2.7.0-rc.2`) and passes `--prerelease` to `gh release create`. Since this script is the single place releases are created, the fix covers both the local flow and the `Build FFI XCFramework` workflow. When `--force-overwrite-existing-release` updates an already-existing release, the pre-release bit is applied with a follow-up `gh release edit`, since `gh release upload` can only replace assets.
- `Scripts/release.sh` passes `--prerelease` when publishing the draft (`gh release edit`), includes the flag in the printed manual-resume command, and announces the pre-release status in its output.
- `docs/ci.md` documents the auto-detection.

Auto-detection was chosen over an explicit flag so it can't be forgotten: per SemVer, a hyphenated suffix *is* what defines a pre-release, and it matches this repo's tag history exactly (all `-alpha.*` tags are pre-releases on GitHub, all stable tags are not).

## Testing

- `bash -n` passes on both scripts.
- Detection and flag expansion exercised under macOS `/bin/bash` 3.2.57 (the interpreter these scripts run with) for `2.5.2`, `2.6.0-alpha.7`, and `2.7.0-rc.1`: stable versions produce exactly the previous `gh` invocations; pre-release versions append `--prerelease` to both `gh release create` and `gh release edit`.
- The `--force-overwrite-existing-release` path exercised the same way with a stubbed `gh`: pre-release versions follow the asset upload with `gh release edit --prerelease`; stable versions skip the edit call.
- Verified the installed `gh` CLI supports `--prerelease` on both `release create` and `release edit`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
