### PR TITLE
[#1806] Manage the invalid-marks table via ext_-prefixed schema migrations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2753,6 +2753,8 @@ dependencies = [
  "rusqlite",
  "rust_decimal",
  "sapling-crypto",
+ "schemerz",
+ "schemerz-rusqlite",
  "secrecy",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,8 @@ eip681 = "0.1.0"
 # Infrastructure
 prost = "0.14"
 rusqlite = "0.37"
+schemerz = "0.2"
+schemerz-rusqlite = "0.370"
 secrecy = "0.8"
 rand = "0.8"
 nonempty = "0.11"

--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -29,8 +29,11 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   witnessable from NU6.3 activation), preparations against the wallet's natural
   anchor, and a boundary the wallet has not scanned or retained yet surfaces as
   the transient nothing-due, not an error — and leaves broadcasting,
-  mined-reconciliation, rejection classification (the `sdk_invalid_marks` side
-  table), and the platform's 5-state derivation to this layer (the v1 crate's
+  mined-reconciliation, rejection classification (the
+  `ext_zcashlc_orchard_ironwood_migration_invalid_marks` extension table, created
+  by the wallet schema migrations via `WalletMigrator::with_external_migrations`
+  and accessed through the wallet's authorizer-guarded extension-transaction API),
+  and the platform's 5-state derivation to this layer (the v1 crate's
   `ReadyToPropose` state and `SyncRequiredBeforeNext` attention reason are gone
   entirely — the engine's atomic split+schedule commit means that intermediate
   moment cannot occur). `Complete` is

