### PR TITLE
Update librustzcash dependency stack and adapt FFI to new APIs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1517,8 +1517,7 @@ dependencies = [
 [[package]]
 name = "equihash"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "306286e8dcc39ab3dfceb74c792ce8baffdab90591321d3ffaae64829734c37f"
+source = "git+https://github.com/zcash/librustzcash?rev=4faf8711189950cf38f99b59b8c21208d0946427#4faf8711189950cf38f99b59b8c21208d0946427"
 dependencies = [
  "blake2b_simd",
  "corez",
@@ -1554,8 +1553,7 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d42773cb15447644d170be20231a3268600e0c4cea8987d013b93ac973d3cf7"
+source = "git+https://github.com/zcash/librustzcash?rev=4faf8711189950cf38f99b59b8c21208d0946427#4faf8711189950cf38f99b59b8c21208d0946427"
 dependencies = [
  "blake2b_simd",
 ]
@@ -1665,6 +1663,18 @@ name = "fluid-let"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "749cff877dc1af878a0b31a41dd221a753634401ea0ef2f87b62d3171522485a"
+
+[[package]]
+name = "flume"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "nanorand",
+ "spin",
+]
 
 [[package]]
 name = "fnv"
@@ -2263,8 +2273,8 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "imt-tree"
-version = "0.1.1"
-source = "git+https://github.com/zodl-inc/vote-nullifier-pir.git?rev=2411f119cdcff9f8452be7144628948b4088a96f#2411f119cdcff9f8452be7144628948b4088a96f"
+version = "0.2.0"
+source = "git+https://github.com/zodl-inc/vote-nullifier-pir.git?rev=0dea3485429c80033e67a1ddb18ee72cc450cefb#0dea3485429c80033e67a1ddb18ee72cc450cefb"
 dependencies = [
  "anyhow",
  "ff",
@@ -2704,6 +2714,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
+name = "nanorand"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
+dependencies = [
+ "getrandom 0.2.17",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2923,9 +2942,9 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orchard"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a54f8d29bfb1e76a9d4e868a1a08cce2e57dd2bdc66232982822ad3114b91ab3"
+checksum = "cca2ede6a4a77bd729eed3be9303d98a08b217edc85190dcf4dbe004086d5a65"
 dependencies = [
  "aes",
  "bitvec",
@@ -3074,9 +3093,8 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pczt"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4712bd8688e1d1aa0eb0e78dc5c846bc2d70dcd1de544ecf053516df174c4fcd"
+version = "0.8.0-rc.1"
+source = "git+https://github.com/zcash/librustzcash?rev=4faf8711189950cf38f99b59b8c21208d0946427#4faf8711189950cf38f99b59b8c21208d0946427"
 dependencies = [
  "blake2b_simd",
  "bls12_381",
@@ -3208,9 +3226,9 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pir-client"
-version = "0.2.0"
+version = "0.4.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f18409a3bbbc58985c0ba79ec464c65e6ebab19cc1a82c5d4e184c3484520100"
+checksum = "666111370cf8a3fb2fa41a2442accc9d283226c1229828ff92c253dda1eb51e3"
 dependencies = [
  "anyhow",
  "ff",
@@ -3227,9 +3245,9 @@ dependencies = [
 
 [[package]]
 name = "pir-types"
-version = "0.1.0"
+version = "0.3.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fd3d6025cac852a7b3b81d6d07d6e21cc03bb3d5873fc13144a74c56f325b9d"
+checksum = "87a9ba9677931ac73da6d7726af28357da8f2e3d635a3e186c92a7f41382fe3e"
 dependencies = [
  "anyhow",
  "ff",
@@ -4251,9 +4269,9 @@ dependencies = [
 
 [[package]]
 name = "shardtree"
-version = "0.6.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "359e552886ae54d1642091645980d83f7db465fd9b5b0248e3680713c1773388"
+checksum = "9cc96e9b6b1c307749019e7e2cf9dd29881b1928ce6866e3702a02a4800aa345"
 dependencies = [
  "bitflags",
  "either",
@@ -4392,6 +4410,9 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
 
 [[package]]
 name = "spki"
@@ -6124,8 +6145,8 @@ checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "vote-commitment-tree"
-version = "0.1.1"
-source = "git+https://github.com/zodl-inc/zcash_voting.git?rev=f9d7d201037c0e3fba9adc95f362a27082710ccc#f9d7d201037c0e3fba9adc95f362a27082710ccc"
+version = "0.3.2"
+source = "git+https://github.com/zodl-inc/zcash_voting.git?rev=464f974865f2afa82bdac15d169168c77ecb9c74#464f974865f2afa82bdac15d169168c77ecb9c74"
 dependencies = [
  "anyhow",
  "ff",
@@ -6140,8 +6161,8 @@ dependencies = [
 
 [[package]]
 name = "vote-commitment-tree-client"
-version = "0.3.0"
-source = "git+https://github.com/zodl-inc/zcash_voting.git?rev=f9d7d201037c0e3fba9adc95f362a27082710ccc#f9d7d201037c0e3fba9adc95f362a27082710ccc"
+version = "0.5.2"
+source = "git+https://github.com/zodl-inc/zcash_voting.git?rev=464f974865f2afa82bdac15d169168c77ecb9c74#464f974865f2afa82bdac15d169168c77ecb9c74"
 dependencies = [
  "base64",
  "ff",
@@ -6155,8 +6176,8 @@ dependencies = [
 
 [[package]]
 name = "voting-circuits"
-version = "0.4.2"
-source = "git+https://github.com/zodl-inc/voting-circuits.git?rev=ed1ea27234e251e98a4b0bf9fcff11babccf1b92#ed1ea27234e251e98a4b0bf9fcff11babccf1b92"
+version = "0.9.0-rc.2"
+source = "git+https://github.com/zodl-inc/voting-circuits.git?rev=a5aae410a6fb14fcbea2f0ce3393035195e86f69#a5aae410a6fb14fcbea2f0ce3393035195e86f69"
 dependencies = [
  "blake2b_simd",
  "ff",
@@ -6165,6 +6186,7 @@ dependencies = [
  "halo2_poseidon",
  "halo2_proofs",
  "incrementalmerkletree",
+ "itertools 0.14.0",
  "lazy_static",
  "orchard",
  "pasta_curves",
@@ -6823,9 +6845,8 @@ dependencies = [
 
 [[package]]
 name = "zcash_address"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58342d0aaa8e2fa98849636f52800ac4bf020574c944c974742fc933db58cac2"
+version = "0.13.0"
+source = "git+https://github.com/zcash/librustzcash?rev=4faf8711189950cf38f99b59b8c21208d0946427#4faf8711189950cf38f99b59b8c21208d0946427"
 dependencies = [
  "bech32",
  "bs58",
@@ -6837,9 +6858,8 @@ dependencies = [
 
 [[package]]
 name = "zcash_client_backend"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04583f0945d5ff80eee80c1844fb0af8b7cc46a0ac26d5e12c4ccd474bec0f03"
+version = "0.24.0-rc.1"
+source = "git+https://github.com/zcash/librustzcash?rev=4faf8711189950cf38f99b59b8c21208d0946427#4faf8711189950cf38f99b59b8c21208d0946427"
 dependencies = [
  "arti-client",
  "base64",
@@ -6848,9 +6868,9 @@ dependencies = [
  "bls12_381",
  "bs58",
  "byteorder",
- "crossbeam-channel",
  "document-features",
  "dynosaur",
+ "flume",
  "fs-mistrust",
  "futures-util",
  "getset",
@@ -6880,7 +6900,6 @@ dependencies = [
  "shardtree",
  "subtle",
  "time",
- "time-core",
  "tokio",
  "tokio-rustls",
  "tonic",
@@ -6906,9 +6925,8 @@ dependencies = [
 
 [[package]]
 name = "zcash_client_sqlite"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1b99abb0e534b72705f49cb43d5f1a448844b49b9c48590f87888cb84ce6d29"
+version = "0.22.0-rc.1"
+source = "git+https://github.com/zcash/librustzcash?rev=4faf8711189950cf38f99b59b8c21208d0946427#4faf8711189950cf38f99b59b8c21208d0946427"
 dependencies = [
  "bip32",
  "bitflags",
@@ -6954,8 +6972,7 @@ dependencies = [
 [[package]]
 name = "zcash_encoding"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1440921903cdb86133fb9e2fe800be488015db2939a30bedb413078a1acb0306"
+source = "git+https://github.com/zcash/librustzcash?rev=4faf8711189950cf38f99b59b8c21208d0946427#4faf8711189950cf38f99b59b8c21208d0946427"
 dependencies = [
  "corez",
  "hex",
@@ -6964,9 +6981,8 @@ dependencies = [
 
 [[package]]
 name = "zcash_keys"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fbcdfbb5c8edb247439d72a397abaae9b7dd14a1c070e7e4fc3536924f9065f"
+version = "0.15.0"
+source = "git+https://github.com/zcash/librustzcash?rev=4faf8711189950cf38f99b59b8c21208d0946427#4faf8711189950cf38f99b59b8c21208d0946427"
 dependencies = [
  "bech32",
  "bip32",
@@ -6994,9 +7010,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_note_encryption"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77efec759c3798b6e4d829fcc762070d9b229b0f13338c40bf993b7b609c2272"
+checksum = "e1cb1b9170c94370e3d66c5cc0877661db743337588b64de7711239eed462198"
 dependencies = [
  "chacha20",
  "chacha20poly1305",
@@ -7007,9 +7023,8 @@ dependencies = [
 
 [[package]]
 name = "zcash_primitives"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c69e07f5eb3f682a6467b4b08ee4956f1acd1e886d70b21c4766953b3a1beba2"
+version = "0.29.0"
+source = "git+https://github.com/zcash/librustzcash?rev=4faf8711189950cf38f99b59b8c21208d0946427#4faf8711189950cf38f99b59b8c21208d0946427"
 dependencies = [
  "blake2b_simd",
  "block-buffer 0.11.0-rc.3",
@@ -7038,9 +7053,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_proofs"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3de6b0ca82e08a9d38b1121f87c5b180b5feac19fecba074cb582882210d2371"
+checksum = "b91fb0b420fb66a765f1fa92ab7a6b631aa54c08415415ef6185256826e74fbd"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -7060,9 +7075,8 @@ dependencies = [
 
 [[package]]
 name = "zcash_protocol"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bec496a0bd62dae98c4b26f51c5dab112d0c5350bbc2ccfdfd05bb3454f714d"
+version = "0.10.0"
+source = "git+https://github.com/zcash/librustzcash?rev=4faf8711189950cf38f99b59b8c21208d0946427#4faf8711189950cf38f99b59b8c21208d0946427"
 dependencies = [
  "corez",
  "document-features",
@@ -7099,9 +7113,8 @@ dependencies = [
 
 [[package]]
 name = "zcash_transparent"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15df1908b428d4edeb7c7caae5692e05e2e92e5c38007a40b20ac098efdffd96"
+version = "0.9.0"
+source = "git+https://github.com/zcash/librustzcash?rev=4faf8711189950cf38f99b59b8c21208d0946427#4faf8711189950cf38f99b59b8c21208d0946427"
 dependencies = [
  "bip32",
  "bs58",
@@ -7124,12 +7137,14 @@ dependencies = [
 
 [[package]]
 name = "zcash_voting"
-version = "0.5.12"
-source = "git+https://github.com/zodl-inc/zcash_voting.git?rev=f9d7d201037c0e3fba9adc95f362a27082710ccc#f9d7d201037c0e3fba9adc95f362a27082710ccc"
+version = "1.0.0"
+source = "git+https://github.com/zodl-inc/zcash_voting.git?rev=464f974865f2afa82bdac15d169168c77ecb9c74#464f974865f2afa82bdac15d169168c77ecb9c74"
 dependencies = [
  "anyhow",
+ "base64",
  "blake2b_simd",
  "bytes",
+ "ed25519-dalek",
  "ff",
  "group",
  "halo2_gadgets",
@@ -7140,25 +7155,38 @@ dependencies = [
  "hyper",
  "hyper-rustls",
  "hyper-util",
+ "imt-tree",
  "incrementalmerkletree",
  "nonempty",
  "orchard",
  "pasta_curves",
  "pczt",
  "pir-client",
+ "pir-types",
+ "prost",
  "rand 0.8.6",
  "rusqlite",
+ "rustls",
  "serde",
  "serde_json",
+ "sha2 0.10.9",
+ "sinsemilla",
  "subtle",
  "thiserror 2.0.18",
  "tokio",
+ "tonic",
+ "uuid",
+ "valar-spiral-rs",
+ "valar-ypir",
  "vote-commitment-tree",
  "vote-commitment-tree-client",
  "voting-circuits",
+ "zcash_client_backend",
+ "zcash_client_sqlite",
  "zcash_keys",
  "zcash_primitives",
  "zcash_protocol",
+ "zeroize",
  "zip32",
 ]
 
@@ -7233,9 +7261,8 @@ dependencies = [
 
 [[package]]
 name = "zip321"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fef061351aa99792deb8f62b00426863a317ca2cb124c9de85550e3ef0f0f2f"
+version = "0.9.0-rc.1"
+source = "git+https://github.com/zcash/librustzcash?rev=4faf8711189950cf38f99b59b8c21208d0946427#4faf8711189950cf38f99b59b8c21208d0946427"
 dependencies = [
  "base64",
  "nom",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,13 +15,13 @@ build = "rust/build.rs"
 [dependencies]
 
 # Zcash
-orchard = { version = "0.14", features = ["unstable-voting-circuits"] }
+orchard = { version = "0.15", features = ["unstable-voting-circuits"] }
 pasta_curves = "0.5"
 ff = "0.13"
 sapling = { package = "sapling-crypto", version = "0.7", default-features = false }
-transparent = { package = "zcash_transparent", version = "0.8", default-features = false }
-zcash_address = { version = "0.12" }
-zcash_client_backend = { version = "0.23", features = [
+transparent = { package = "zcash_transparent", version = "0.9", default-features = false }
+zcash_address = { version = "0.13" }
+zcash_client_backend = { version = "0.24.0-rc.1", features = [
     "lightwalletd-tonic-tls-webpki-roots",
     "orchard",
     "pczt",
@@ -29,14 +29,14 @@ zcash_client_backend = { version = "0.23", features = [
     "transparent-inputs",
     "unstable",
 ] }
-zcash_client_sqlite = { version = "0.21", features = ["orchard", "transparent-inputs", "unstable", "serde"] }
+zcash_client_sqlite = { version = "0.22.0-rc.1", features = ["orchard", "transparent-inputs", "unstable", "serde"] }
 zcash_note_encryption = "0.4.1"
-zcash_primitives = "0.28"
-zcash_proofs = "0.28"
-zcash_protocol = "0.9"
+zcash_primitives = "0.29"
+zcash_proofs = "0.29"
+zcash_protocol = "0.10"
 zcash_script = "0.4"
 zip32 = "0.2"
-pczt = { version = "0.7", features = ["prover"] }
+pczt = { version = "0.8.0-rc.1", features = ["prover"] }
 
 # EIP-681
 eip681 = "0.1.0"
@@ -83,11 +83,8 @@ rust_decimal = { version = "1", default-features = false, features = ["c-repr"] 
 xz2 = { version = "0.1", features = ["static"] }
 
 # Voting
-zcash_voting = { version = "0.5.3", default-features = false, features = [
-    "client-pir",
-    "client-tree-sync",
-] }
-zcash_keys = { version = "0.14", features = ["orchard"] }
+zcash_voting = "1.0.0"
+zcash_keys = { version = "0.15", features = ["orchard"] }
 
 [build-dependencies]
 bindgen = "0.72"
@@ -103,6 +100,24 @@ crate-type = ["staticlib"]
 lto = true
 
 [patch.crates-io]
-voting-circuits = { git = "https://github.com/zodl-inc/voting-circuits.git", rev = "ed1ea27234e251e98a4b0bf9fcff11babccf1b92" }
-imt-tree = { git = "https://github.com/zodl-inc/vote-nullifier-pir.git", rev = "2411f119cdcff9f8452be7144628948b4088a96f" }
-zcash_voting = { git = "https://github.com/zodl-inc/zcash_voting.git", rev = "f9d7d201037c0e3fba9adc95f362a27082710ccc" }
+voting-circuits = { git = "https://github.com/zodl-inc/voting-circuits.git", rev = "a5aae410a6fb14fcbea2f0ce3393035195e86f69" }
+imt-tree = { git = "https://github.com/zodl-inc/vote-nullifier-pir.git", rev = "0dea3485429c80033e67a1ddb18ee72cc450cefb" }
+zcash_voting = { git = "https://github.com/zodl-inc/zcash_voting.git", rev = "464f974865f2afa82bdac15d169168c77ecb9c74" }
+
+# Pin the whole librustzcash stack to a single git rev carrying the merged Ironwood
+# historical selector, pending a crates.io release. zcash_voting no longer hard-pins
+# librustzcash (it declares crates.io versions and patches from its own root), so this
+# workspace's patch governs the rev for the entire graph and everything resolves to one
+# copy. Bump this rev in one place to advance the stack.
+equihash = { git = "https://github.com/zcash/librustzcash", rev = "4faf8711189950cf38f99b59b8c21208d0946427" }
+f4jumble = { git = "https://github.com/zcash/librustzcash", rev = "4faf8711189950cf38f99b59b8c21208d0946427" }
+pczt = { git = "https://github.com/zcash/librustzcash", rev = "4faf8711189950cf38f99b59b8c21208d0946427" }
+zcash_address = { git = "https://github.com/zcash/librustzcash", rev = "4faf8711189950cf38f99b59b8c21208d0946427" }
+zcash_client_backend = { git = "https://github.com/zcash/librustzcash", rev = "4faf8711189950cf38f99b59b8c21208d0946427" }
+zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash", rev = "4faf8711189950cf38f99b59b8c21208d0946427" }
+zcash_encoding = { git = "https://github.com/zcash/librustzcash", rev = "4faf8711189950cf38f99b59b8c21208d0946427" }
+zcash_keys = { git = "https://github.com/zcash/librustzcash", rev = "4faf8711189950cf38f99b59b8c21208d0946427" }
+zcash_primitives = { git = "https://github.com/zcash/librustzcash", rev = "4faf8711189950cf38f99b59b8c21208d0946427" }
+zcash_protocol = { git = "https://github.com/zcash/librustzcash", rev = "4faf8711189950cf38f99b59b8c21208d0946427" }
+zcash_transparent = { git = "https://github.com/zcash/librustzcash", rev = "4faf8711189950cf38f99b59b8c21208d0946427" }
+zip321 = { git = "https://github.com/zcash/librustzcash", rev = "4faf8711189950cf38f99b59b8c21208d0946427" }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -39,16 +39,16 @@ use zcash_address::ZcashAddress;
 use zcash_client_backend::{
     address::Address,
     data_api::{
-        Account, AccountBirthday, AccountPurpose, InputSource, MaxSpendMode, SeedRelevance,
-        TransactionDataRequest, TransactionStatus, TransparentKeyOrigin, TransparentOutputFilter,
+        Account, AccountBirthday, AccountPurpose, CoinbaseFilter, InputSource, MaxSpendMode,
+        SeedRelevance, TransactionDataRequest, TransactionStatus, TransparentKeyOrigin,
         WalletCommitmentTrees, WalletRead, WalletWrite, Zip32Derivation,
         chain::{CommitmentTreeRoot, scan_cached_blocks},
         scanning::ScanPriority,
         wallet::{
             self, SpendingKeys, create_pczt_from_proposal, create_proposed_transactions,
             decrypt_and_store_transaction, extract_and_store_transaction_from_pczt,
-            input_selection::GreedyInputSelector, propose_send_max_transfer, propose_shielding,
-            propose_transfer,
+            input_selection::{GreedyInputSelector, SpendPolicy}, propose_send_max_transfer,
+            propose_shielding, propose_transfer,
         },
     },
     encoding::AddressCodec,
@@ -76,7 +76,7 @@ use zcash_primitives::{
 };
 use zcash_proofs::prover::LocalTxProver;
 use zcash_protocol::{
-    ShieldedProtocol,
+    ShieldedPool,
     consensus::{
         BlockHeight, BranchId, Network,
         Network::{MainNetwork, TestNetwork},
@@ -1021,7 +1021,7 @@ pub unsafe extern "C" fn zcashlc_get_verified_transparent_balance(
                 &taddr,
                 target,
                 confirmations_policy,
-                TransparentOutputFilter::All,
+                CoinbaseFilter::AllTransparentOutputs,
             )
             .map_err(|e| anyhow!("Error while fetching verified transparent balance: {}", e))?;
         let amount = utxos
@@ -1085,7 +1085,7 @@ pub unsafe extern "C" fn zcashlc_get_verified_transparent_balance_for_account(
                         taddr,
                         target,
                         confirmations_policy,
-                        TransparentOutputFilter::All,
+                        CoinbaseFilter::AllTransparentOutputs,
                     )
                     .map_err(|e| {
                         anyhow!("Error while fetching verified transparent balance: {}", e)
@@ -1136,7 +1136,7 @@ pub unsafe extern "C" fn zcashlc_get_total_transparent_balance(
                 &taddr,
                 target,
                 wallet::ConfirmationsPolicy::new_symmetrical(NonZeroU32::MIN, true),
-                TransparentOutputFilter::All,
+                CoinbaseFilter::AllTransparentOutputs,
             )
             .map_err(|e| anyhow!("Error while fetching total transparent balance: {}", e))?
             .iter()
@@ -1201,10 +1201,10 @@ pub unsafe extern "C" fn zcashlc_get_total_transparent_balance_for_account(
     unwrap_exc_or(res, -1)
 }
 
-fn parse_protocol(code: u32) -> Option<ShieldedProtocol> {
+fn parse_protocol(code: u32) -> Option<ShieldedPool> {
     match code {
-        2 => Some(ShieldedProtocol::Sapling),
-        3 => Some(ShieldedProtocol::Orchard),
+        2 => Some(ShieldedPool::Sapling),
+        3 => Some(ShieldedPool::Orchard),
         _ => None,
     }
 }
@@ -1331,7 +1331,7 @@ pub unsafe extern "C" fn zcashlc_rewind_to_height(
         let mut db_data = unsafe { wallet_db(db_data, db_data_len, network)? };
 
         let height = BlockHeight::from(height);
-        let result_height = db_data.rewind_to_height(height);
+        let result_height = db_data.truncate_to_height(height);
 
         result_height.map_or_else(
             |err| match err {
@@ -1836,6 +1836,10 @@ pub unsafe extern "C" fn zcashlc_put_utxo(
                 script_pubkey,
             ),
             Some(BlockHeight::from(height as u32)),
+            // This UTXO is supplied by the caller with no account association or key scope.
+            None,
+            None,
+            None,
         )
         .ok_or_else(|| {
             anyhow!(
@@ -2088,7 +2092,7 @@ fn zip317_helper<DbT>(
         MultiOutputChangeStrategy::new(
             StandardFeeRule::Zip317,
             change_memo,
-            ShieldedProtocol::Orchard,
+            ShieldedPool::Orchard,
             DustOutputPolicy::default(),
             SplitPolicy::with_min_output_value(
                 NonZeroUsize::new(4).unwrap(),
@@ -2168,6 +2172,7 @@ pub unsafe extern "C" fn zcashlc_propose_transfer(
             &change_strategy,
             req,
             wallet::ConfirmationsPolicy::try_from(confirmations_policy)?,
+            &SpendPolicy::default(),
             None,
         )
         .map_err(|e| anyhow!("Error while sending funds: {}", e))?;
@@ -2241,7 +2246,7 @@ pub unsafe extern "C" fn zcashlc_propose_send_max_transfer(
             &mut db_data,
             &network,
             account_uuid,
-            &[ShieldedProtocol::Sapling, ShieldedProtocol::Orchard],
+            &[ShieldedPool::Sapling, ShieldedPool::Orchard],
             &StandardFeeRule::Zip317,
             to,
             memo,
@@ -2308,6 +2313,7 @@ pub unsafe extern "C" fn zcashlc_propose_transfer_from_uri(
             &change_strategy,
             req,
             wallet::ConfirmationsPolicy::try_from(confirmations_policy)?,
+            &SpendPolicy::default(),
             None,
         )
         .map_err(|e| anyhow!("Error while sending funds: {}", e))?;
@@ -2515,7 +2521,7 @@ pub unsafe extern "C" fn zcashlc_propose_shielding(
             &from_addrs,
             account_uuid,
             confirmations_policy,
-            TransparentOutputFilter::All,
+            CoinbaseFilter::AllTransparentOutputs,
         )
         .map_err(|e| anyhow!("Error while shielding transaction: {}", e))?;
 
@@ -2598,7 +2604,7 @@ pub unsafe extern "C" fn zcashlc_create_proposed_transactions(
         let proposal =
             Proposal::decode(unsafe { slice::from_raw_parts(proposal_ptr, proposal_len) })
                 .map_err(|e| anyhow!("Invalid proposal: {}", e))?
-                .try_into_standard_proposal(&db_data)?;
+                .try_into_standard_proposal(&network, &db_data)?;
         let usk = unsafe { decode_usk(usk_ptr, usk_len) }?;
         let spend_params = Path::new(OsStr::from_bytes(unsafe {
             slice::from_raw_parts(spend_params, spend_params_len)
@@ -2617,7 +2623,6 @@ pub unsafe extern "C" fn zcashlc_create_proposed_transactions(
             &SpendingKeys::from_unified_spending_key(usk),
             OvkPolicy::Sender,
             &proposal,
-            None,
         )
         .map_err(|e| anyhow!("Error while sending funds: {}", e))?;
 
@@ -2679,7 +2684,7 @@ pub unsafe extern "C" fn zcashlc_create_pczt_from_proposal(
         let proposal =
             Proposal::decode(unsafe { slice::from_raw_parts(proposal_ptr, proposal_len) })
                 .map_err(|e| anyhow!("Invalid proposal: {}", e))?
-                .try_into_standard_proposal(&db_data)?;
+                .try_into_standard_proposal(&network, &db_data)?;
 
         let account_uuid = account_uuid_from_bytes(account_uuid_bytes)?;
 
@@ -2690,10 +2695,16 @@ pub unsafe extern "C" fn zcashlc_create_pczt_from_proposal(
                 account_uuid,
                 OvkPolicy::Sender,
                 &proposal,
+                // Use the transaction's default expiry height and the default Orchard
+                // bundle type; the SDK does not expose overrides for these.
+                None,
+                orchard::builder::BundleType::DEFAULT,
             )
             .map_err(|e| anyhow!("Error creating PCZT from single-step proposal: {}", e))?;
 
-            Ok(ffi::BoxedSlice::some(pczt.serialize()))
+            Ok(ffi::BoxedSlice::some(pczt.serialize().map_err(|e| {
+                anyhow!("Failed to serialize PCZT: {:?}", e)
+            })?))
         } else {
             Err(anyhow!(
                 "Multi-step proposals are not yet supported for PCZT generation."
@@ -2752,7 +2763,9 @@ pub unsafe extern "C" fn zcashlc_redact_pczt_for_signer(
             })
             .finish();
 
-        Ok(ffi::BoxedSlice::some(redacted_pczt.serialize()))
+        Ok(ffi::BoxedSlice::some(redacted_pczt.serialize().map_err(
+            |e| anyhow!("Failed to serialize redacted PCZT: {:?}", e),
+        )?))
     });
     unwrap_exc_or_null(res)
 }
@@ -2844,11 +2857,26 @@ pub unsafe extern "C" fn zcashlc_add_proofs_to_pczt(
         let pczt_bytes = unsafe { slice::from_raw_parts(pczt_ptr, pczt_len) };
         let pczt = Pczt::parse(pczt_bytes).map_err(|e| anyhow!("Invalid PCZT: {:?}", e))?;
 
+        // The Orchard proving key must be built for the circuit governing the Orchard pool
+        // under the consensus branch this PCZT was created for; derive it from the PCZT's
+        // consensus branch id before the PCZT is consumed by the prover.
+        let pczt_branch_id = BranchId::try_from(*pczt.global().consensus_branch_id())
+            .map_err(|_| anyhow!("PCZT has an invalid consensus branch id"))?;
+
         let mut prover = Prover::new(pczt);
 
         if prover.requires_orchard_proof() {
+            let orchard_circuit_version =
+                zcash_primitives::transaction::components::orchard::bundle_version_for_branch(
+                    pczt_branch_id,
+                    orchard::ValuePool::Orchard,
+                )
+                .ok_or_else(|| {
+                    anyhow!("PCZT's consensus branch does not support the Orchard pool")
+                })?
+                .circuit_version();
             prover = prover
-                .create_orchard_proof(&orchard::circuit::ProvingKey::build())
+                .create_orchard_proof(&orchard::circuit::ProvingKey::build(orchard_circuit_version))
                 .map_err(|e| anyhow!("Failed to create Orchard proof for PCZT: {:?}", e))?;
         }
         assert!(!prover.requires_orchard_proof());
@@ -2877,7 +2905,9 @@ pub unsafe extern "C" fn zcashlc_add_proofs_to_pczt(
 
         let pczt_with_proofs = prover.finish();
 
-        Ok(ffi::BoxedSlice::some(pczt_with_proofs.serialize()))
+        Ok(ffi::BoxedSlice::some(pczt_with_proofs.serialize().map_err(
+            |e| anyhow!("Failed to serialize proven PCZT: {:?}", e),
+        )?))
     });
     unwrap_exc_or_null(res)
 }

--- a/rust/src/tor.rs
+++ b/rust/src/tor.rs
@@ -16,6 +16,7 @@ use zcash_client_backend::{
     tor::{Client, DormantMode},
     wallet::WalletTransparentOutput,
 };
+use zcash_client_sqlite::AccountUuid;
 use zcash_primitives::block::BlockHash;
 use zcash_protocol::{
     TxId,
@@ -204,7 +205,7 @@ impl LwdConn {
         address: TransparentAddress,
         start: Option<BlockHeight>,
         limit: Option<u32>,
-        mut f: impl FnMut(WalletTransparentOutput) -> anyhow::Result<()>,
+        mut f: impl FnMut(WalletTransparentOutput<AccountUuid>) -> anyhow::Result<()>,
     ) -> anyhow::Result<()> {
         let request = service::GetAddressUtxosArg {
             addresses: vec![address.encode(params)],
@@ -231,6 +232,11 @@ impl LwdConn {
                         Script(script::Code(result.script)),
                     ),
                     Some(BlockHeight::from(u32::try_from(result.height)?)),
+                    // These UTXOs are discovered by scanning lightwalletd for an address;
+                    // the wallet has no account association or key scope for them here.
+                    None,
+                    None,
+                    None,
                 )
                 .ok_or(anyhow!(
                     "Received UTXO that doesn't correspond to a valid P2PKH or P2SH address"

--- a/rust/src/voting/delegation.rs
+++ b/rust/src/voting/delegation.rs
@@ -50,7 +50,7 @@ pub unsafe extern "C" fn zcashlc_voting_precompute_delegation_pir(
     let res = catch_panic(|| {
         let handle =
             unsafe { db.as_ref() }.ok_or_else(|| anyhow!("VotingDatabaseHandle is null"))?;
-        crate::parse_network(network_id)?;
+        let network = super::helpers::voting_network(network_id)?;
         let round_id_str = unsafe { str_from_ptr(round_id, round_id_len) }?;
         let notes_bytes = unsafe { bytes_from_ptr(notes_json, notes_json_len) }?;
         let json_notes: Vec<JsonNoteInfo> = if notes_bytes.is_empty() {
@@ -69,7 +69,7 @@ pub unsafe extern "C" fn zcashlc_voting_precompute_delegation_pir(
                 bundle_index,
                 &core_notes,
                 &pir_client,
-                network_id,
+                network,
             )
             .map_err(|e| anyhow!("precompute_delegation_pir failed: {}", e))?;
 

--- a/rust/src/voting/helpers.rs
+++ b/rust/src/voting/helpers.rs
@@ -8,6 +8,20 @@ use zcash_protocol::consensus::Network;
 use zcash_voting as voting;
 use zip32::Scope;
 
+/// Converts the FFI `network_id` convention (`0` = testnet, `1` = mainnet) into the
+/// [`zcash_voting::Network`] value now required by the voting database API.
+pub(super) fn voting_network(network_id: u32) -> anyhow::Result<voting::Network> {
+    match network_id {
+        crate::NETWORK_ID_TESTNET => Ok(voting::Network::Testnet),
+        crate::NETWORK_ID_MAINNET => Ok(voting::Network::Mainnet),
+        other => Err(anyhow!(
+            "Invalid network id: {other}. Expected {} (testnet) or {} (mainnet).",
+            crate::NETWORK_ID_TESTNET,
+            crate::NETWORK_ID_MAINNET,
+        )),
+    }
+}
+
 /// Borrow a byte slice from a raw `(ptr, len)` pair.
 ///
 /// When `len == 0`, returns an empty slice without reading `ptr`, so `ptr` may be null.

--- a/rust/src/voting/json.rs
+++ b/rust/src/voting/json.rs
@@ -74,8 +74,8 @@ pub struct JsonVanWitness {
     pub anchor_height: u32,
 }
 
-impl From<voting::tree_sync::VanWitness> for JsonVanWitness {
-    fn from(w: voting::tree_sync::VanWitness) -> Self {
+impl From<voting::vote::VanWitness> for JsonVanWitness {
+    fn from(w: voting::vote::VanWitness) -> Self {
         Self {
             auth_path: w.auth_path.iter().map(|h| h.to_vec()).collect(),
             position: w.position,

--- a/rust/src/voting/share_tracking.rs
+++ b/rust/src/voting/share_tracking.rs
@@ -30,7 +30,7 @@ pub unsafe extern "C" fn zcashlc_voting_compute_share_nullifier(
             .try_into()
             .map_err(|_| anyhow!("primary_blind must be exactly 32 bytes"))?;
 
-        let nullifier = voting::share_tracking::compute_share_nullifier(&vc, share_index, &blind)
+        let nullifier = voting::share::compute_nullifier(&vc, share_index, &blind)
             .map_err(|e| anyhow!("compute_share_nullifier failed: {}", e))?;
 
         // Fixed-width hex: one 64-char allocation instead of per-byte `format!` temporaries.


### PR DESCRIPTION
Updates the Zcash/librustzcash dependency stack for the SDK's Rust core and adapts the FFI to the new crate APIs.

## Dependencies

- orchard 0.14 → 0.15, zcash_protocol 0.9 → 0.10, zcash_address 0.12 → 0.13, zcash_transparent 0.8 → 0.9
- zcash_client_backend 0.23 → 0.24.0-rc.1, zcash_client_sqlite 0.21 → 0.22.0-rc.1
- zcash_primitives / zcash_proofs 0.28 → 0.29, pczt 0.7 → 0.8.0-rc.1, zcash_keys 0.14 → 0.15
- voting crates (`zcash_voting`, `voting-circuits`, `imt-tree`) bumped to their current revs

The whole librustzcash stack is pinned to a single git rev via `[patch.crates-io]`, pending a crates.io release carrying the merged Ironwood historical selector. `zcash_voting` no longer hard-pins librustzcash (it declares crates.io versions and patches from its own root), so this workspace's patch governs the rev for the entire graph and everything resolves to a single copy.

## FFI adaptations

- `TransparentOutputFilter::All` → `CoinbaseFilter::AllTransparentOutputs`
- `WalletTransparentOutput` gained an `<AccountId>` parameter; `from_parts` gained `recipient_account` / `recipient_key_scope` / `funding_account`
- `WalletDb::rewind_to_height` → `truncate_to_height`
- `propose_transfer` gained a `&SpendPolicy` argument
- `Proposal::try_into_standard_proposal` now takes `(params, wallet_db)`
- `create_proposed_transactions` dropped its trailing argument
- `create_pczt_from_proposal` gained `target_expiry_height` and an Orchard `BundleType`; `Pczt::serialize` now returns a `Result`
- `ProvingKey::build` now requires an `OrchardCircuitVersion`, derived from the PCZT's consensus branch id so the proving key matches the pool's circuit
- voting: `share_tracking::compute_share_nullifier` → `share::compute_nullifier`, `tree_sync::VanWitness` → `vote::VanWitness`, `precompute_delegation_pir` now takes a `zcash_voting::Network`
- `ShieldedProtocol` → `ShieldedPool` (the alias was deprecated)

## Verification

- `cargo build` is clean with zero warnings; the resolved graph has a single copy of every zcash-stack crate.
- `cargo test --lib` passes (26/26).

⚠️ Verified against the macOS slice via `cargo`/`swift` only. As an FFI-boundary change, this still needs a full `init-local-ffi.sh` across all architectures before merge.

🤖 Prepared with [Claude Code](https://claude.com/claude-code) assistance.