### PR TITLE
[#1806] MOB-1513 R2: quiet immediate aftermath — is_immediate + consumed mined runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -158,11 +158,20 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `Proposal` plus its decoded `amount`/`fee`) instead of a `MigrationSchedule`, executed through the
   normal transfer pipeline (`createProposedTransactions` / `createPCZTFromProposal`) rather than the
   engine's schedule/commit machinery; a new `recordImmediateMigration(accountUUID:txid:)` folds a
-  successful broadcast into the same platform state machine (`InProgress` / `Complete` / re-offer).
-  The welding `migrationProposeImmediateTransfers` and its FFI
+  successful broadcast into the same platform state machine (`InProgress` while unmined, then quiet
+  once mined — see the immediate-aftermath entry below). The welding
+  `migrationProposeImmediateTransfers` and its FFI
   `zcashlc_migration_propose_immediate_transfers` are removed, replaced by the general-purpose
   `proposeSendMaxTransfer(accountUUID:recipient:memo:orchardOnly:)` (an ordinary send-max primitive
   the migration engine itself never touches). See `MIGRATING.md`.
+- The immediate-migration aftermath goes quiet, and `MigrationProgress` gains `isImmediate: Bool`:
+  once an immediate (send-max) sweep recorded via `recordImmediateMigration(accountUUID:txid:)`
+  mines, the migration state machine no longer reports `.complete` for it — the mined run is consumed
+  and the state falls back to `.notStarted` (nothing to acknowledge; the balance-gated "Migration
+  Required" prompt re-offers only if new Orchard funds arrive later). `MigrationProgress.isImmediate`
+  is `true` only for an in-progress immediate sweep and `false` for engine-tracked runs, so the app
+  can suppress per-transfer progress UI during the immediate lane; the public initializer defaults
+  `isImmediate` to `false`, so it is source-compatible. (MOB-1513)
 - The Rust core builds against the `michal/ironwood-migration` line of `zcash/librustzcash`
   (its base of main plus the cherry-picked Ironwood historical note selector, carrying the
   unreleased `zcash_pool_migration` crate), pinned via `[patch.crates-io]` until the 0.24-era

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -49,10 +49,19 @@ the app executes through the normal transaction pipeline, with one new call to r
   remains for `proposeMigrationTransfers`'s gradual path).
 - **New: `recordImmediateMigration(accountUUID:txid:) async throws`.** Call it after a successful
   broadcast (software or Keystone lane) so the platform migration state machine reports the sweep:
-  `InProgress(0 of 1)` while unmined, `Complete` once mined, or a re-offer (`NotStarted`) if it
-  expires unmined. One row per account — a new record supersedes any previous one. Not
+  `InProgress(0 of 1)` while unmined, then a quiet `NotStarted` once it mines. A MINED immediate
+  sweep is CONSUMED — it is NOT surfaced as `Complete`, so there is nothing for the user to
+  acknowledge and no per-run completion screen (the sweep zeroes the spendable Orchard balance, so
+  the balance-gated "Migration Required" prompt does not re-offer unless new Orchard funds arrive
+  later; an unmined sweep that expires likewise falls back to `NotStarted` so the prompt re-offers
+  while funds remain). One row per account — a new record supersedes any previous one. Not
   broadcast-sensitive itself (no `migrationBroadcastDuringSync` guard): the actual broadcast already
   rides the guarded `createProposedTransactions`/`createTransactionFromPCZT` path.
+- **`MigrationProgress` gains `isImmediate: Bool`** (additive — the public memberwise initializer
+  defaults it to `false`, so existing `MigrationProgress(...)` construction sites keep compiling
+  unchanged). It is `true` only while the immediate (send-max) lane's sweep is in progress and
+  `false` for engine-tracked schedule runs, letting the app keep the immediate aftermath quiet (no
+  per-transfer progress UI).
 - **Removed** (internal welding surface, never reachable from outside the SDK):
   `ZcashRustBackendWelding.migrationProposeImmediateTransfers` and its FFI,
   `zcashlc_migration_propose_immediate_transfers`. Replaced by the general-purpose

--- a/Sources/ZcashLightClientKit/Model/MigrationModels.swift
+++ b/Sources/ZcashLightClientKit/Model/MigrationModels.swift
@@ -41,18 +41,24 @@ public struct MigrationProgress: Equatable, Sendable {
     public let remainingOrchard: Zatoshi
     /// The height at which the next transfer becomes broadcastable, or `nil` if none is scheduled.
     public let nextTransferReadyAtHeight: BlockHeight?
+    /// Whether this snapshot belongs to the immediate (single-transaction) send-max migration lane
+    /// rather than an engine-tracked schedule. The app uses it to keep the immediate aftermath
+    /// quiet (no per-transfer progress UI). Engine-tracked runs report `false`.
+    public let isImmediate: Bool
 
     /// Creates a `MigrationProgress`.
     public init(
         completedTransfers: Int,
         totalTransfers: Int,
         remainingOrchard: Zatoshi,
-        nextTransferReadyAtHeight: BlockHeight?
+        nextTransferReadyAtHeight: BlockHeight?,
+        isImmediate: Bool = false
     ) {
         self.completedTransfers = completedTransfers
         self.totalTransfers = totalTransfers
         self.remainingOrchard = remainingOrchard
         self.nextTransferReadyAtHeight = nextTransferReadyAtHeight
+        self.isImmediate = isImmediate
     }
 }
 

--- a/Sources/ZcashLightClientKit/Rust/ZcashRustBackend.swift
+++ b/Sources/ZcashLightClientKit/Rust/ZcashRustBackend.swift
@@ -2447,7 +2447,8 @@ extension FfiMigrationProgress {
             completedTransfers: Int(completed_transfers),
             totalTransfers: Int(total_transfers),
             remainingOrchard: Zatoshi(remaining_orchard_value),
-            nextTransferReadyAtHeight: next_transfer_ready_at_height >= 0 ? BlockHeight(next_transfer_ready_at_height) : nil
+            nextTransferReadyAtHeight: next_transfer_ready_at_height >= 0 ? BlockHeight(next_transfer_ready_at_height) : nil,
+            isImmediate: is_immediate
         )
     }
 }