--- a/rust/src/ext_schema.rs
+++ b/rust/src/ext_schema.rs
@@ -1,0 +1,86 @@
+//! The SDK's extension tables in the wallet database.
+//!
+//! Tables this SDK stores alongside `zcash_client_sqlite`'s own schema follow the wallet
+//! database's extension contract (see `WalletMigrator::with_external_migrations`): every
+//! name carries the `ext_zcashlc_` prefix (the wallet promises never to use `ext_`), and
+//! the schema is created and evolved exclusively by the [`schemerz`] migrations registered
+//! here — never ad hoc at call time — so extension tables share the wallet database's
+//! schema versioning. Runtime writes go through
+//! [`WalletDb::transactionally_with_extension`], whose authorizer confines them to the
+//! `ext_` namespace.
+//!
+//! [`zcashlc_init_data_database`](crate::zcashlc_init_data_database) applies these
+//! migrations alongside the wallet's own; every other entry point may assume the tables
+//! exist, because the platform initializes the database before using it (the Swift
+//! `Initializer` does this at startup).
+//!
+//! [`WalletDb::transactionally_with_extension`]: zcash_client_sqlite::WalletDb::transactionally_with_extension
+
+use std::collections::HashSet;
+
+use schemerz_rusqlite::RusqliteMigration;
+use uuid::Uuid;
+use zcash_client_sqlite::wallet::init::{
+    WalletMigrationError, migrations::CURRENT_LEAF_MIGRATIONS,
+};
+
+/// The SDK's external migrations, in the form [`WalletMigrator::with_external_migrations`]
+/// accepts.
+///
+/// [`WalletMigrator::with_external_migrations`]: zcash_client_sqlite::wallet::init::WalletMigrator::with_external_migrations
+pub(crate) fn external_migrations() -> Vec<Box<dyn RusqliteMigration<Error = WalletMigrationError>>>
+{
+    vec![Box::new(AddInvalidTransferMarksTable)]
+}
+
+const ADD_INVALID_TRANSFER_MARKS_TABLE_ID: Uuid =
+    Uuid::from_u128(0x0e1fd980_5cad_41c5_a6db_183dab527dcc);
+
+/// Adds `ext_zcashlc_orchard_ironwood_migration_invalid_marks`, the table recording
+/// terminal rejection classifications for Orchard -> Ironwood pool-migration transfers.
+///
+/// The engine has no failure states (a rejected broadcast leaves the transaction re-offered),
+/// so the platform's rejection classifier records terminal rejections here, keyed by account
+/// and the engine's per-run transaction id; see the accessors in [`crate::migration`]. The
+/// account is stored as raw uuid bytes rather than a foreign key into `accounts`, per the
+/// extension contract's warning against depending on wallet-internal ids.
+struct AddInvalidTransferMarksTable;
+
+impl schemerz::Migration<Uuid> for AddInvalidTransferMarksTable {
+    fn id(&self) -> Uuid {
+        ADD_INVALID_TRANSFER_MARKS_TABLE_ID
+    }
+
+    fn dependencies(&self) -> HashSet<Uuid> {
+        // The marks annotate the engine's pool-migration transactions, whose tables are
+        // registered in the wallet's own migration graph; anchoring on the wallet's leaf
+        // frontier guarantees they exist first.
+        CURRENT_LEAF_MIGRATIONS.iter().copied().collect()
+    }
+
+    fn description(&self) -> &'static str {
+        "Adds the SDK's invalid-transfer marks table for Orchard -> Ironwood pool migrations."
+    }
+}
+
+impl RusqliteMigration for AddInvalidTransferMarksTable {
+    type Error = WalletMigrationError;
+
+    fn up(&self, transaction: &rusqlite::Transaction) -> Result<(), Self::Error> {
+        transaction.execute_batch(
+            "CREATE TABLE ext_zcashlc_orchard_ironwood_migration_invalid_marks (
+                account_uuid BLOB NOT NULL,
+                tx_id INTEGER NOT NULL,
+                reason TEXT NOT NULL,
+                PRIMARY KEY (account_uuid, tx_id)
+            )",
+        )?;
+        Ok(())
+    }
+
+    fn down(&self, _transaction: &rusqlite::Transaction) -> Result<(), Self::Error> {
+        Err(WalletMigrationError::CannotRevert(
+            ADD_INVALID_TRANSFER_MARKS_TABLE_ID,
+        ))
+    }
+}

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -67,7 +67,7 @@ use zcash_client_sqlite::{
     chain::{BlockMeta, init::init_blockmeta_db},
     error::SqliteClientError,
     util::SystemClock,
-    wallet::init::{WalletMigrationError, init_wallet_db},
+    wallet::init::{WalletMigrationError, WalletMigrator},
 };
 use zcash_primitives::{
     block::BlockHash,
@@ -91,6 +91,7 @@ use zip32::fingerprint::SeedFingerprint;
 
 mod derivation;
 mod eip681;
+mod ext_schema;
 mod ffi;
 mod migration;
 mod migration_engine;
@@ -315,7 +316,13 @@ pub unsafe extern "C" fn zcashlc_init_data_database(
             ))
         };
 
