### PR TITLE
[#1806] Port the Keystone batch-signing UR bridge from the Android SDK

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "adler32"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
+
+[[package]]
 name = "aead"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -38,6 +44,12 @@ checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "amplify"
@@ -469,7 +481,7 @@ dependencies = [
  "clang-sys",
  "itertools 0.13.0",
  "log",
- "prettyplease",
+ "prettyplease 0.2.37",
  "proc-macro2",
  "quote",
  "regex",
@@ -492,6 +504,21 @@ dependencies = [
  "sha2 0.11.0-pre.4",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "bitcoin-private"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73290177011694f38ec25e165d0387ab7ea749a4b81cd4c80dae5988229f7a57"
+
+[[package]]
+name = "bitcoin_hashes"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d7066118b13d4b20b23645932dfb3a81ce7e29f95726c2036fa33cd7b092501"
+dependencies = [
+ "bitcoin-private",
 ]
 
 [[package]]
@@ -664,7 +691,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ecb53484c9c167ba674026b656d8a27d7657a58e6066aa902bfb1a4aa00ae20"
 dependencies = [
  "clap",
- "heck",
+ "heck 0.5.0",
  "indexmap 2.14.0",
  "log",
  "proc-macro2",
@@ -906,6 +933,21 @@ checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "crc"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
 
 [[package]]
 name = "crc32fast"
@@ -1160,6 +1202,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dary_heap"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b1e3a325bc115f096c8b77bbf027a7c2592230e70be2d985be950d3d5e60ebe"
+
+[[package]]
 name = "data-encoding"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1206,7 +1254,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d308ebe4b10924331bd079044b418da7b227d724d3e2408567a47ad7c3da2a0"
 dependencies = [
  "derive-deftly-macros",
- "heck",
+ "heck 0.5.0",
 ]
 
 [[package]]
@@ -1215,7 +1263,7 @@ version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd5f2b7218a51c827a11d22d1439b598121fac94bf9b99452e4afffe512d78c9"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "indexmap 2.14.0",
  "itertools 0.15.0",
  "proc-macro-crate",
@@ -1676,6 +1724,12 @@ dependencies = [
 
 [[package]]
 name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
+name = "fixedbitset"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
@@ -1719,6 +1773,12 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "fpe"
@@ -2089,7 +2149,18 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "foldhash",
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -2120,6 +2191,12 @@ dependencies = [
  "spin",
  "stable_deref_trait",
 ]
+
+[[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "heck"
@@ -2444,6 +2521,15 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
@@ -2520,6 +2606,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "keystone-ur"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a08a7e0ccd113dac19485c5c0fe87c70b663f896c48e4493814e446175078d4"
+dependencies = [
+ "bitcoin_hashes",
+ "crc",
+ "minicbor",
+ "phf 0.11.3",
+ "rand_xoshiro",
+]
+
+[[package]]
 name = "known-folders"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2562,6 +2661,30 @@ name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "libflate"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85f7ef5c7e3c2ed51f0fbc40e016c66558b699f16593521f30b98713bbb99cb8"
+dependencies = [
+ "adler32",
+ "crc32fast",
+ "dary_heap",
+ "libflate_lz77",
+ "no_std_io2",
+]
+
+[[package]]
+name = "libflate_lz77"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff7a10e427698aef6eef269482776debfef63384d30f13aad39a1a95e0e098fd"
+dependencies = [
+ "hashbrown 0.16.1",
+ "no_std_io2",
+ "rle-decode-fast",
+]
 
 [[package]]
 name = "libloading"
@@ -2624,7 +2747,7 @@ dependencies = [
  "orchard",
  "pasta_curves",
  "pczt",
- "prost",
+ "prost 0.14.4",
  "rand 0.8.7",
  "rayon",
  "rusqlite",
@@ -2639,6 +2762,8 @@ dependencies = [
  "tor-rtcompat",
  "tracing",
  "tracing-subscriber",
+ "ur",
+ "ur-registry",
  "uuid",
  "xz2",
  "zcash_address",
@@ -2656,6 +2781,12 @@ dependencies = [
  "zeroize",
  "zip32",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
@@ -2769,6 +2900,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "minicbor"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7005aaf257a59ff4de471a9d5538ec868a21586534fff7f85dd97d4043a6139"
+dependencies = [
+ "minicbor-derive",
+]
+
+[[package]]
+name = "minicbor-derive"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1154809406efdb7982841adb6311b3d095b46f78342dd646736122fe6b19e267"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2798,6 +2949,12 @@ dependencies = [
 
 [[package]]
 name = "multimap"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
+
+[[package]]
+name = "multimap"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
@@ -2809,6 +2966,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "no_std_io2"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "418abd1b6d34fbf6cae440dc874771b0525a604428704c76e48b29a5e67b8003"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -3224,11 +3390,21 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "petgraph"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
+dependencies = [
+ "fixedbitset 0.4.2",
+ "indexmap 2.14.0",
+]
+
+[[package]]
+name = "petgraph"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
 dependencies = [
- "fixedbitset",
+ "fixedbitset 0.5.7",
  "indexmap 2.14.0",
 ]
 
@@ -3238,9 +3414,19 @@ version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
 dependencies = [
- "fixedbitset",
+ "fixedbitset 0.5.7",
  "hashbrown 0.15.5",
  "indexmap 2.14.0",
+]
+
+[[package]]
+name = "phf"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+dependencies = [
+ "phf_macros 0.11.3",
+ "phf_shared 0.11.3",
 ]
 
 [[package]]
@@ -3249,9 +3435,19 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
 dependencies = [
- "phf_macros",
- "phf_shared",
+ "phf_macros 0.13.1",
+ "phf_shared 0.13.1",
  "serde",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+dependencies = [
+ "phf_shared 0.11.3",
+ "rand 0.8.7",
 ]
 
 [[package]]
@@ -3261,7 +3457,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
 dependencies = [
  "fastrand",
- "phf_shared",
+ "phf_shared 0.13.1",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
+dependencies = [
+ "phf_generator 0.11.3",
+ "phf_shared 0.11.3",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3270,11 +3479,20 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
 dependencies = [
- "phf_generator",
- "phf_shared",
+ "phf_generator 0.13.1",
+ "phf_shared 0.13.1",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
 ]
 
 [[package]]
@@ -3455,6 +3673,16 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c8646e95016a7a6c4adea95bafa8a16baab64b583356217f2c85db4a39d9a86"
+dependencies = [
+ "proc-macro2",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
@@ -3513,12 +3741,44 @@ dependencies = [
 
 [[package]]
 name = "prost"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b82eaa1d779e9a4bc1c3217db8ffbeabaae1dca241bf70183242128d48681cd"
+dependencies = [
+ "bytes",
+ "prost-derive 0.11.9",
+]
+
+[[package]]
+name = "prost"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "528ac67416ff8646872a3c02cad9cc4ee5dc9f9540c9b10771855c95cb2e5ae1"
 dependencies = [
  "bytes",
- "prost-derive",
+ "prost-derive 0.14.4",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "119533552c9a7ffacc21e099c24a0ac8bb19c2a2a3f363de84cd9b844feab270"
+dependencies = [
+ "bytes",
+ "heck 0.4.1",
+ "itertools 0.10.5",
+ "lazy_static",
+ "log",
+ "multimap 0.8.3",
+ "petgraph 0.6.5",
+ "prettyplease 0.1.25",
+ "prost 0.11.9",
+ "prost-types 0.11.9",
+ "regex",
+ "syn 1.0.109",
+ "tempfile",
+ "which 4.4.2",
 ]
 
 [[package]]
@@ -3527,17 +3787,30 @@ version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "itertools 0.13.0",
  "log",
- "multimap",
+ "multimap 0.10.1",
  "petgraph 0.8.3",
- "prettyplease",
- "prost",
- "prost-types",
+ "prettyplease 0.2.37",
+ "prost 0.14.4",
+ "prost-types 0.14.4",
  "regex",
  "syn 2.0.119",
  "tempfile",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
+dependencies = [
+ "anyhow",
+ "itertools 0.10.5",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3555,11 +3828,20 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213622a1460818959ac1181aaeb2dc9c7f63df720db7d788b3e24eacd1983e13"
+dependencies = [
+ "prost 0.11.9",
+]
+
+[[package]]
+name = "prost-types"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f94967dc7688f3054c7fac87473ffae4cc4c3904800e2d9f5b857246d8963b0a"
 dependencies = [
- "prost",
+ "prost 0.14.4",
 ]
 
 [[package]]
@@ -3679,6 +3961,15 @@ dependencies = [
  "libc",
  "rand_core 0.9.5",
  "winapi",
+]
+
+[[package]]
+name = "rand_xoshiro"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
+dependencies = [
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -3859,6 +4150,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rle-decode-fast"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3582f63211428f83597b51b2ddb88e2a91a9d52d12831f9d08f5e624e8977422"
+
+[[package]]
 name = "rsa"
 version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3933,6 +4230,19 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -3940,7 +4250,7 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
@@ -4474,7 +4784,7 @@ version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -4590,7 +4900,7 @@ version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -4670,7 +4980,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.3",
  "once_cell",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -4690,6 +5000,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
  "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-core"
+version = "1.0.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c001ee18b7e5e3f62cbf58c7fe220119e68d902bb7443179c0c8aef30090e999"
+dependencies = [
+ "thiserror-core-impl",
+]
+
+[[package]]
+name = "thiserror-core-impl"
+version = "1.0.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4c60d69f36615a077cc7663b9cb8e42275722d23e58a7fa3d2c7f2915d09d04"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4989,7 +5319,7 @@ version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c68f61875ac5293cf72e6c8cf0158086428c82c37229e98c840878f1706b0322"
 dependencies = [
- "prettyplease",
+ "prettyplease 0.2.37",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -5002,7 +5332,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50849f68853be452acf590cde0b146665b8d507b3b8af17261df47e02c209ea0"
 dependencies = [
  "bytes",
- "prost",
+ "prost 0.14.4",
  "tonic",
 ]
 
@@ -5012,10 +5342,10 @@ version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "654e5643eff75d7f8c99197ce1440ed19a3474eada74c12bbac488b2cafdae27"
 dependencies = [
- "prettyplease",
+ "prettyplease 0.2.37",
  "proc-macro2",
- "prost-build",
- "prost-types",
+ "prost-build 0.14.4",
+ "prost-types 0.14.4",
  "quote",
  "syn 2.0.119",
  "tempfile",
@@ -5753,7 +6083,7 @@ dependencies = [
  "itertools 0.14.0",
  "memchr",
  "paste",
- "phf",
+ "phf 0.13.1",
  "rand 0.9.5",
  "serde",
  "serde_with",
@@ -6205,6 +6535,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
 
 [[package]]
+name = "ur"
+version = "0.3.0"
+source = "git+https://github.com/KeystoneHQ/ur-rs?tag=0.3.3#81b8bb3b6b3a823128489c81ffee5bb4001ba2ae"
+dependencies = [
+ "bitcoin_hashes",
+ "crc",
+ "minicbor",
+ "phf 0.11.3",
+ "rand_xoshiro",
+]
+
+[[package]]
+name = "ur-registry"
+version = "1.0.8"
+source = "git+https://github.com/KeystoneHQ/keystone-sdk-rust?rev=7c90bf1ae504720c3f4b44ff26f996836d8b1553#7c90bf1ae504720c3f4b44ff26f996836d8b1553"
+dependencies = [
+ "bs58",
+ "hex",
+ "keystone-ur",
+ "libflate",
+ "minicbor",
+ "no_std_io2",
+ "paste",
+ "prost 0.11.9",
+ "prost-build 0.11.9",
+ "prost-types 0.11.9",
+ "serde",
+ "thiserror 1.0.69",
+ "thiserror-core",
+]
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6453,6 +6815,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "which"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix 0.38.44",
 ]
 
 [[package]]
@@ -6903,7 +7277,7 @@ dependencies = [
  "pczt",
  "percent-encoding",
  "postcard",
- "prost",
+ "prost 0.14.4",
  "rand 0.8.7",
  "rand_core 0.6.4",
  "rayon",
@@ -6926,7 +7300,7 @@ dependencies = [
  "tracing",
  "trait-variant",
  "webpki-roots",
- "which",
+ "which 8.0.5",
  "zcash_address",
  "zcash_encoding",
  "zcash_keys",
@@ -6956,7 +7330,7 @@ dependencies = [
  "maybe-rayon",
  "nonempty",
  "orchard",
- "prost",
+ "prost 0.14.4",
  "rand 0.8.7",
  "rand_core 0.6.4",
  "rand_distr",
@@ -7199,7 +7573,7 @@ dependencies = [
  "pczt",
  "pir-client",
  "pir-types",
- "prost",
+ "prost 0.14.4",
  "rand 0.8.7",
  "rusqlite",
  "rustls",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,8 +41,23 @@ zcash_protocol = { version = "0.10", features = ["local-consensus"] }
 zcash_pool_migration_backend = { git = "https://github.com/zcash/librustzcash", rev = "3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb", features = ["wallet"] }
 zcash_script = "0.4"
 zip32 = "0.2"
-pczt = { version = "0.8.0-rc.1", features = ["prover"] }
+pczt = { version = "0.8.0-rc.1", features = ["prover", "orchard", "sapling", "signer"] }
 shardtree = "0.7"
+
+# Keystone hardware-wallet batch signing for the Orchard migration flow.
+#
+# Bypasses the compiled Keystone mobile SDKs (stale — single-PCZT only, no batch API) by
+# depending directly on `keystone-sdk-rust`'s `ur-registry` crate and `ur-rs` from git, mirroring
+# `chainapsis/vizor-wallet`'s verified-working pattern for the same integration (see
+# `rust/src/migration_keystone.rs`'s module doc). The actual batching primitive is
+# `pczt::roles::signer::batch` (the `signer` feature above), not Keystone-specific; these crates
+# only provide the outer UR/QR envelope. `ur-registry`'s Zcash batch-signing types haven't reached
+# a tagged release yet — Android's SDK floats this branch and its lock resolves exactly this rev;
+# we pin it directly instead.
+ur = { git = "https://github.com/KeystoneHQ/ur-rs", tag = "0.3.3" }
+ur-registry = { git = "https://github.com/KeystoneHQ/keystone-sdk-rust", rev = "7c90bf1ae504720c3f4b44ff26f996836d8b1553", package = "ur-registry", default-features = false, features = [
+    "std",
+] }
 
 # EIP-681
 eip681 = "0.1.0"

--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -110,6 +110,47 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (`runs_len == 0`), not an error; NULL = error. Signer per-session capacity
   is deliberately NOT a parameter: the platform evaluates signing sessions
   from the per-run transaction counts.
+- Keystone batch-signing UR bridge (`rust/src/migration_keystone.rs`, ported from
+  `zcash-android-wallet-sdk`'s `backend-lib` at the same librustzcash pin — the engine/pczt APIs
+  transferred directly): four new FFI functions plus the ZIP 32 spend-derivation annotation the
+  two existing external-signer build calls now apply.
+  - `zcashlc_migration_keystone_build_sign_batch_qr_parts` redacts every passed-in unsigned PCZT
+    with `redact_pczt_for_batch_signer` (clearing the wire spend FVK and any pre-existing
+    Orchard/Ironwood `spend_auth_sig` — the dummy padding spend `IoFinalizer` already self-signs,
+    which the Keystone batch firmware otherwise rejects outright) before encoding a
+    `pczt::roles::signer::batch::BatchSignRequest` into animated multi-part
+    `"zcash-sign-batch"` UR QR frames (`FfiKeystoneQrParts`, this crate's first string-array FFI
+    output type, freed by `zcashlc_free_migration_keystone_qr_parts`). Takes ONE ordered PCZT
+    array (preparation PCZTs first, then transfer PCZTs) rather than the Android source's
+    `(split, transfers)` pair — same wire order, flattened Rust-side shape, since the Swift
+    caller already holds every unsigned PCZT as one collection. `ids` is deliberately not a
+    parameter here; the build step has no use for them.
+  - `zcashlc_migration_keystone_reset_sign_batch_decoder` (void, infallible) and
+    `zcashlc_migration_keystone_decode_sign_batch_part` (returns
+    `FfiKeystoneBatchDecodeResult`, freed by
+    `zcashlc_free_migration_keystone_batch_decode_result`) drive the stateful multi-frame
+    `"zcash-batch-sig-result"` scan session one QR frame at a time — `complete`/`progress` for
+    the fountain-decoder state, and, once complete, the serialized `BatchSignResponse` bytes plus
+    the signing device's own reported firmware version (the only place a batch-signed migration
+    can learn it, since the response never echoes back PCZT bytes). Verifies the decoded
+    response's request id against the caller-supplied `expected_request_id` and errors on
+    mismatch rather than silently accepting a scan of an unrelated/stale response.
+  - `zcashlc_migration_keystone_apply_batch_signatures` applies the decoded response's
+    signatures back onto the SAME caller-held unsigned PCZTs, in the SAME order passed to the
+    build call (signatures align by position, not by any id in the wire format), returning
+    signed-but-unproven PCZT bytes through `FfiUnsignedTransferPczts` (now documented as a
+    generic `(id, PCZT bytes)` pair set, not just an unsigned-PCZT container) with the input ids
+    passed through positionally. Errors if the response's signature-set count doesn't match the
+    PCZT count.
+  - `zcashlc_migration_create_unsigned_note_split_pczts` and
+    `zcashlc_migration_create_unsigned_transfer_pczts` now annotate every returned PCZT with the
+    account's ZIP 32 seed fingerprint and account index (`spend_zip32_derivation`, on every not-
+    yet-signed Orchard/Ironwood spend action) before returning it: the engine's builder never
+    sets this, and combined with the batch redaction above clearing the spend FVK, an
+    un-annotated migration PCZT gives Keystone no way to identify the account at all, failing
+    on-device with "None of inputs belongs to the provided account". Applied as post-processing
+    after `commit_or_resume` so both a freshly built AND a resumed (already-committed) run get
+    annotated.
 
 ### Changed
 - The librustzcash family pin advanced to current main, which now carries both

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -95,6 +95,7 @@ mod ffi;
 mod migration;
 mod migration_engine;
 mod migration_finalize;
+mod migration_keystone;
 mod migration_plan_cache;
 mod tor;
 // Voting stays UNGATED: the module compiles as honest-error stubs (15 C symbols preserved —

--- a/rust/src/migration.rs
+++ b/rust/src/migration.rs
@@ -64,7 +64,7 @@ use zcash_client_backend::data_api::{InputSource, WalletRead, WalletWrite};
 use zcash_client_backend::wallet::{LockOwner, OutputRef};
 use zcash_client_sqlite::AccountUuid;
 use zcash_protocol::consensus::{
-    BLOCKS_PER_HOUR, BlockHeight, Network, NetworkUpgrade, Parameters,
+    BLOCKS_PER_HOUR, BlockHeight, Network, NetworkConstants, NetworkUpgrade, Parameters,
 };
 use zcash_protocol::value::Zatoshis;
 use zcash_protocol::{PoolType, ShieldedPool, TxId};
@@ -1110,7 +1110,10 @@ pub struct FfiUnsignedTransferPczt {
     pub pczt_len: usize,
 }
 
-/// A set of unsigned PCZTs to route to an external signer.
+/// A set of unsigned PCZTs to route to an external signer. Despite the name, this is really a
+/// generic `(id, PCZT bytes)` pair set: [`zcashlc_migration_keystone_apply_batch_signatures`]
+/// also returns its batch-SIGNED PCZTs through this same type, positionally paired back up with
+/// the ids the caller passed in.
 #[repr(C)]
 pub struct FfiUnsignedTransferPczts {
     pub ptr: *mut FfiUnsignedTransferPczt,
@@ -1132,6 +1135,78 @@ impl FfiUnsignedTransferPczts {
             ptr,
             len,
         })))
+    }
+}
+
+/// A set of animated multi-part QR frame strings for a Keystone batch-signing request. Element
+/// order is the wire fragment order — display/scan them in that order.
+///
+/// This crate's first string-array FFI output type: kept intentionally minimal (unlike
+/// [`FfiUnsignedTransferPczts`], there is no paired per-element id or byte blob here, just
+/// strings), rather than generalizing [`ffi::BoxedSlice`] (a single binary blob, not an array) or
+/// inventing a shared generic array wrapper for a need that has arisen exactly once so far.
+#[repr(C)]
+pub struct FfiKeystoneQrParts {
+    /// Heap array of `len` owned, NUL-terminated UTF-8 strings.
+    pub ptr: *mut *mut c_char,
+    pub len: usize,
+}
+
+impl FfiKeystoneQrParts {
+    fn from_parts(parts: Vec<String>) -> anyhow::Result<*mut Self> {
+        let items = parts
+            .into_iter()
+            .map(|part| cstring_raw(&part, "keystone QR part"))
+            .collect::<anyhow::Result<Vec<_>>>()?;
+        let (ptr, len) = ptr_from_vec(items);
+        Ok(Box::into_raw(Box::new(FfiKeystoneQrParts { ptr, len })))
+    }
+}
+
+/// The result of feeding one scanned QR frame to
+/// `zcashlc_migration_keystone_decode_sign_batch_part`, mirroring
+/// [`crate::migration_keystone::DecodePartResult`].
+///
+/// `complete == false` means more frames are needed: `progress` is the 0-100 completion
+/// percentage so far, and `data`/the firmware fields are unset (null / `false` / zeroed).
+/// `complete == true` means `data` holds the serialized `BatchSignResponse` bytes to pass to
+/// `zcashlc_migration_keystone_apply_batch_signatures`, and — when `has_firmware_version` — the
+/// signing device's own reported firmware version is in `firmware_major`/`firmware_minor`/
+/// `firmware_build`.
+#[repr(C)]
+pub struct FfiKeystoneBatchDecodeResult {
+    pub complete: bool,
+    pub progress: u32,
+    /// Heap `data_len`-byte serialized `BatchSignResponse` (null unless `complete`).
+    pub data: *mut u8,
+    pub data_len: usize,
+    pub has_firmware_version: bool,
+    pub firmware_major: u8,
+    pub firmware_minor: u8,
+    pub firmware_build: u8,
+}
+
+impl FfiKeystoneBatchDecodeResult {
+    fn from_parts(result: crate::migration_keystone::DecodePartResult) -> *mut Self {
+        let (data, data_len) = match result.data {
+            Some(bytes) => ptr_from_vec(bytes),
+            None => (ptr::null_mut(), 0),
+        };
+        let (has_firmware_version, firmware_major, firmware_minor, firmware_build) =
+            match result.firmware_version {
+                Some([major, minor, build]) => (true, major, minor, build),
+                None => (false, 0, 0, 0),
+            };
+        Box::into_raw(Box::new(FfiKeystoneBatchDecodeResult {
+            complete: result.complete,
+            progress: result.progress,
+            data,
+            data_len,
+            has_firmware_version,
+            firmware_major,
+            firmware_minor,
+            firmware_build,
+        }))
     }
 }
 
@@ -1268,6 +1343,38 @@ pub unsafe extern "C" fn zcashlc_free_migration_unsigned_transfer_pczts(
             }
             free_ptr_from_vec(u.pczt, u.pczt_len);
         });
+        drop(boxed);
+    }
+}
+
+/// Frees a [`FfiKeystoneQrParts`], including every element string.
+///
+/// # Safety
+/// `ptr` must be null or point to a [`FfiKeystoneQrParts`] handed out by this module.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn zcashlc_free_migration_keystone_qr_parts(ptr: *mut FfiKeystoneQrParts) {
+    if !ptr.is_null() {
+        let boxed = unsafe { Box::from_raw(ptr) };
+        free_ptr_from_vec_with(boxed.ptr, boxed.len, |s| {
+            if !s.is_null() {
+                unsafe { zcashlc_string_free(*s) }
+            }
+        });
+        drop(boxed);
+    }
+}
+
+/// Frees a [`FfiKeystoneBatchDecodeResult`], including its data bytes.
+///
+/// # Safety
+/// `ptr` must be null or point to a [`FfiKeystoneBatchDecodeResult`] handed out by this module.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn zcashlc_free_migration_keystone_batch_decode_result(
+    ptr: *mut FfiKeystoneBatchDecodeResult,
+) {
+    if !ptr.is_null() {
+        let boxed = unsafe { Box::from_raw(ptr) };
+        free_ptr_from_vec(boxed.data, boxed.data_len);
         drop(boxed);
     }
 }
@@ -2202,6 +2309,38 @@ pub unsafe extern "C" fn zcashlc_migration_refresh_stale_transfers(
     unwrap_exc_or_null(res)
 }
 
+/// Fetches the account's ZIP 32 seed fingerprint and account index, required to annotate
+/// external-signer (Keystone) migration PCZTs with `spend_zip32_derivation` — see
+/// [`crate::migration_keystone::annotate_spend_zip32_derivation`]'s doc comment for why this is
+/// needed.
+///
+/// Applied as a post-processing step on whatever unsigned PCZT bytes `commit_or_resume` returns
+/// (freshly built, or resumed from an already-committed migration) rather than inside the engine
+/// build call itself: `commit_or_resume` only calls the engine builder on first commit, so
+/// annotating only there would silently skip already-committed migrations (e.g. ones committed
+/// before this annotation existed) on every later re-entry into the Keystone sign screen.
+fn account_zip32_derivation(
+    wallet: &MigrationWallet,
+    account: AccountUuid,
+) -> anyhow::Result<([u8; 32], zip32::AccountId)> {
+    use zcash_client_backend::data_api::Account;
+
+    let account_info = wallet
+        .get_account(account)
+        .map_err(|e| anyhow!("account lookup failed: {}", e))?
+        .ok_or_else(|| anyhow!("Account not found"))?;
+    let derivation = account_info.source().key_derivation().ok_or_else(|| {
+        anyhow!(
+            "Account has no known ZIP 32 seed fingerprint/account index — cannot annotate \
+             migration PCZTs for external-signer batch signing"
+        )
+    })?;
+    Ok((
+        derivation.seed_fingerprint().to_bytes(),
+        derivation.account_index(),
+    ))
+}
+
 /// Builds the whole migration UNSIGNED (external-signer lane): every transaction is persisted
 /// `AwaitingSignature`, and the preparation (note-split) subset is returned for the signing
 /// ceremony. The run is created HERE; the transfer subset of the same build is served by
@@ -2211,6 +2350,11 @@ pub unsafe extern "C" fn zcashlc_migration_refresh_stale_transfers(
 /// `proposal_handle` identifies the cached plan the run is built from — the one whose schedule
 /// the platform displayed. A fresh build fails with `MIGRATION_PLAN_STALE` when that plan is
 /// missing or superseded; the resume path does not consult the handle (see [`commit_or_resume`]).
+///
+/// Every returned PCZT is annotated with the account's ZIP 32 spend derivation (see
+/// [`account_zip32_derivation`]) so an external signer (Keystone) can identify which of its
+/// accounts each spend belongs to — annotation happens here, after `commit_or_resume`, so it
+/// covers both a freshly built and a resumed (already-committed) run alike.
 ///
 /// # Safety
 /// See [`open`]. Free the returned pointer with
@@ -2236,6 +2380,20 @@ pub unsafe extern "C" fn zcashlc_migration_create_unsigned_note_split_pczts(
             .into_iter()
             .filter(|(id, _)| prep_ids.contains(id))
             .collect();
+        let (seed_fingerprint, account_index) = account_zip32_derivation(&ctx.wallet, ctx.account)?;
+        let preps = preps
+            .into_iter()
+            .map(|(id, pczt_bytes)| {
+                let pczt_bytes = crate::migration_keystone::annotate_spend_zip32_derivation(
+                    &pczt_bytes,
+                    seed_fingerprint,
+                    ctx.network.coin_type(),
+                    account_index,
+                )
+                .map_err(|e| anyhow!("Error annotating note-split PCZT derivation: {:?}", e))?;
+                Ok::<_, anyhow::Error>((id, pczt_bytes))
+            })
+            .collect::<anyhow::Result<Vec<_>>>()?;
         FfiUnsignedTransferPczts::from_pairs(preps)
     });
     unwrap_exc_or_null(res)
@@ -2296,6 +2454,9 @@ pub unsafe extern "C" fn zcashlc_migration_store_signed_note_split_pczts(
 /// gates the fresh-build case where this call is the one creating the run — see
 /// [`commit_or_resume`]).
 ///
+/// Every returned PCZT is annotated with the account's ZIP 32 spend derivation — see
+/// [`account_zip32_derivation`] and `zcashlc_migration_create_unsigned_note_split_pczts`'s doc.
+///
 /// # Safety
 /// See [`open`]. Free the returned pointer with
 /// [`zcashlc_free_migration_unsigned_transfer_pczts`].
@@ -2320,6 +2481,20 @@ pub unsafe extern "C" fn zcashlc_migration_create_unsigned_transfer_pczts(
             .into_iter()
             .filter(|(id, _)| transfer_ids.contains(id))
             .collect();
+        let (seed_fingerprint, account_index) = account_zip32_derivation(&ctx.wallet, ctx.account)?;
+        let transfers: Vec<_> = transfers
+            .into_iter()
+            .map(|(id, pczt_bytes)| {
+                let pczt_bytes = crate::migration_keystone::annotate_spend_zip32_derivation(
+                    &pczt_bytes,
+                    seed_fingerprint,
+                    ctx.network.coin_type(),
+                    account_index,
+                )
+                .map_err(|e| anyhow!("Error annotating transfer PCZT derivation: {:?}", e))?;
+                Ok::<_, anyhow::Error>((id, pczt_bytes))
+            })
+            .collect::<anyhow::Result<Vec<_>>>()?;
         FfiUnsignedTransferPczts::from_pairs(transfers)
     });
     unwrap_exc_or_null(res)
@@ -2388,6 +2563,136 @@ unsafe fn decode_signed_pairs(
         out.push((id, bytes));
     }
     Ok(out)
+}
+
+// ----- Keystone batch-signing UR bridge (crate::migration_keystone) -----
+//
+// Pure PCZT/UR operations over caller-held bytes — no wallet database, no migration engine.
+
+/// Decode the platform's parallel `(pczt, pczt_len)` arrays into owned PCZT byte vectors.
+///
+/// # Safety
+/// `pczts`/`pczt_lens` must be valid for reads of `len` elements; every `pczts[i]` must be valid
+/// for `pczt_lens[i]` bytes.
+unsafe fn decode_pczt_list(
+    pczts: *const *const u8,
+    pczt_lens: *const usize,
+    len: usize,
+) -> anyhow::Result<Vec<Vec<u8>>> {
+    let pczt_ptrs = unsafe { slice_or_empty(pczts, len) };
+    let lens = unsafe { slice_or_empty(pczt_lens, len) };
+    let mut out = Vec::with_capacity(len);
+    for i in 0..len {
+        if pczt_ptrs[i].is_null() {
+            return Err(anyhow!("pczt at index {i} is null"));
+        }
+        out.push(unsafe { slice::from_raw_parts(pczt_ptrs[i], lens[i]) }.to_vec());
+    }
+    Ok(out)
+}
+
+/// Builds the animated multi-part QR frames for a Keystone batch-signing request covering every
+/// PCZT in `pczts`, in the given order (preparation PCZTs first, then transfer PCZTs — see
+/// [`crate::migration_keystone`]'s module doc). `ids` is deliberately NOT a parameter: the build
+/// step has no use for them — only [`zcashlc_migration_keystone_apply_batch_signatures`] echoes
+/// ids back out, since that is what the caller matches signed PCZTs to stored transactions by.
+///
+/// # Safety
+/// `request_id` must be valid for reads of `request_id_len` bytes. `pczts`/`pczt_lens` must be
+/// valid for reads of `pczts_len` elements, and each `pczts[i]` valid for `pczt_lens[i]` bytes.
+/// Free the returned pointer with [`zcashlc_free_migration_keystone_qr_parts`].
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn zcashlc_migration_keystone_build_sign_batch_qr_parts(
+    request_id: *const u8,
+    request_id_len: usize,
+    pczts: *const *const u8,
+    pczt_lens: *const usize,
+    pczts_len: usize,
+    max_fragment_len: usize,
+) -> *mut FfiKeystoneQrParts {
+    let res = catch_panic(|| {
+        let request_id = unsafe { slice_or_empty(request_id, request_id_len) }.to_vec();
+        let pczts = unsafe { decode_pczt_list(pczts, pczt_lens, pczts_len)? };
+        let parts = crate::migration_keystone::build_sign_batch_qr_parts(
+            request_id,
+            &pczts,
+            max_fragment_len,
+        )
+        .map_err(|e| anyhow!("Error building Keystone sign-batch QR parts: {e}"))?;
+        FfiKeystoneQrParts::from_parts(parts)
+    });
+    unwrap_exc_or_null(res)
+}
+
+/// Discards any in-flight multi-part Keystone sign-batch-response scan session. Callers should
+/// invoke this on scan-screen entry so a new attempt always starts from a clean slate regardless
+/// of how a previous attempt ended (cancel, back button, mid-stream error). Void and infallible.
+#[unsafe(no_mangle)]
+pub extern "C" fn zcashlc_migration_keystone_reset_sign_batch_decoder() {
+    crate::migration_keystone::reset_sign_batch_decoder();
+}
+
+/// Feeds one scanned QR frame into the active (or a freshly started) Keystone sign-batch-response
+/// decode session, pinned to the `"zcash-batch-sig-result"` UR type. `expected_request_id` must
+/// match the decoded response's own request id once complete, or this errors (a scan of an
+/// unrelated/stale response) instead of silently accepting it. See
+/// [`crate::migration_keystone::decode_sign_batch_part`].
+///
+/// # Safety
+/// `part` must be a valid, NUL-terminated C string. `expected_request_id` must be valid for reads
+/// of `expected_request_id_len` bytes. Free the returned pointer with
+/// [`zcashlc_free_migration_keystone_batch_decode_result`].
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn zcashlc_migration_keystone_decode_sign_batch_part(
+    part: *const c_char,
+    expected_request_id: *const u8,
+    expected_request_id_len: usize,
+) -> *mut FfiKeystoneBatchDecodeResult {
+    let res = catch_panic(|| {
+        if part.is_null() {
+            return Err(anyhow!("part is null"));
+        }
+        let part = unsafe { CStr::from_ptr(part) }
+            .to_str()
+            .map_err(|e| anyhow!("part is not valid UTF-8: {e}"))?;
+        let expected_request_id =
+            unsafe { slice_or_empty(expected_request_id, expected_request_id_len) };
+        let result = crate::migration_keystone::decode_sign_batch_part(part, expected_request_id)
+            .map_err(|e| anyhow!("Error decoding Keystone sign-batch QR part: {e}"))?;
+        Ok(FfiKeystoneBatchDecodeResult::from_parts(result))
+    });
+    unwrap_exc_or_null(res)
+}
+
+/// Applies the ceremony's Keystone batch signatures to the caller-held unsigned PCZTs,
+/// positionally (see [`crate::migration_keystone::apply_batch_signatures`]) — `ids`/`pczts` must
+/// be the SAME PCZTs, in the SAME order, passed to
+/// [`zcashlc_migration_keystone_build_sign_batch_qr_parts`]. `ids` pass through positionally onto
+/// the returned signed PCZTs, reusing [`FfiUnsignedTransferPczts`] as a generic `(id, PCZT
+/// bytes)` pair set (see its doc) and [`decode_signed_pairs`] to decode the parallel input
+/// arrays.
+///
+/// # Safety
+/// See [`decode_signed_pairs`]. `response` must be valid for reads of `response_len` bytes. Free
+/// the returned pointer with [`zcashlc_free_migration_unsigned_transfer_pczts`].
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn zcashlc_migration_keystone_apply_batch_signatures(
+    ids: *const *const c_char,
+    ids_len: usize,
+    pczts: *const *const u8,
+    pczt_lens: *const usize,
+    response: *const u8,
+    response_len: usize,
+) -> *mut FfiUnsignedTransferPczts {
+    let res = catch_panic(|| {
+        let unsigned = unsafe { decode_signed_pairs(ids, ids_len, pczts, pczt_lens)? };
+        let (ids, pczts): (Vec<MigrationTxId>, Vec<Vec<u8>>) = unsigned.into_iter().unzip();
+        let response = unsafe { slice_or_empty(response, response_len) };
+        let signed = crate::migration_keystone::apply_batch_signatures(&pczts, response)
+            .map_err(|e| anyhow!("Error applying Keystone batch signatures: {e}"))?;
+        FfiUnsignedTransferPczts::from_pairs(ids.into_iter().zip(signed).collect())
+    });
+    unwrap_exc_or_null(res)
 }
 
 /// The Ironwood (NU6.3) activation height for a standard network, or `-1` when unset/unknown (and

--- a/rust/src/migration.rs
+++ b/rust/src/migration.rs
@@ -2775,6 +2775,77 @@ mod tests {
         create_fixture_account_with_usk(path).0
     }
 
+    /// A view-only account imported by UFVK (no seed) — the negative-path counterpart to
+    /// [`create_fixture_account_with_usk`], which only ever produces seed-derived accounts.
+    /// Returns the wallet handle itself (not just the uuid bytes), since the caller exercises
+    /// [`account_zip32_derivation`] directly, off the FFI boundary.
+    fn create_fixture_view_only_account(path: &std::path::Path) -> (MigrationWallet, AccountUuid) {
+        use zcash_client_backend::data_api::{Account, AccountBirthday, AccountPurpose};
+        use zcash_client_backend::proto::service::TreeState;
+        use zcash_keys::keys::UnifiedSpendingKey;
+        use zcash_protocol::consensus::MAIN_NETWORK;
+
+        let path_bytes = path.to_str().unwrap().as_bytes();
+        let mut wallet = unsafe {
+            crate::wallet_db(
+                path_bytes.as_ptr(),
+                path_bytes.len(),
+                parse_network(NETWORK_ID_MAINNET).expect("mainnet parses"),
+            )
+        }
+        .expect("the wallet database must open");
+
+        // A throwaway seed, only to derive SOME validly-shaped UFVK to import — the wallet is
+        // never given this seed (that is the entire point of `import_account_ufvk`), so it has
+        // no ZIP 32 path to recover from it later.
+        let usk = UnifiedSpendingKey::from_seed(&MAIN_NETWORK, &[9u8; 32], zip32::AccountId::ZERO)
+            .expect("valid ZIP 32 seed derivation");
+        let ufvk = usk.to_unified_full_viewing_key();
+        let treestate = TreeState {
+            hash: "00".repeat(32),
+            ..TreeState::default()
+        };
+        let birthday = match AccountBirthday::from_treestate(treestate, None) {
+            Ok(birthday) => birthday,
+            Err(_) => panic!("the fixture treestate must convert to a birthday"),
+        };
+        let account = wallet
+            .import_account_ufvk(
+                "fixture-view-only",
+                &ufvk,
+                &birthday,
+                AccountPurpose::ViewOnly,
+                None,
+            )
+            .expect("ufvk import must succeed");
+        let account_id = account.id();
+        (wallet, account_id)
+    }
+
+    /// `account_zip32_derivation` is this SDK's own addition (annotating Keystone migration
+    /// PCZTs with the spend derivation path — see its doc comment), so it has no Android
+    /// original to mirror. A UFVK-imported (view-only) account is exactly the case its error
+    /// branch guards: the wallet was never given a seed for it, so there is no ZIP 32 path to
+    /// annotate with, and Keystone has no way to recognize which of its accounts a spend belongs
+    /// to.
+    #[test]
+    fn account_zip32_derivation_errors_for_a_view_only_account() {
+        let path = init_fixture_db("zcashlc_migration_account_zip32_derivation_view_only");
+        let (wallet, account) = create_fixture_view_only_account(&path);
+
+        let result = account_zip32_derivation(&wallet, account);
+        let err = match result {
+            Ok(_) => panic!("a view-only account must have no known ZIP 32 derivation"),
+            Err(e) => e,
+        };
+        assert!(
+            err.to_string()
+                .contains("Account has no known ZIP 32 seed fingerprint/account index"),
+            "unexpected error message: {err}"
+        );
+        let _ = std::fs::remove_file(&path);
+    }
+
     /// A minimal stored migration: `n_preps` preparation transactions then `n_transfers`
     /// transfers, all ids engine-ordered (preps first), with the given lifecycle states.
     fn test_state(

--- a/rust/src/migration_keystone.rs
+++ b/rust/src/migration_keystone.rs
@@ -1,0 +1,562 @@
+//! Keystone (hardware-wallet) batch-signing UR bridge for the Orchard→Ironwood migration flow.
+//!
+//! Bypasses the compiled Keystone mobile SDKs (stale — single-PCZT only, no batch API) by
+//! depending directly on `ur-registry`/`ur` (see the root `Cargo.toml`'s comment), mirroring the
+//! pattern `chainapsis/vizor-wallet` already uses for its own Keystone integration — the same
+//! pattern this module's Android sibling (`migration_keystone.rs` in
+//! `zcash-android-wallet-sdk`'s `backend-lib`) already ports from. The batching primitive itself
+//! is `pczt::roles::signer::batch::{BatchSignRequest, BatchSignResponse}` — not Keystone-specific;
+//! these crates only provide the outer UR/CBOR/QR envelope (`ZcashSignBatch`/
+//! `ZcashBatchSigResult`, registry types `"zcash-sign-batch"`/`"zcash-batch-sig-result"`).
+//!
+//! `BatchSignResponse`'s signatures are aligned by *position*, not by any id embedded in the wire
+//! format — callers here are responsible for retaining the same PCZT ordering between
+//! [`build_sign_batch_qr_parts`] and [`apply_batch_signatures`]. Both take ONE ordered
+//! `&[Vec<u8>]` of unsigned PCZTs — preparation (note-split) PCZTs first, then transfer PCZTs, in
+//! schedule order — the caller MUST pass the same PCZTs in the same order to build and apply.
+//! This is a deliberate shape change from the Android sibling's `(split: Option<&[u8]>,
+//! transfers: &[Vec<u8>])` pair: the wire order is identical (split, then transfers-in-schedule-
+//! order), only the Rust-side shape is flattened to one slice, since the Swift caller already
+//! holds every unsigned PCZT (from `zcashlc_migration_create_unsigned_note_split_pczts` /
+//! `zcashlc_migration_create_unsigned_transfer_pczts`) as one ordered collection. The unsigned
+//! PCZT bytes are passed back into `apply_batch_signatures` by that same caller rather than
+//! retained as Rust-side session state — the only genuinely stateful piece here is the
+//! multi-frame QR *decode* accumulation, which inherently spans multiple FFI calls (one per
+//! scanned camera frame).
+
+use std::sync::Mutex;
+
+use pczt::roles::signer::batch::{BatchSignRequest, BatchSignResponse};
+use pczt::roles::signer::{Signer, SpendAuthSignature};
+use ur_registry::traits::RegistryItem;
+use ur_registry::zcash::zcash_batch_sig_result::ZcashBatchSigResult;
+use ur_registry::zcash::zcash_sign_batch::ZcashSignBatch;
+
+/// Annotates every not-yet-signed Orchard/Ironwood spend action in an IO-finalized migration
+/// PCZT with the account's ZIP 32 derivation path, so an external signer (Keystone) can derive
+/// its own full viewing key and recognize which of its accounts a spend belongs to.
+///
+/// This SDK's engine call (`zcash_pool_migration_backend::engine::build_preparation_unsigned`,
+/// driven by `migration.rs`'s `commit_or_resume`) never sets this metadata — it only runs the
+/// shared `Creator`/`IoFinalizer` plumbing, with no `Updater` step for spend derivation (unlike
+/// `zcash_client_backend::data_api::wallet::create_pczt_from_proposal`, which sets it for
+/// ordinary sends). Combined with [`build_sign_batch_qr_parts`]'s batch redaction correctly
+/// clearing the wire `spend_fvk` (the device is expected to derive its own), an un-annotated
+/// migration PCZT gives Keystone no way to identify the account at all, which fails on-device
+/// with "None of inputs belongs to the provided account".
+///
+/// A dummy padding spend that `IoFinalizer` already self-signed carries a `spend_auth_sig` at
+/// this point and is left alone (its throwaway key needs no derivation, and this crate's
+/// [`build_sign_batch_qr_parts`] clears its `spend_auth_sig` for the batch anyway); every action
+/// still awaiting a real signature — a real spend, or a wallet-controlled zero-value spend
+/// paired with a change output — gets the derivation.
+pub(crate) fn annotate_spend_zip32_derivation(
+    pczt_bytes: &[u8],
+    seed_fingerprint: [u8; 32],
+    coin_type: u32,
+    account_index: zip32::AccountId,
+) -> anyhow::Result<Vec<u8>> {
+    use pczt::roles::updater::Updater;
+
+    let derivation_path = [
+        zip32::ChildIndex::hardened(32).index(),
+        zip32::ChildIndex::hardened(coin_type).index(),
+        zip32::ChildIndex::hardened(u32::from(account_index)).index(),
+    ];
+
+    let pczt = pczt::parse(pczt_bytes).map_err(|e| anyhow::anyhow!("parse pczt: {e:?}"))?;
+    let updated = Updater::new(pczt)
+        .update_orchard_with(|mut updater| {
+            annotate_unsigned_actions(&mut updater, seed_fingerprint, &derivation_path)
+        })
+        .map_err(|e| anyhow::anyhow!("annotate orchard spend derivation: {e:?}"))?
+        .update_ironwood_with(|mut updater| {
+            annotate_unsigned_actions(&mut updater, seed_fingerprint, &derivation_path)
+        })
+        .map_err(|e| anyhow::anyhow!("annotate ironwood spend derivation: {e:?}"))?
+        .finish();
+
+    updated
+        .serialize()
+        .map_err(|e| anyhow::anyhow!("serialize pczt: {e:?}"))
+}
+
+fn annotate_unsigned_actions(
+    updater: &mut orchard::pczt::Updater<'_>,
+    seed_fingerprint: [u8; 32],
+    derivation_path: &[u32],
+) -> Result<(), orchard::pczt::UpdaterError> {
+    let unsigned_indices: Vec<usize> = updater
+        .bundle()
+        .actions()
+        .iter()
+        .enumerate()
+        .filter_map(|(index, action)| action.spend().spend_auth_sig().is_none().then_some(index))
+        .collect();
+    for index in unsigned_indices {
+        let derivation =
+            orchard::pczt::Zip32Derivation::parse(seed_fingerprint, derivation_path.to_vec())
+                .expect("valid ZIP 32 derivation");
+        updater.update_action_with(index, |mut action_updater| {
+            action_updater.set_spend_zip32_derivation(derivation);
+            Ok(())
+        })?;
+    }
+    Ok(())
+}
+
+/// Builds the animated multi-part QR frames for a Keystone batch-signing request covering every
+/// PCZT in `pczts_unsigned`, in the given order (preparation PCZTs first, then transfer PCZTs —
+/// see this module's doc comment).
+///
+/// Every PCZT is passed through
+/// [`redact_pczt_for_batch_signer`](zcash_client_backend::data_api::wallet::redact_pczt_for_batch_signer)
+/// before being added to the request. The wallet's own IO-finalizer already puts `spend_auth_sig`
+/// on every dummy/wallet-controlled Orchard and Ironwood spend when the unsigned PCZT is built —
+/// but the Keystone batch-signing firmware rejects any batch request containing a pre-existing
+/// Orchard/Ironwood `spend_auth_sig` outright ("Invalid pczt, Zcash batch request must not
+/// contain Orchard spend authorization signatures"). Redacting clears those (plus the spend FVK,
+/// which the device derives itself) so only what the batch signer protocol expects reaches the
+/// wire; the caller's own retained, unredacted PCZT bytes are what [`apply_batch_signatures`]
+/// applies the returned signatures back onto — the caller MUST pass the same PCZTs in the same
+/// order to build and apply.
+///
+/// `request_id` is an opaque correlation token (e.g. a UUID's bytes) round-tripped by the device
+/// and checked in [`decode_sign_batch_part`] to reject a scan of an unrelated/stale response.
+pub(crate) fn build_sign_batch_qr_parts(
+    request_id: Vec<u8>,
+    pczts_unsigned: &[Vec<u8>],
+    max_fragment_len: usize,
+) -> anyhow::Result<Vec<String>> {
+    use zcash_client_backend::data_api::wallet::redact_pczt_for_batch_signer;
+
+    let mut pczts = Vec::with_capacity(pczts_unsigned.len());
+    for bytes in pczts_unsigned {
+        let parsed = pczt::parse(bytes).map_err(|e| anyhow::anyhow!("parse pczt: {e:?}"))?;
+        pczts.push(redact_pczt_for_batch_signer(&parsed));
+    }
+
+    let request = BatchSignRequest::new(pczts);
+    let data = request
+        .serialize()
+        .map_err(|e| anyhow::anyhow!("serialize batch sign request: {e:?}"))?;
+    let batch = ZcashSignBatch::new(request_id, data);
+    let cbor: Vec<u8> = batch
+        .try_into()
+        .map_err(|e| anyhow::anyhow!("cbor-encode zcash-sign-batch: {e:?}"))?;
+
+    let mut encoder = ur::Encoder::new(
+        &cbor,
+        max_fragment_len,
+        ZcashSignBatch::get_registry_type().get_type(),
+    )
+    .map_err(|e| anyhow::anyhow!("ur encoder: {e}"))?;
+    let count = encoder.fragment_count();
+    let mut parts = Vec::with_capacity(count);
+    for _ in 0..count {
+        parts.push(
+            encoder
+                .next_part()
+                .map_err(|e| anyhow::anyhow!("ur next_part: {e}"))?
+                .to_uppercase(),
+        );
+    }
+    Ok(parts)
+}
+
+/// In-flight multi-part `zcash-batch-sig-result` scan session. `None` means no session in
+/// flight — mirrors `chainapsis/vizor-wallet`'s `UR_SESSION`/`UrSession` pattern for the same
+/// reason: an FFI call per scanned QR frame has nowhere else to keep fountain-decoder state.
+static DECODE_SESSION: Mutex<Option<ur::Decoder>> = Mutex::new(None);
+
+/// The result of feeding one scanned QR frame to [`decode_sign_batch_part`].
+pub(crate) struct DecodePartResult {
+    pub complete: bool,
+    pub progress: u32,
+    /// The serialized `BatchSignResponse` bytes, once `complete` — feed into
+    /// [`apply_batch_signatures`].
+    pub data: Option<Vec<u8>>,
+    /// The signing device's raw `[major, minor, build]` firmware version, once `complete` — the
+    /// `zcash-batch-sig-result` envelope's own field 3 (see keystone-sdk-rust's
+    /// `ZcashBatchSigResult::get_firmware_version`), not anything recovered from the resulting
+    /// signed PCZT bytes. The batch response is signatures-only (no PCZT is echoed back — see
+    /// [`build_sign_batch_qr_parts`]'s doc comment), so this is the *only* place a batch-signed
+    /// migration can learn the device's firmware version; a PCZT-proprietary-field scan (the
+    /// mechanism the single-transaction Keystone sign flow's firmware stamp relies on) always
+    /// comes back empty here, since [`apply_batch_signatures`] reconstructs the "signed" PCZT from
+    /// the caller's own retained unsigned bytes plus these signatures, never from device-returned
+    /// PCZT bytes.
+    pub firmware_version: Option<[u8; 3]>,
+}
+
+/// Discards any in-flight multi-part scan session. Callers should invoke this on scan-screen
+/// entry so a new attempt always starts from a clean slate regardless of how a previous attempt
+/// ended (cancel, back button, mid-stream error).
+pub(crate) fn reset_sign_batch_decoder() {
+    if let Ok(mut guard) = DECODE_SESSION.lock() {
+        *guard = None;
+    }
+}
+
+/// Feeds one scanned QR frame into the active (or a freshly started) decode session, pinned to
+/// the `"zcash-batch-sig-result"` UR type. `expected_request_id` must match the decoded
+/// `ZcashBatchSigResult`'s own request id once complete, or this returns an error (a scan of an
+/// unrelated/stale response) instead of silently accepting it.
+pub(crate) fn decode_sign_batch_part(
+    part: &str,
+    expected_request_id: &[u8],
+) -> anyhow::Result<DecodePartResult> {
+    let part_lower = part.to_lowercase();
+    let mut guard = DECODE_SESSION
+        .lock()
+        .map_err(|_| anyhow::anyhow!("decode session lock poisoned"))?;
+
+    if guard.is_none() {
+        let (kind, cbor) =
+            ur::decode(&part_lower).map_err(|e| anyhow::anyhow!("ur decode: {e}"))?;
+        match kind {
+            ur::ur::Kind::SinglePart => return finish_decode(cbor, expected_request_id),
+            ur::ur::Kind::MultiPart => {
+                let mut decoder = ur::Decoder::default();
+                decoder
+                    .receive(&part_lower)
+                    .map_err(|e| anyhow::anyhow!("ur receive: {e}"))?;
+                let progress = decoder.progress();
+                *guard = Some(decoder);
+                return Ok(DecodePartResult {
+                    complete: false,
+                    progress: progress as u32,
+                    data: None,
+                    firmware_version: None,
+                });
+            }
+        }
+    }
+
+    if let Err(e) = guard.as_mut().unwrap().receive(&part_lower) {
+        *guard = None;
+        return Err(anyhow::anyhow!("ur receive: {e}"));
+    }
+
+    if guard.as_ref().unwrap().complete() {
+        let message = guard
+            .as_mut()
+            .unwrap()
+            .message()
+            .map_err(|e| anyhow::anyhow!("ur message: {e}"))?;
+        *guard = None;
+        let cbor = message.ok_or_else(|| anyhow::anyhow!("decoder complete but no message"))?;
+        return finish_decode(cbor, expected_request_id);
+    }
+
+    let progress = guard.as_ref().unwrap().progress();
+    Ok(DecodePartResult {
+        complete: false,
+        progress: progress as u32,
+        data: None,
+        firmware_version: None,
+    })
+}
+
+fn finish_decode(cbor: Vec<u8>, expected_request_id: &[u8]) -> anyhow::Result<DecodePartResult> {
+    let result = ZcashBatchSigResult::try_from(cbor)
+        .map_err(|e| anyhow::anyhow!("cbor-decode zcash-batch-sig-result: {e:?}"))?;
+    if result.get_request_id() != expected_request_id {
+        return Err(anyhow::anyhow!(
+            "zcash-batch-sig-result request id does not match the outstanding sign request"
+        ));
+    }
+    Ok(DecodePartResult {
+        complete: true,
+        progress: 100,
+        data: Some(result.get_data().to_vec()),
+        firmware_version: Some(*result.get_firmware_version()),
+    })
+}
+
+/// Applies a decoded `BatchSignResponse` back to the retained unsigned PCZTs — in the exact order
+/// they were passed to [`build_sign_batch_qr_parts`] — producing signed-but-unproven PCZT bytes
+/// for each, in that same order. These are the same shape
+/// `zcashlc_migration_store_signed_note_split_pczts`/`zcashlc_migration_store_signed_schedule_pczts`
+/// already expect from the in-process-signing composition — no other change needed there.
+///
+/// Returns an error if the response's signature-set count doesn't match the number of PCZTs
+/// passed in — the caller MUST pass the same PCZTs in the same order to build and apply.
+pub(crate) fn apply_batch_signatures(
+    pczts_unsigned: &[Vec<u8>],
+    batch_sign_response: &[u8],
+) -> anyhow::Result<Vec<Vec<u8>>> {
+    let response = BatchSignResponse::parse(batch_sign_response)
+        .map_err(|e| anyhow::anyhow!("parse batch sign response: {e:?}"))?;
+    let signatures = response.signatures();
+    if signatures.len() != pczts_unsigned.len() {
+        return Err(anyhow::anyhow!(
+            "batch sign response has {} signature set(s), expected {} (one per PCZT passed to \
+             apply_batch_signatures, in the same order passed to build_sign_batch_qr_parts)",
+            signatures.len(),
+            pczts_unsigned.len(),
+        ));
+    }
+
+    pczts_unsigned
+        .iter()
+        .zip(signatures)
+        .map(|(bytes, sigs)| apply_signatures_to_one(bytes, sigs))
+        .collect()
+}
+
+fn apply_signatures_to_one(
+    unsigned_bytes: &[u8],
+    sigs: &[SpendAuthSignature],
+) -> anyhow::Result<Vec<u8>> {
+    let pczt =
+        pczt::parse(unsigned_bytes).map_err(|e| anyhow::anyhow!("parse unsigned pczt: {e:?}"))?;
+    let mut signer = Signer::new(pczt).map_err(|e| anyhow::anyhow!("signer init: {e:?}"))?;
+    for sig in sigs {
+        signer
+            .apply_orchard_spend_auth_signature(sig)
+            .map_err(|e| anyhow::anyhow!("apply spend auth signature: {e:?}"))?;
+    }
+    signer
+        .finish()
+        .serialize()
+        .map_err(|e| anyhow::anyhow!("serialize signed pczt: {e:?}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use orchard::keys::{FullViewingKey, Scope, SpendingKey};
+    use orchard::value::NoteValue;
+    use pczt::roles::creator::Creator;
+    use pczt::roles::io_finalizer::IoFinalizer;
+    use rand::rngs::OsRng;
+    use shardtree::ShardTree;
+    use shardtree::store::memory::MemoryShardStore;
+    use ur_registry::zcash::zcash_sign_batch::ZcashSignBatch;
+    use zcash_note_encryption::try_note_decryption;
+    use zcash_primitives::transaction::builder::{BuildConfig, Builder, PcztResult};
+    use zcash_primitives::transaction::fees::zip317;
+    use zcash_protocol::consensus::{BlockHeight, Network};
+    use zcash_protocol::memo::{Memo, MemoBytes};
+    use zcash_protocol::value::Zatoshis;
+
+    /// Builds a real, IO-finalized single-Orchard-pool PCZT (one spend, one output),
+    /// mirroring the shape the real migration pipeline hands to
+    /// [`build_sign_batch_qr_parts`]: since the transaction has fewer real actions than
+    /// Orchard's default padding minimum, the Orchard builder inserts a dummy padding
+    /// action, and `IoFinalizer` self-signs that dummy spend (see `pczt::roles::io_finalizer`'s
+    /// "dummy spends will have been signed" note) — producing exactly the kind of
+    /// pre-existing `spend_auth_sig` the Keystone batch firmware rejects.
+    fn build_single_pool_orchard_pczt() -> Vec<u8> {
+        let mut rng = OsRng;
+        let sk = SpendingKey::from_zip32_seed(&[11u8; 32], 1, zip32::AccountId::ZERO)
+            .expect("valid Orchard ZIP 32 spending key");
+        let fvk = FullViewingKey::from(&sk);
+        let ivk = fvk.to_ivk(Scope::Internal);
+        let ovk = fvk.to_ovk(Scope::Internal);
+        let recipient = fvk.address_at(0u32, Scope::Internal);
+
+        // Pretend we already received a note to spend.
+        let value = NoteValue::from_raw(1_000_000);
+        let note = {
+            let bundle_version = orchard::bundle::BundleVersion::orchard_v2();
+            let mut builder = orchard::builder::Builder::new(
+                orchard::builder::BundleType::DEFAULT,
+                bundle_version,
+                bundle_version.default_flags(),
+                orchard::Anchor::empty_tree(),
+            )
+            .expect("orchard builder");
+            builder
+                .add_output(None, recipient, value, Memo::Empty.encode().into_bytes())
+                .expect("add output");
+            let (bundle, meta) = builder
+                .build::<i64>(&mut rng)
+                .expect("build orchard bundle")
+                .expect("non-empty bundle");
+            let action = bundle
+                .actions()
+                .get(meta.output_action_index(0).expect("output action index"))
+                .expect("action present");
+            let domain = orchard::note_encryption::OrchardDomain::for_action(action);
+            let (note, _, _) =
+                try_note_decryption(&domain, &ivk.prepare(), action).expect("decrypt own output");
+            note
+        };
+
+        // Single-leaf tree for the spend's witness/anchor.
+        let (anchor, merkle_path) = {
+            let cmx: orchard::note::ExtractedNoteCommitment = note.commitment().into();
+            let leaf = orchard::tree::MerkleHashOrchard::from_cmx(&cmx);
+            let mut tree = ShardTree::<_, 32, 16>::new(
+                MemoryShardStore::<orchard::tree::MerkleHashOrchard, u32>::empty(),
+                100,
+            );
+            tree.append(leaf, incrementalmerkletree::Retention::Marked)
+                .expect("append leaf");
+            tree.checkpoint(9_999_999).expect("checkpoint");
+            let position = 0.into();
+            let merkle_path = tree
+                .witness_at_checkpoint_depth(position, 0)
+                .expect("witness lookup")
+                .expect("witness present");
+            let anchor = merkle_path.root(leaf);
+            (anchor.into(), merkle_path.into())
+        };
+
+        // Well past TestNetwork's NU5 (Orchard) activation, comfortably before NU6.
+        let target_height = BlockHeight::from_u32(1_900_000);
+        let mut builder: Builder<Network, ()> = Builder::new(
+            Network::TestNetwork,
+            target_height,
+            BuildConfig::Standard {
+                sapling_anchor: None,
+                orchard_anchor: Some(anchor),
+                ironwood_anchor: None,
+                orchard_bundle_type: orchard::builder::BundleType::DEFAULT,
+                ironwood_bundle_type: orchard::builder::BundleType::DEFAULT,
+            },
+        );
+        builder
+            .add_orchard_spend::<zip317::FeeRule>(fvk.clone(), note, merkle_path)
+            .expect("add spend");
+        builder
+            .add_orchard_output::<zip317::FeeRule>(
+                Some(ovk),
+                recipient,
+                // 1_000_000 in - 10_000 ZIP-317 fee (2 grace actions x 5_000 marginal fee).
+                Zatoshis::const_from_u64(990_000),
+                MemoBytes::empty(),
+            )
+            .expect("add output");
+
+        let PcztResult { pczt_parts, .. } = builder
+            .build_for_pczt(OsRng, &zip317::FeeRule::standard())
+            .expect("build_for_pczt");
+
+        let base = Creator::build_from_parts(pczt_parts).expect("creator");
+        let base = IoFinalizer::new(base).finalize_io().expect("io finalize");
+        base.serialize().expect("serialize")
+    }
+
+    #[test]
+    fn build_sign_batch_qr_parts_strips_preexisting_orchard_spend_auth_sig() {
+        let unsigned = build_single_pool_orchard_pczt();
+
+        // Sanity-check the premise: the IO-finalized PCZT already carries a dummy
+        // spend_auth_sig before redaction — this is what regressed without the fix.
+        let parsed = pczt::parse(&unsigned).expect("parse base pczt");
+        assert!(
+            parsed
+                .orchard()
+                .actions()
+                .iter()
+                .any(|action| action.spend().spend_auth_sig().is_some()),
+            "test setup must produce a pre-signed dummy Orchard spend",
+        );
+
+        let parts = build_sign_batch_qr_parts(
+            b"test-request-id".to_vec(),
+            &[unsigned.clone()],
+            // Large enough that the whole request fits in a single UR frame.
+            1_000_000,
+        )
+        .expect("build_sign_batch_qr_parts");
+        assert_eq!(parts.len(), 1, "expected a single QR frame");
+
+        // `ur::Encoder` always emits the indexed multi-part wire format, even for a
+        // single fragment, so decode via `ur::Decoder` rather than assuming
+        // `ur::ur::Kind::SinglePart`.
+        let mut decoder = ur::Decoder::default();
+        decoder
+            .receive(&parts[0].to_lowercase())
+            .expect("ur receive");
+        assert!(
+            decoder.complete(),
+            "single fragment should complete decoding"
+        );
+        let cbor = decoder
+            .message()
+            .expect("ur message")
+            .expect("decoder complete but no message");
+        let batch = ZcashSignBatch::try_from(cbor).expect("cbor-decode zcash-sign-batch");
+        let request = BatchSignRequest::parse(batch.get_data()).expect("parse batch sign request");
+
+        assert_eq!(request.pczts().len(), 1);
+        for action in request.pczts()[0].orchard().actions() {
+            assert!(
+                action.spend().spend_auth_sig().is_none(),
+                "batch request must not contain a pre-existing Orchard spend_auth_sig",
+            );
+        }
+    }
+
+    #[test]
+    fn annotate_spend_zip32_derivation_sets_derivation_only_on_unsigned_actions() {
+        let unsigned = build_single_pool_orchard_pczt();
+        let base = pczt::parse(&unsigned).expect("parse base pczt");
+        // Sanity-check the premise: neither action carries a derivation path yet.
+        for action in base.orchard().actions() {
+            assert!(
+                !format!("{:?}", action.spend()).contains("zip32_derivation: Some"),
+                "test setup must start without any spend zip32_derivation set",
+            );
+        }
+
+        let seed_fingerprint = [42u8; 32];
+        let coin_type = 1; // testnet
+        let account_index = zip32::AccountId::ZERO;
+        let annotated =
+            annotate_spend_zip32_derivation(&unsigned, seed_fingerprint, coin_type, account_index)
+                .expect("annotate_spend_zip32_derivation");
+
+        let parsed = pczt::parse(&annotated).expect("parse annotated pczt");
+        let actions = parsed.orchard().actions();
+        assert_eq!(actions.len(), base.orchard().actions().len());
+
+        let mut unsigned_count = 0;
+        let mut signed_count = 0;
+        for (base_action, action) in base.orchard().actions().iter().zip(actions.iter()) {
+            let has_derivation = format!("{:?}", action.spend()).contains("zip32_derivation: Some");
+            if base_action.spend().spend_auth_sig().is_some() {
+                // Already-signed (dummy) spends are left alone.
+                signed_count += 1;
+                assert!(
+                    !has_derivation,
+                    "an already-signed dummy spend must not get a derivation path",
+                );
+            } else {
+                unsigned_count += 1;
+                assert!(
+                    has_derivation,
+                    "a real, still-unsigned spend must get a derivation path",
+                );
+            }
+        }
+        assert_eq!(
+            unsigned_count, 1,
+            "expected exactly one real unsigned spend"
+        );
+        assert_eq!(signed_count, 1, "expected exactly one dummy signed spend");
+    }
+
+    /// New vs. the Android original: pins the single-array shape's count-mismatch check.
+    /// `BatchSignResponse::new` is cheap to construct directly (no device fixture needed) — an
+    /// empty signature-set list is already a mismatch against any non-empty PCZT slice.
+    #[test]
+    fn apply_batch_signatures_returns_error_on_signature_count_mismatch() {
+        let unsigned = build_single_pool_orchard_pczt();
+        let response_bytes = BatchSignResponse::new(Vec::new())
+            .serialize()
+            .expect("serialize empty batch sign response");
+
+        let err = apply_batch_signatures(&[unsigned], &response_bytes)
+            .expect_err("signature-set count mismatch must error");
+        let message = err.to_string();
+        assert!(
+            message.contains("expected 1"),
+            "error should report the expected PCZT count: {message}"
+        );
+    }
+}

--- a/rust/src/migration_keystone.rs
+++ b/rust/src/migration_keystone.rs
@@ -559,4 +559,95 @@ mod tests {
             "error should report the expected PCZT count: {message}"
         );
     }
+
+    /// Feeds `parts` to [`decode_sign_batch_part`] in order, cycling back to the start if more
+    /// are needed, until a call reports completion or errors. Mirrors a real scan loop, which
+    /// keeps feeding scanned camera frames — the same single frame repeatedly, for a
+    /// single-fragment response — until the decoder reports done, rather than assuming a fixed
+    /// call count.
+    fn feed_parts_until_complete(
+        parts: &[String],
+        expected_request_id: &[u8],
+    ) -> anyhow::Result<DecodePartResult> {
+        // Comfortably more than enough attempts for any fragment count exercised here.
+        let attempts = parts.len().max(1) * 4;
+        for i in 0..attempts {
+            let result = decode_sign_batch_part(&parts[i % parts.len()], expected_request_id)?;
+            if result.complete {
+                return Ok(result);
+            }
+        }
+        panic!("decode_sign_batch_part did not complete after {attempts} attempts");
+    }
+
+    /// New vs. the Android original: `decode_sign_batch_part` is this SDK's own addition, so it
+    /// has no upstream test to mirror. Pins its two device-independent guarantees without a real
+    /// Keystone: the `expected_request_id` mismatch check, and the firmware/data passthrough on
+    /// success. Constructs a `ZcashBatchSigResult` directly (its `new` is public — see
+    /// keystone-sdk-rust's `zcash_batch_sig_result.rs`), CBOR- and UR-encodes it exactly the way
+    /// a real device response arrives on the wire (the encode-side mirror of
+    /// [`build_sign_batch_qr_parts_strips_preexisting_orchard_spend_auth_sig`]'s decode step),
+    /// then feeds the resulting frame(s) through the production decode path twice — once under
+    /// the wrong `expected_request_id`, once under the right one.
+    #[test]
+    fn decode_sign_batch_part_checks_request_id_and_returns_data_and_firmware() {
+        let request_id = b"test-request-id".to_vec();
+        let data = b"pretend-serialized-batch-sign-response".to_vec();
+        let firmware_version = [4u8, 5, 6];
+
+        let result = ZcashBatchSigResult::new(request_id.clone(), data.clone(), firmware_version);
+        let cbor: Vec<u8> = result
+            .try_into()
+            .expect("cbor-encode zcash-batch-sig-result");
+
+        // `ur::Encoder` always emits the indexed multi-part wire format, even for a single
+        // fragment (see `build_sign_batch_qr_parts_strips_preexisting_orchard_spend_auth_sig`'s
+        // comment) — `decode_sign_batch_part` is exercised exactly as a real scan would, whatever
+        // the fragment count.
+        let mut encoder = ur::Encoder::new(
+            &cbor,
+            // Large enough that the whole result fits in a single UR frame.
+            1_000_000,
+            ZcashBatchSigResult::get_registry_type().get_type(),
+        )
+        .expect("ur encoder");
+        let count = encoder.fragment_count();
+        let mut parts = Vec::with_capacity(count);
+        for _ in 0..count {
+            parts.push(encoder.next_part().expect("ur next_part").to_uppercase());
+        }
+
+        // A scan of the full response under the WRONG expected request id must be rejected, not
+        // silently accepted.
+        reset_sign_batch_decoder();
+        let mismatch = feed_parts_until_complete(&parts, b"some-other-request-id");
+        let err = match mismatch {
+            Ok(_) => panic!("wrong expected_request_id must error"),
+            Err(e) => e,
+        };
+        assert!(
+            err.to_string()
+                .contains("does not match the outstanding sign request"),
+            "unexpected error message: {err}"
+        );
+
+        // The decode session is a global static (see `DECODE_SESSION`'s doc comment) — a fresh
+        // scan must not see any state left over from the mismatched-id scan above.
+        reset_sign_batch_decoder();
+        let decoded = feed_parts_until_complete(&parts, &request_id)
+            .expect("decode_sign_batch_part with the right request id must succeed");
+        assert!(decoded.complete, "final part must report completion");
+        assert_eq!(
+            decoded.data.expect("data present on completion"),
+            data,
+            "decoded data must round-trip exactly"
+        );
+        assert_eq!(
+            decoded
+                .firmware_version
+                .expect("firmware version present on completion"),
+            firmware_version,
+            "firmware version must pass through exactly"
+        );
+    }
 }


### PR DESCRIPTION
Ports the Keystone batch-signing UR bridge from the Android SDK (`zcash-android-wallet-sdk` @ `79aca498`, `backend-lib/src/main/rust/migration_keystone.rs`) into this SDK's rust FFI — the port [#1823](https://github.com/zcash/zcash-swift-wallet-sdk/pull/1823) was closed in favor of ("the batch redaction … will come to this SDK when the batch signing logic is ported").

**What lands here (rust layer only — the Swift surface and slipstream forwards stack on top as separate PRs):**

- New `rust/src/migration_keystone.rs` — a 1:1 logic port:
  - `build_sign_batch_qr_parts`: packs the ceremony's unsigned PCZTs into one `pczt::roles::signer::batch::BatchSignRequest`, passing **every PCZT through `zcash_client_backend::data_api::wallet::redact_pczt_for_batch_signer` inside the same function** (construction and redaction inseparable — this also strips the IO-finalizer's pre-existing dummy `spend_auth_sig`s, which Keystone batch firmware rejects outright), wraps it in the `zcash-sign-batch` UR envelope with the caller's request id, and fountain-encodes the animated QR frame strings.
  - Stateful multi-frame decode (`reset_sign_batch_decoder` / `decode_sign_batch_part`): the only rust-side session state; verifies the request id at completion (a stale/unrelated scan errors instead of being silently accepted) and surfaces the device firmware version from the `zcash-batch-sig-result` envelope — the response is **signatures only**, no PCZT is echoed back, so this envelope field is the only place to learn it.
  - `apply_batch_signatures`: applies the positional signature sets back onto the caller-retained unsigned PCZTs, producing signed-but-unproven bytes for the existing store calls; errors on a count mismatch.
  - One deliberate shape divergence from Android, by design review: a single ordered PCZT array instead of Android's `(split, transfers)` pair — the wire behavior is identical; callers pass preparations first, then transfers, and must hand the SAME array in the SAME order to build and apply (documented on both functions).
- ZIP-32 spend-derivation annotation (`annotate_spend_zip32_derivation`) applied serve-time in **both** `zcashlc_migration_create_unsigned_note_split_pczts` and `zcashlc_migration_create_unsigned_transfer_pczts` — the pool-migration builders never set it, batch redaction clears the wire spend FVK, and without the annotation Keystone fails on-device with "None of inputs belongs to the provided account". Already-signed dummy spends are left alone; an account with no known derivation errors.
- Four externs: `zcashlc_migration_keystone_{build_sign_batch_qr_parts, reset_sign_batch_decoder, decode_sign_batch_part, apply_batch_signatures}` + `FfiKeystoneQrParts` / `FfiKeystoneBatchDecodeResult` and their free functions.
- Deps: `pczt` features += `orchard`,`sapling`,`signer`; `ur` (KeystoneHQ/ur-rs, tag 0.3.3) and `ur-registry` (KeystoneHQ/keystone-sdk-rust, **pinned** at rev `7c90bf1a` — Android floats the branch; its lock resolves this same rev). The compiled Keystone platform SDKs are stale (single-PCZT only) — depending on the rust crates directly mirrors the pattern Android adopted from `vizor-wallet`. **No librustzcash pin changes**: the batch primitives (`redact_pczt_for_batch_signer`, `pczt::roles::signer::batch`) already exist at the family pin `3a10e7f` both SDKs share.
- Tests (two commits: the port + the final-review test hardening): the two Android regression tests ported against a real IO-finalized Orchard PCZT (batch request carries no pre-existing `spend_auth_sig`; annotation lands only on unsigned actions), a signature-count-mismatch test, a full decode round-trip pinning the request-id mismatch rejection and the firmware `[u8;3]` passthrough (the ceremony's anti-spoofing property, constructed device-free via the registry crate's public `ZcashBatchSigResult::new`), and a view-only-account fixture proving the no-derivation error path. `cargo test` 84/0; `cargo check --target aarch64-apple-ios` clean.

**Coordination note:** [#1825](https://github.com/zcash/zcash-swift-wallet-sdk/pull/1825) (opaque migration handles) targets the same base branch and touches the same two create-unsigned functions where the annotation hooks in; whichever merges second has a small, mechanical rebase (the annotation is a 3-line serve-time insertion per path).

Closes nothing on its own — MOB-1513 (R5). Stacked PRs: Swift surface → `…-sdk-pool-migration`, slipstream forwards → `michal/slipstream-support`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