--- a/Tests/OfflineTests/MigrationFFITests.swift
+++ b/Tests/OfflineTests/MigrationFFITests.swift
@@ -23,6 +23,7 @@
 //
 
 import XCTest
+import libzcashlc
 @testable import TestUtils
 @testable import ZcashLightClientKit
 
@@ -266,6 +267,42 @@ final class MigrationFFITests: XCTestCase {
         }
         XCTAssertEqual(progress.completedTransfers, 0)
         XCTAssertEqual(progress.totalTransfers, 1)
+        XCTAssertTrue(
+            progress.isImmediate,
+            "a recorded immediate-lane run must map to isImmediate = true through the real FFI"
+        )
+    }
+
+    /// MOB-1513 R2: the FFI→model mapping (`FfiMigrationProgress.unsafeToMigrationProgress()`) must
+    /// copy `is_immediate` straight through, so the immediate lane's quiet-aftermath flag survives
+    /// the boundary and the model's defaulted `isImmediate` can never silently swallow it. Both
+    /// paths are exercised on the mapping directly (constructing the `#[repr(C)]` struct) because an
+    /// engine-tracked InProgress — the only real-FFI `is_immediate == false` source — needs a
+    /// seeded, synced Orchard balance this offline suite does not have. The `true` path is
+    /// additionally covered end-to-end over the real FFI by
+    /// `testMigrationRecordImmediateRunThenMigrationStateReportsInProgress` above.
+    func testMigrationProgressMappingCarriesIsImmediateBothWays() throws {
+        let immediate = FfiMigrationProgress(
+            is_present: true,
+            completed_transfers: 0,
+            total_transfers: 1,
+            remaining_orchard_value: 0,
+            next_transfer_ready_at_height: -1,
+            is_immediate: true
+        )
+        let immediateProgress = try XCTUnwrap(immediate.unsafeToMigrationProgress())
+        XCTAssertTrue(immediateProgress.isImmediate, "an immediate-lane FFI struct must map to isImmediate = true")
+
+        let engine = FfiMigrationProgress(
+            is_present: true,
+            completed_transfers: 1,
+            total_transfers: 3,
+            remaining_orchard_value: 12_345,
+            next_transfer_ready_at_height: 100,
+            is_immediate: false
+        )
+        let engineProgress = try XCTUnwrap(engine.unsafeToMigrationProgress())
+        XCTAssertFalse(engineProgress.isImmediate, "an engine-tracked FFI struct must map to isImmediate = false")
     }
 
     // MARK: - Ironwood activation height

--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -74,6 +74,18 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   is deliberately NOT a parameter: the platform evaluates signing sessions
   from the per-run transaction counts.
 