-        match init_wallet_db(&mut db_data, seed) {
+        let migrator =
+            WalletMigrator::new().with_external_migrations(ext_schema::external_migrations());
+        let migrator = match seed {
+            Some(seed) => migrator.with_seed(seed),
+            None => migrator,
+        };
+        match migrator.init_or_migrate(&mut db_data) {
             Ok(_) => Ok(0),
             Err(e)
                 if matches!(

--- a/rust/src/migration.rs
+++ b/rust/src/migration.rs
@@ -20,8 +20,10 @@
 //!   completion the platform asks `zcashlc_migration_propose_transfers` whether anything remains
 //!   (an empty schedule means no).
 //! - Mined-transaction reconciliation ([`reconcile_mined`]) runs at the head of every read.
-//! - Rejection classification is recorded in the SDK-owned `sdk_invalid_marks` side table (the
-//!   engine has no failure states).
+//! - Rejection classification is recorded in the SDK-owned
+//!   `ext_zcashlc_orchard_ironwood_migration_invalid_marks` extension table (the engine has no
+//!   failure states), created by the wallet schema migrations via [`crate::ext_schema`] and
+//!   written through the wallet's extension-transaction API.
 //!
 //! Consent contract: plan details never cross the FFI boundary inward. Each propose/prepare call
 //! caches its plan under an opaque [`migration_plan_cache::PlanHandle`] (returned to the platform
@@ -162,9 +164,10 @@ struct CallCtx {
 }
 
 /// Open the per-call context from the common FFI arguments. Every entry point calls this fresh and
-/// drops it at the end (no persistent handle). The engine's store tables are created by the wallet
-/// schema migrations during `init_data_db` (`zcash_client_sqlite::pool_migration` registers them);
-/// only the SDK's own side tables are ensured idempotently here.
+/// drops it at the end (no persistent handle). All tables are created by the wallet schema
+/// migrations during `init_data_db`: the engine's store tables by `zcash_client_sqlite`'s own
+/// migration graph (`zcash_client_sqlite::pool_migration` registers them), and the SDK's extension
+/// tables by the external migrations in [`crate::ext_schema`].
 ///
 /// # Safety
 /// - `db_data` must be valid for reads of `db_data_len` bytes and encode a filesystem path.
@@ -182,8 +185,6 @@ unsafe fn open(
     let wallet = unsafe { crate::wallet_db(db_data, db_data_len, network.clone())? };
     let store_conn = Connection::open(&db_path)
         .map_err(|e| anyhow!("Error opening migration store connection: {e}"))?;
-    init_invalid_marks(&store_conn)
-        .map_err(|e| anyhow!("Error initializing migration marks table: {e}"))?;
     let account = account_uuid_from_bytes(account_uuid_bytes)
         .map_err(|e| anyhow!("account uuid must be 16 bytes: {e}"))?;
     let account_bytes = *account.expose_uuid().as_bytes();
@@ -211,48 +212,68 @@ impl CallCtx {
 //
 // The engine has no failure states: a rejected broadcast leaves the transaction `Signed`/`Proved`
 // and re-offered. The platform's rejection classifier distinguishes terminal rejections
-// (invalid-note, expired) from retryable ones; the terminal ones are recorded here so
+// (invalid-note, expired) from retryable ones; the terminal ones are recorded in the
+// `ext_zcashlc_orchard_ironwood_migration_invalid_marks` extension table so
 // `zcashlc_migration_has_invalid_transfers` / the `RequiresAttention` derivation can surface
 // them. Cleared when the run is cancelled (`zcashlc_migration_restart_step`).
-
-fn init_invalid_marks(conn: &Connection) -> rusqlite::Result<()> {
-    conn.execute_batch(
-        "CREATE TABLE IF NOT EXISTS sdk_invalid_marks (
-            account_uuid BLOB NOT NULL,
-            tx_id INTEGER NOT NULL,
-            reason TEXT NOT NULL,
-            PRIMARY KEY (account_uuid, tx_id)
-        )",
-    )
-}
+//
+// The table is created by the wallet schema migrations (see [`crate::ext_schema`]); access goes
+// through `WalletDb::transactionally_with_extension`, whose authorizer restricts writes to the
+// `ext_` namespace.
 
 fn insert_invalid_mark(
-    conn: &Connection,
+    wallet: &mut MigrationWallet,
     account: &[u8; 16],
     id: MigrationTxId,
     reason: &str,
-) -> rusqlite::Result<()> {
-    conn.execute(
-        "INSERT INTO sdk_invalid_marks (account_uuid, tx_id, reason) VALUES (?1, ?2, ?3)
-         ON CONFLICT(account_uuid, tx_id) DO UPDATE SET reason = excluded.reason",
-        rusqlite::params![&account[..], u32::from(id), reason],
-    )?;
-    Ok(())
+) -> anyhow::Result<()> {
+    wallet.transactionally_with_extension(|_wdb, ext| {
+        ext.execute(
+            "INSERT INTO ext_zcashlc_orchard_ironwood_migration_invalid_marks
+                (account_uuid, tx_id, reason)
+             VALUES (?1, ?2, ?3)
+             ON CONFLICT(account_uuid, tx_id) DO UPDATE SET reason = excluded.reason",
+            rusqlite::params![&account[..], u32::from(id), reason],
+        )?;
+        Ok(())
+    })
 }
 
-fn invalid_marks(conn: &Connection, account: &[u8; 16]) -> rusqlite::Result<Vec<u32>> {
-    let mut stmt =
-        conn.prepare("SELECT tx_id FROM sdk_invalid_marks WHERE account_uuid = ?1 ORDER BY tx_id")?;
-    let rows = stmt.query_map(rusqlite::params![&account[..]], |row| row.get::<_, u32>(0))?;
-    rows.collect()
+/// The account's marked transaction ids, sorted ascending. The extension-transaction API exposes
+/// single-row queries only, so the ids arrive as one aggregated row and are split here.
+fn invalid_marks(wallet: &mut MigrationWallet, account: &[u8; 16]) -> anyhow::Result<Vec<u32>> {
+    let joined: Option<String> = wallet.transactionally_with_extension(|_wdb, ext| {
+        ext.query_row(
+            "SELECT group_concat(tx_id)
+             FROM ext_zcashlc_orchard_ironwood_migration_invalid_marks
+             WHERE account_uuid = ?1",
+            rusqlite::params![&account[..]],
+            |row| row.get(0),
+        )
+        .map_err(anyhow::Error::from)
+    })?;
+    let mut ids = joined
+        .as_deref()
+        .unwrap_or("")
+        .split_terminator(',')
+        .map(|id| {
+            id.parse::<u32>()
+                .map_err(|e| anyhow!("invalid mark id {id}: {e}"))
+        })
+        .collect::<anyhow::Result<Vec<u32>>>()?;
+    ids.sort_unstable();
+    Ok(ids)
 }
 
-fn clear_invalid_marks(conn: &Connection, account: &[u8; 16]) -> rusqlite::Result<()> {
-    conn.execute(
-        "DELETE FROM sdk_invalid_marks WHERE account_uuid = ?1",
-        rusqlite::params![&account[..]],
-    )?;
-    Ok(())
+fn clear_invalid_marks(wallet: &mut MigrationWallet, account: &[u8; 16]) -> anyhow::Result<()> {
+    wallet.transactionally_with_extension(|_wdb, ext| {
+        ext.execute(
+            "DELETE FROM ext_zcashlc_orchard_ironwood_migration_invalid_marks
+             WHERE account_uuid = ?1",
+            rusqlite::params![&account[..]],
+        )?;
+        Ok(())
+    })
 }
 
 // ----- reconciliation, planning, committing -----
@@ -1444,7 +1465,7 @@ pub unsafe extern "C" fn zcashlc_migration_state(
         let Some(state) = reconcile_mined(&mut ctx)? else {
             return marshal_state(DerivedState::NotStarted, Zatoshis::ZERO);
         };
-        let marks = invalid_marks(&ctx.store_conn, &ctx.account_bytes)
+        let marks = invalid_marks(&mut ctx.wallet, &ctx.account_bytes)
             .map_err(|e| anyhow!("marks read failed: {e}"))?;
         let tip = ctx.tip()?;
         let derived = derive_state(Some(&state), tip, &marks);
@@ -1475,7 +1496,7 @@ pub unsafe extern "C" fn zcashlc_migration_progress(
         let Some(state) = reconcile_mined(&mut ctx)? else {
             return Ok(Box::into_raw(Box::new(FfiMigrationProgress::absent())));
         };
-        let marks = invalid_marks(&ctx.store_conn, &ctx.account_bytes)
+        let marks = invalid_marks(&mut ctx.wallet, &ctx.account_bytes)
             .map_err(|e| anyhow!("marks read failed: {e}"))?;
         let tip = ctx.tip()?;
         let value = match derive_state(Some(&state), tip, &marks) {
@@ -1576,7 +1597,7 @@ pub unsafe extern "C" fn zcashlc_migration_has_invalid_transfers(
         if matches!(state.status(), MigrationStatus::Complete) {
             return Ok(false);
         }
-        let marks = invalid_marks(&ctx.store_conn, &ctx.account_bytes)
+        let marks = invalid_marks(&mut ctx.wallet, &ctx.account_bytes)
             .map_err(|e| anyhow!("marks read failed: {e}"))?;
         if !marks.is_empty() {
             return Ok(true);
@@ -2157,7 +2178,7 @@ pub unsafe extern "C" fn zcashlc_migration_record_transfer_result(
                 } else {
                     "expired"
                 };
-                insert_invalid_mark(&ctx.store_conn, &ctx.account_bytes, id, reason)
+                insert_invalid_mark(&mut ctx.wallet, &ctx.account_bytes, id, reason)
                     .map_err(|e| anyhow!("marks write failed: {e}"))?;
                 Ok(true)
             }
@@ -2196,7 +2217,7 @@ pub unsafe extern "C" fn zcashlc_migration_restart_step(
                 }
             }
         }
-        clear_invalid_marks(&ctx.store_conn, &ctx.account_bytes)
+        clear_invalid_marks(&mut ctx.wallet, &ctx.account_bytes)
             .map_err(|e| anyhow!("marks clear failed: {e}"))?;
         match plan_and_cache(&mut ctx, false)? {
             Some((plan, reference_height, handle)) => {
@@ -3195,20 +3216,28 @@ mod tests {
         );
     }
 
+    /// Round-trips the invalid-transfer marks through the extension table that
+    /// `zcashlc_init_data_database`'s external migrations create (exercising the whole chain:
+    /// the `ext_zcashlc_*` schema migration, then the mediated extension-transaction access).
     #[test]
     fn invalid_marks_round_trip() {
-        let conn = Connection::open_in_memory().unwrap();
-        init_invalid_marks(&conn).unwrap();
+        use zcash_client_sqlite::WalletDb;
+        use zcash_client_sqlite::util::SystemClock;
+
+        let path = init_fixture_db("zcashlc_migration_invalid_marks_round_trip");
+        let network = parse_network(NETWORK_ID_MAINNET).expect("mainnet parses");
+        let mut wallet = WalletDb::for_path(&path, network, SystemClock, OsRng)
+            .expect("the fixture wallet opens");
         let account = [9u8; 16];
         let other = [8u8; 16];
-        assert!(invalid_marks(&conn, &account).unwrap().is_empty());
-        insert_invalid_mark(&conn, &account, MigrationTxId::new(4), "invalid_note").unwrap();
-        insert_invalid_mark(&conn, &account, MigrationTxId::new(2), "expired").unwrap();
-        insert_invalid_mark(&conn, &other, MigrationTxId::new(7), "invalid_note").unwrap();
-        assert_eq!(invalid_marks(&conn, &account).unwrap(), vec![2, 4]);
-        clear_invalid_marks(&conn, &account).unwrap();
-        assert!(invalid_marks(&conn, &account).unwrap().is_empty());
-        assert_eq!(invalid_marks(&conn, &other).unwrap(), vec![7]);
+        assert!(invalid_marks(&mut wallet, &account).unwrap().is_empty());
+        insert_invalid_mark(&mut wallet, &account, MigrationTxId::new(4), "invalid_note").unwrap();
+        insert_invalid_mark(&mut wallet, &account, MigrationTxId::new(2), "expired").unwrap();
+        insert_invalid_mark(&mut wallet, &other, MigrationTxId::new(7), "invalid_note").unwrap();
+        assert_eq!(invalid_marks(&mut wallet, &account).unwrap(), vec![2, 4]);
+        clear_invalid_marks(&mut wallet, &account).unwrap();
+        assert!(invalid_marks(&mut wallet, &account).unwrap().is_empty());
+        assert_eq!(invalid_marks(&mut wallet, &other).unwrap(), vec![7]);
     }
 
     /// On a freshly initialized wallet database with a chain tip but no spendable notes, locking


### PR DESCRIPTION
Addresses the blocking review comment on the `sdk_invalid_marks` side table: tables the SDK stores in the wallet database must carry the `ext_` prefix reserved for extensions and be created/evolved via sql migrations, never ad hoc, and engine-adjacent needs must be met through the upstream APIs rather than worked around with direct database access (the same directives as zodl-inc/slipstream#4).

- The table is renamed to `ext_zcashlc_orchard_ironwood_migration_invalid_marks` and is now created by a schemerz migration in the new `ext_schema` module, registered through `WalletMigrator::with_external_migrations` in `zcashlc_init_data_database` — so it shares the wallet database's schema versioning, per the extension contract documented in `zcash_client_sqlite::wallet::init`.
- The ad-hoc `CREATE TABLE IF NOT EXISTS` in the per-call `open` path is gone; every entry point now assumes init ran first, exactly as the engine's own store tables already did.
- Reads and writes of the marks go through `WalletDb::transactionally_with_extension`, whose authorizer confines writes to the `ext_` namespace, instead of a raw second connection. The set read arrives as a single `group_concat` row because the extension-transaction API currently exposes scalar queries only.
- The round-trip test now exercises the full chain (init-time external migration, then mediated access) against a real wallet database file.

This was the only ad-hoc DDL / direct-SQL site in the branch; the engine's store is reached exclusively through
`PoolMigrations::for_account`.

This code review checklist is intended to serve as a starting point for the author and reviewer, although it may not be appropriate for all types of changes (e.g. fixing a spelling typo in documentation).  For more in-depth discussion of how we think about code review, please see [Code Review Guidelines](../blob/main/CODE_REVIEW_GUIDELINES.md).

# Author
<!-- NOTE: Do not modify these when initially opening the pull request.  This is a checklist template that you tick off AFTER the pull request is created. -->
- [ ] Self-review: Did you review your own code in GitHub's web interface? Code often looks different when reviewing the diff in a browser, making it easier to spot potential bugs.
- [ ] Automated tests: Did you add appropriate automated tests for any code changes?
- [ ] Code coverage: Did you check the code coverage report for the automated tests?  While we are not looking for perfect coverage, the tool can point out potential cases that have been missed.
- [ ] Documentation: Did you update Docs as appropiate? (E.g [README.md](../blob/main/README.md), etc.)
- [ ] Run the app: Did you run the app and try the changes? 
- [ ] Did you provide Screenshots of what the App looks like before and after your changes as part of the description of this PR? (only applicable to UI Changes)
- [ ] Rebase and squash: Did you pull in the latest changes from the main branch and squash your commits before assigning a reviewer? Having your code up to date and squashed will make it easier for others to review. Use best judgement when squashing commits, as some changes (such as refactoring) might be easier to review as a separate commit.


# Reviewer

- [ ] Checklist review: Did you go through the code with the [Code Review Guidelines](../blob/main/CODE_REVIEW_GUIDELINES.md) checklist?
- [ ] Ad hoc review: Did you perform an ad hoc review?  _In addition to a first pass using the code review guidelines, do a second pass using your best judgement and experience which may identify additional questions or comments. Research shows that code review is most effective when done in multiple passes, where reviewers look for different things through each pass._
- [ ] Automated tests: Did you review the automated tests?
- [ ] Manual tests: Did you review the manual tests?_You will find manual testing guidelines under our [manual testing section](../blob/mater/docs/testing/manual_testing)_
- [ ] How is Code Coverage affected by this PR? _We encourage you to compare coverage befor and after your changes and when possible, leave it in a better place. [Learn More...](../blob/master/docs/testing/local_coverage.md)_
- [ ] Documentation: Did you review Docs, [README.md](../blob/master/README.md), [LICENSE.md](../blob/master/LICENSE.md), and [Architecture.md](../blob/master/docs/Architecture.md) as appropriate?
- [ ] Run the app: Did you run the app and try the changes? While the CI server runs the app to look for build failures or crashes, humans running the app are more likely to notice unexpected log messages, UI inconsistencies, or bad output data.