+### Changed
+- Immediate-migration state derivation (`zcashlc_migration_state` /
+  `zcashlc_migration_progress`): a MINED immediate (send-max) run is now CONSUMED —
+  it derives no migration state (the derivation falls through to `NotStarted`) and
+  masks a stale engine `Complete` left by an earlier engine-tracked run, so the app
+  goes fully quiet once the sweep mines instead of showing a per-run `Complete`. An
+  UNMINED, unexpired immediate run still derives `InProgress` of one, and the
+  expired-unmined re-offer is unchanged. To let the app keep the immediate
+  aftermath quiet, `FfiMigrationProgress` gains a trailing `is_immediate` boolean —
+  `true` for the immediate lane, `false` for engine-tracked runs (and for the
+  absent sentinel). Part of the still-unreleased migration surface above.
+
 ## 2.6.0-alpha.6 - 2026-06-26
 
 ### Fixed

--- a/rust/src/migration.rs
+++ b/rust/src/migration.rs
@@ -23,8 +23,10 @@
 //! - `include_residual` is accepted and ignored (documented-inert; the engine plans canonically
 //!   and ZIP 318 expects the residual to remain in Orchard).
 //! - The immediate lane (an ordinary send-max sweep, entirely outside the engine) is tracked in
-//!   its own SDK-owned `sdk_immediate_runs` side table and folded into [`derive_state`] — see that
-//!   function's precedence rule.
+//!   its own SDK-owned `sdk_immediate_runs` side table and folded into [`derive_state`]: while
+//!   unmined it derives `InProgress` (flagged `is_immediate`); once mined it is CONSUMED — it
+//!   derives nothing and masks any stale engine `Complete`, so the aftermath stays quiet — and past
+//!   its expiry it is ignored. See that function's precedence rule.
 //!
 //! Error channel: failures land in the thread-local last-error message. Two stable prefixes let
 //! the Swift layer surface dedicated errors: `MIGRATION_PLAN_STALE:` (commit without a matching
@@ -686,6 +688,9 @@ enum DerivedState {
         completed_transfers: u32,
         total_transfers: u32,
         next_transfer_ready_at_height: Option<BlockHeight>,
+        /// Whether this run is the immediate (single-transaction) send-max sweep rather than an
+        /// engine-tracked schedule. `true` only for the immediate lane; engine runs carry `false`.
+        is_immediate: bool,
     },
     InvalidTransfer(u32),
     TransferExpired,
@@ -724,17 +729,29 @@ impl ImmediateRunLookup {
     }
 }
 
-/// The immediate-run row's derivation, or `None` when it should be ignored (expired unmined, or
-/// vanished) so the caller falls through to the engine's own terminal/absent verdict.
+/// The immediate-run row's derivation:
+/// - mined -> `NotStarted`: the sweep is CONSUMED (its swept balance is zero, nothing to
+///   acknowledge). Returning a state here — rather than `None` — masks any stale engine `Complete`
+///   the caller would otherwise fall back to, keeping the aftermath quiet.
+/// - unmined and not past its expiry bound -> `InProgress` of one, flagged `is_immediate`.
+/// - `None` when the row should be ignored (expired unmined, or vanished) so the caller falls
+///   through to the engine's own terminal/absent verdict.
 fn derive_immediate_run(run: &ImmediateRunLookup, tip: BlockHeight) -> Option<DerivedState> {
     if run.mined_height.is_some() {
-        return Some(DerivedState::Complete);
+        // A mined immediate sweep is CONSUMED: it swept the whole spendable Orchard balance to
+        // zero, so there is nothing for the app to acknowledge and no `Complete` screen to show.
+        // It derives `NotStarted` — which, returned here (the caller only consults an immediate run
+        // once no engine run is active), also MASKS any stale engine `Complete` left by an earlier
+        // engine-tracked run, keeping the immediate aftermath fully quiet. If new Orchard funds
+        // arrive later, the ordinary balance-gated re-offer path applies afresh.
+        return Some(DerivedState::NotStarted);
     }
     if tip <= run.expiry_bound() {
         return Some(DerivedState::InProgress {
             completed_transfers: 0,
             total_transfers: 1,
             next_transfer_ready_at_height: None,
+            is_immediate: true,
         });
     }
     None
@@ -754,8 +771,9 @@ fn derive_immediate_run(run: &ImmediateRunLookup, tip: BlockHeight) -> Option<De
 /// Precedence: an engine run counts as ACTIVE — and wins outright, exactly as before the immediate
 /// lane existed — whenever one is stored and has not reached a terminal status. A `Failed` or
 /// `Complete` engine run, or no stored engine run at all, instead defers to `immediate_run` (mined
-/// -> `Complete`; unmined and not expired -> `InProgress` of one; expired or vanished -> ignored)
-/// before falling back to the engine's own terminal/absent verdict.
+/// -> consumed: `NotStarted`, masking any stale engine `Complete`; unmined and not expired ->
+/// `InProgress` of one, flagged `is_immediate`; expired or vanished -> ignored) before falling back
+/// to the engine's own terminal/absent verdict.
 fn derive_state(
     persisted: Option<&MigrationState>,
     tip: BlockHeight,
@@ -816,6 +834,7 @@ fn derive_state(
         completed_transfers: completed,
         total_transfers: transfers.len() as u32,
         next_transfer_ready_at_height: next_ready,
+        is_immediate: false,
     }
 }
 
@@ -857,6 +876,10 @@ pub struct FfiMigrationProgress {
     pub remaining_orchard_value: i64,
     /// The height at which the next transfer becomes broadcastable, or `-1` if none is scheduled.
     pub next_transfer_ready_at_height: i64,
+    /// Whether this progress belongs to the immediate (single-transaction) send-max migration lane
+    /// rather than an engine-tracked schedule. The app uses it to keep the immediate aftermath
+    /// quiet (no per-transfer UI). Engine-tracked runs report `false`.
+    pub is_immediate: bool,
 }
 
 impl FfiMigrationProgress {
@@ -867,6 +890,7 @@ impl FfiMigrationProgress {
             total_transfers: 0,
             remaining_orchard_value: 0,
             next_transfer_ready_at_height: -1,
+            is_immediate: false,
         }
     }
 }
@@ -1229,12 +1253,14 @@ fn marshal_state(
             completed_transfers,
             total_transfers,
             next_transfer_ready_at_height,
+            is_immediate,
         } => FfiMigrationState::InProgress(FfiMigrationProgress {
             is_present: true,
             completed_transfers,
             total_transfers,
             remaining_orchard_value: zat_to_i64(remaining_orchard),
             next_transfer_ready_at_height: height_opt_to_i64(next_transfer_ready_at_height),
+            is_immediate,
         }),
         DerivedState::InvalidTransfer(id) => {
             FfiMigrationState::RequiresAttention(FfiAttentionReason::InvalidTransfer {
@@ -1335,12 +1361,14 @@ pub unsafe extern "C" fn zcashlc_migration_progress(
                 completed_transfers,
                 total_transfers,
                 next_transfer_ready_at_height,
+                is_immediate,
             } => FfiMigrationProgress {
                 is_present: true,
                 completed_transfers,
                 total_transfers,
                 remaining_orchard_value: zat_to_i64(remaining_orchard(&mut ctx)?),
                 next_transfer_ready_at_height: height_opt_to_i64(next_transfer_ready_at_height),
+                is_immediate,
             },
             _ => FfiMigrationProgress::absent(),
         };
@@ -2443,10 +2471,15 @@ mod tests {
                 completed_transfers,
                 total_transfers,
                 next_transfer_ready_at_height,
+                is_immediate,
             } => {
                 assert_eq!(completed_transfers, 1);
                 assert_eq!(total_transfers, 3);
                 assert_eq!(next_transfer_ready_at_height, Some(h(50)));
+                assert!(
+                    !is_immediate,
+                    "an engine-tracked run must carry is_immediate = false"
+                );
             }
             _ => panic!("expected InProgress"),
         }
@@ -2504,21 +2537,43 @@ mod tests {
                 completed_transfers,
                 total_transfers,
                 next_transfer_ready_at_height,
+                is_immediate,
             } => {
                 assert_eq!(completed_transfers, 0);
                 assert_eq!(total_transfers, 1);
                 assert_eq!(next_transfer_ready_at_height, None);
+                assert!(
+                    is_immediate,
+                    "an immediate-lane run must carry is_immediate = true"
+                );
             }
             _ => panic!("expected InProgress"),
         }
     }
 
     #[test]
-    fn derive_immediate_run_mined_is_complete() {
+    fn derive_immediate_run_mined_is_consumed() {
+        // R2: a mined immediate sweep is CONSUMED — the swept balance is zero and there is nothing
+        // for the app to acknowledge, so it derives no migration UI (NotStarted), not a `Complete`
+        // screen. If new Orchard funds arrive later, the ordinary balance-gated re-offer applies.
         let run = immediate_lookup(100, Some(250), Some(500));
         assert!(matches!(
             derive_state(None, h(300), &[], Some(&run)),
-            DerivedState::Complete
+            DerivedState::NotStarted
+        ));
+    }
+
+    #[test]
+    fn derive_mined_immediate_run_masks_stale_complete_engine_state() {
+        // R2 masking rule: a consumed (mined) immediate run must suppress a stale engine `Complete`
+        // left by an earlier engine-tracked run, so the user sees NO migration UI at all — neither
+        // the immediate run's own screen (a mined immediate run has none) nor the stale Complete.
+        // Net: NotStarted.
+        let state = test_state(MigrationStatus::Complete, &[MINED], &[MINED], 50, 10_000);
+        let run = immediate_lookup(1_000, Some(1_050), Some(1_500));
+        assert!(matches!(
+            derive_state(Some(&state), h(1_100), &[], Some(&run)),
+            DerivedState::NotStarted
         ));
     }
 
@@ -2556,7 +2611,8 @@ mod tests {
             50,
             10_000,
         );
-        // This immediate run would derive to Complete on its own — but must not win.
+        // This immediate run is mined, so on its own it would be consumed (NotStarted) — but the
+        // active engine run wins regardless.
         let run = immediate_lookup(100, Some(250), Some(500));
         assert!(matches!(
             derive_state(Some(&state), h(300), &[], Some(&run)),
@@ -2565,19 +2621,26 @@ mod tests {
     }
 
     #[test]
-    fn derive_immediate_run_overrides_stale_complete_engine_state() {
-        // A `Complete` engine run is terminal (not "active"), so a separate, later immediate run
-        // still gets a say instead of being masked by the stale Complete verdict.
+    fn derive_unmined_immediate_run_overrides_stale_complete_engine_state() {
+        // A `Complete` engine run is terminal (not "active"), so a separate, later UNMINED (still
+        // live) immediate run still gets a say instead of being masked by the stale Complete
+        // verdict: it derives its own `InProgress`. (A MINED immediate run instead masks the stale
+        // Complete to NotStarted — see `derive_mined_immediate_run_masks_stale_complete_engine_state`.)
         let state = test_state(MigrationStatus::Complete, &[MINED], &[MINED], 50, 10_000);
         let run = immediate_lookup(1_000, None, Some(1_500));
         match derive_state(Some(&state), h(1_100), &[], Some(&run)) {
             DerivedState::InProgress {
                 completed_transfers,
                 total_transfers,
+                is_immediate,
                 ..
             } => {
                 assert_eq!(completed_transfers, 0);
                 assert_eq!(total_transfers, 1);
+                assert!(
+                    is_immediate,
+                    "the immediate run that wins is an immediate-lane run"
+                );
             }
             _ => panic!(
                 "expected the immediate run's InProgress to win over the stale Complete engine state"


### PR DESCRIPTION
Round-2 QA fix for the immediate-migration aftermath (MOB-1513, spec: "Spec — Round 2" comment on the ticket). Two semantic changes to the SDK-owned migration state derivation:

## What changed

1. **`is_immediate` surfaced on InProgress.** `FfiMigrationProgress` gains a trailing `is_immediate` field; the InProgress state derived from an immediate run reports `true`, engine runs report `false`. Swift: `MigrationProgress.isImmediate` (defaulted `false` in the public initializer for source compatibility; the FFI mapping passes the real value and is covered by a test). Lets the app suppress the "Migration Progress" banner/screens for the in-flight immediate sweep.

2. **A mined immediate run is consumed.** `derive_immediate_run`'s mined arm now derives `NotStarted` instead of `Complete` — nothing to acknowledge, no Complete screen, and the derivation still **masks a stale engine `Complete`** (returning a state, not `None`, is what makes the mask work). Expired-unmined behavior and active-engine-run precedence are unchanged: an expired unmined sweep still falls through so "Migration Required" re-offers while funds remain.

Docs updated for both semantics (module doc, `derive_immediate_run`/`derive_state` docs, MIGRATING, CHANGELOGs — including correcting the R1 "Complete" bullet).

## Tests

- rust: 58/58 offline — new/updated fixture tests: unmined immediate → `InProgress(0 of 1, is_immediate=true)`; engine InProgress → `false`; **mined immediate + stale engine Complete → NotStarted**; expired-unmined unchanged; active-engine precedence unchanged. (The pre-existing unmined-overrides-stale-Complete test is preserved, renamed to name its arm.)
- Swift `OfflineTests`: 659/659 — mapping tests for both `isImmediate` paths, plus the real-FFI path proving the mapping (not the initializer default) supplies the value.
- Red-first evidence for both halves recorded in the task log.

## Notes

- `michal/slipstream-support` will be rebased onto this branch (standing recipe) so the app's path dependency picks the fixes up immediately; after this PR merges it re-anchors onto the merged tip.
- Left open for Michal to review and merge, per Round-1 precedent (#1817).

🤖 Generated with [Claude Code](https://claude.com/claude-code)