### PR TITLE
Select the ZIP 318 anchor bucket interval per network

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2774,11 +2774,11 @@ dependencies = [
  "zcash_keys",
  "zcash_note_encryption",
  "zcash_pool_migration",
- "zcash_primitives 0.30.0",
+ "zcash_primitives",
  "zcash_proofs",
  "zcash_protocol",
  "zcash_script",
- "zcash_transparent 0.10.0",
+ "zcash_transparent",
  "zcash_voting",
  "zeroize",
  "zip32",
@@ -3369,10 +3369,10 @@ dependencies = [
  "serde",
  "serde_with",
  "zcash_note_encryption",
- "zcash_primitives 0.30.0",
+ "zcash_primitives",
  "zcash_protocol",
  "zcash_script",
- "zcash_transparent 0.10.0",
+ "zcash_transparent",
 ]
 
 [[package]]
@@ -6656,7 +6656,7 @@ checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 [[package]]
 name = "vote-commitment-tree"
 version = "0.3.2"
-source = "git+https://github.com/zodl-inc/zcash_voting.git?rev=a4daaf77f793b35a98a3d811b920a01b95fbfa7a#a4daaf77f793b35a98a3d811b920a01b95fbfa7a"
+source = "git+https://github.com/zodl-inc/zcash_voting.git?rev=e5d885c2128f59ba39f44631dee537a0ade2f3fd#e5d885c2128f59ba39f44631dee537a0ade2f3fd"
 dependencies = [
  "anyhow",
  "ff",
@@ -6672,7 +6672,7 @@ dependencies = [
 [[package]]
 name = "vote-commitment-tree-client"
 version = "0.5.2"
-source = "git+https://github.com/zodl-inc/zcash_voting.git?rev=a4daaf77f793b35a98a3d811b920a01b95fbfa7a#a4daaf77f793b35a98a3d811b920a01b95fbfa7a"
+source = "git+https://github.com/zodl-inc/zcash_voting.git?rev=e5d885c2128f59ba39f44631dee537a0ade2f3fd#e5d885c2128f59ba39f44631dee537a0ade2f3fd"
 dependencies = [
  "base64",
  "ff",
@@ -7307,10 +7307,10 @@ dependencies = [
  "zcash_encoding",
  "zcash_keys",
  "zcash_note_encryption",
- "zcash_primitives 0.30.0",
+ "zcash_primitives",
  "zcash_protocol",
  "zcash_script",
- "zcash_transparent 0.10.0",
+ "zcash_transparent",
  "zip32",
  "zip321",
 ]
@@ -7355,10 +7355,10 @@ dependencies = [
  "zcash_encoding",
  "zcash_keys",
  "zcash_pool_migration",
- "zcash_primitives 0.30.0",
+ "zcash_primitives",
  "zcash_protocol",
  "zcash_script",
- "zcash_transparent 0.10.0",
+ "zcash_transparent",
  "zip32",
 ]
 
@@ -7398,7 +7398,7 @@ dependencies = [
  "zcash_address",
  "zcash_encoding",
  "zcash_protocol",
- "zcash_transparent 0.10.0",
+ "zcash_transparent",
  "zip32",
 ]
 
@@ -7430,38 +7430,8 @@ dependencies = [
  "shardtree",
  "zcash_client_backend",
  "zcash_keys",
- "zcash_primitives 0.30.0",
+ "zcash_primitives",
  "zcash_protocol",
-]
-
-[[package]]
-name = "zcash_primitives"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdbeccc05bfe63b6dee9e989c6ff5027421741562a4853c36504dd621f6a81b1"
-dependencies = [
- "blake2b_simd",
- "block-buffer 0.11.0-rc.3",
- "corez",
- "crypto-common 0.2.0-rc.1",
- "document-features",
- "equihash",
- "ff",
- "hex",
- "incrementalmerkletree",
- "jubjub",
- "memuse",
- "nonempty",
- "orchard",
- "rand_core 0.6.4",
- "redjubjub",
- "sapling-crypto",
- "sha2 0.10.9",
- "zcash_encoding",
- "zcash_note_encryption",
- "zcash_protocol",
- "zcash_script",
- "zcash_transparent 0.9.0",
 ]
 
 [[package]]
@@ -7491,7 +7461,7 @@ dependencies = [
  "zcash_note_encryption",
  "zcash_protocol",
  "zcash_script",
- "zcash_transparent 0.10.0",
+ "zcash_transparent",
 ]
 
 [[package]]
@@ -7512,7 +7482,7 @@ dependencies = [
  "sapling-crypto",
  "tracing",
  "xdg",
- "zcash_primitives 0.30.0",
+ "zcash_primitives",
 ]
 
 [[package]]
@@ -7555,31 +7525,6 @@ dependencies = [
 
 [[package]]
 name = "zcash_transparent"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72e0f8c142bed366ed5886dcfa8772ec90b5420cc127e6cdb76b6744c53a287b"
-dependencies = [
- "bip32",
- "bs58",
- "corez",
- "document-features",
- "getset",
- "hex",
- "nonempty",
- "ripemd 0.1.3",
- "secp256k1",
- "sha2 0.10.9",
- "subtle",
- "zcash_address",
- "zcash_encoding",
- "zcash_protocol",
- "zcash_script",
- "zcash_spec",
- "zip32",
-]
-
-[[package]]
-name = "zcash_transparent"
 version = "0.10.0"
 source = "git+https://github.com/zcash/librustzcash?rev=cd2b9a6a27dd784df3d245cd047bfeade21d9430#cd2b9a6a27dd784df3d245cd047bfeade21d9430"
 dependencies = [
@@ -7605,7 +7550,7 @@ dependencies = [
 [[package]]
 name = "zcash_voting"
 version = "1.0.0"
-source = "git+https://github.com/zodl-inc/zcash_voting.git?rev=a4daaf77f793b35a98a3d811b920a01b95fbfa7a#a4daaf77f793b35a98a3d811b920a01b95fbfa7a"
+source = "git+https://github.com/zodl-inc/zcash_voting.git?rev=e5d885c2128f59ba39f44631dee537a0ade2f3fd#e5d885c2128f59ba39f44631dee537a0ade2f3fd"
 dependencies = [
  "anyhow",
  "base64",
@@ -7651,7 +7596,7 @@ dependencies = [
  "zcash_client_backend",
  "zcash_client_sqlite",
  "zcash_keys",
- "zcash_primitives 0.29.0",
+ "zcash_primitives",
  "zcash_protocol",
  "zeroize",
  "zip32",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1597,7 +1597,7 @@ dependencies = [
 [[package]]
 name = "equihash"
 version = "0.3.0"
-source = "git+https://github.com/zcash/librustzcash?rev=3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb#3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb"
+source = "git+https://github.com/zcash/librustzcash?rev=cd2b9a6a27dd784df3d245cd047bfeade21d9430#cd2b9a6a27dd784df3d245cd047bfeade21d9430"
 dependencies = [
  "blake2b_simd",
  "corez",
@@ -1633,7 +1633,7 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.1"
-source = "git+https://github.com/zcash/librustzcash?rev=3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb#3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb"
+source = "git+https://github.com/zcash/librustzcash?rev=cd2b9a6a27dd784df3d245cd047bfeade21d9430#cd2b9a6a27dd784df3d245cd047bfeade21d9430"
 dependencies = [
  "blake2b_simd",
 ]
@@ -2773,12 +2773,12 @@ dependencies = [
  "zcash_client_sqlite",
  "zcash_keys",
  "zcash_note_encryption",
- "zcash_pool_migration_backend",
- "zcash_primitives",
+ "zcash_pool_migration",
+ "zcash_primitives 0.30.0",
  "zcash_proofs",
  "zcash_protocol",
  "zcash_script",
- "zcash_transparent",
+ "zcash_transparent 0.10.0",
  "zcash_voting",
  "zeroize",
  "zip32",
@@ -3349,8 +3349,8 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pczt"
-version = "0.8.0-rc.1"
-source = "git+https://github.com/zcash/librustzcash?rev=3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb#3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb"
+version = "0.8.0"
+source = "git+https://github.com/zcash/librustzcash?rev=cd2b9a6a27dd784df3d245cd047bfeade21d9430#cd2b9a6a27dd784df3d245cd047bfeade21d9430"
 dependencies = [
  "blake2b_simd",
  "bls12_381",
@@ -3369,10 +3369,10 @@ dependencies = [
  "serde",
  "serde_with",
  "zcash_note_encryption",
- "zcash_primitives",
+ "zcash_primitives 0.30.0",
  "zcash_protocol",
  "zcash_script",
- "zcash_transparent",
+ "zcash_transparent 0.10.0",
 ]
 
 [[package]]
@@ -3790,7 +3790,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
 dependencies = [
  "heck 0.5.0",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "log",
  "multimap 0.10.1",
  "petgraph 0.8.3",
@@ -3822,7 +3822,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -3855,7 +3855,7 @@ dependencies = [
  "derive-deftly",
  "libc",
  "paste",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -7238,7 +7238,7 @@ dependencies = [
 [[package]]
 name = "zcash_address"
 version = "0.13.0"
-source = "git+https://github.com/zcash/librustzcash?rev=3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb#3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb"
+source = "git+https://github.com/zcash/librustzcash?rev=cd2b9a6a27dd784df3d245cd047bfeade21d9430#cd2b9a6a27dd784df3d245cd047bfeade21d9430"
 dependencies = [
  "bech32",
  "bs58",
@@ -7251,7 +7251,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_backend"
 version = "0.24.0-rc.1"
-source = "git+https://github.com/zcash/librustzcash?rev=3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb#3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb"
+source = "git+https://github.com/zcash/librustzcash?rev=cd2b9a6a27dd784df3d245cd047bfeade21d9430#cd2b9a6a27dd784df3d245cd047bfeade21d9430"
 dependencies = [
  "arti-client",
  "base64",
@@ -7307,10 +7307,10 @@ dependencies = [
  "zcash_encoding",
  "zcash_keys",
  "zcash_note_encryption",
- "zcash_primitives",
+ "zcash_primitives 0.30.0",
  "zcash_protocol",
  "zcash_script",
- "zcash_transparent",
+ "zcash_transparent 0.10.0",
  "zip32",
  "zip321",
 ]
@@ -7318,7 +7318,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_sqlite"
 version = "0.22.0-rc.1"
-source = "git+https://github.com/zcash/librustzcash?rev=3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb#3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb"
+source = "git+https://github.com/zcash/librustzcash?rev=cd2b9a6a27dd784df3d245cd047bfeade21d9430#cd2b9a6a27dd784df3d245cd047bfeade21d9430"
 dependencies = [
  "bip32",
  "bitflags",
@@ -7354,18 +7354,19 @@ dependencies = [
  "zcash_client_backend",
  "zcash_encoding",
  "zcash_keys",
- "zcash_pool_migration_backend",
- "zcash_primitives",
+ "zcash_pool_migration",
+ "zcash_primitives 0.30.0",
  "zcash_protocol",
  "zcash_script",
- "zcash_transparent",
+ "zcash_transparent 0.10.0",
  "zip32",
 ]
 
 [[package]]
 name = "zcash_encoding"
 version = "0.4.0"
-source = "git+https://github.com/zcash/librustzcash?rev=3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb#3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1440921903cdb86133fb9e2fe800be488015db2939a30bedb413078a1acb0306"
 dependencies = [
  "corez",
  "hex",
@@ -7375,7 +7376,7 @@ dependencies = [
 [[package]]
 name = "zcash_keys"
 version = "0.15.0"
-source = "git+https://github.com/zcash/librustzcash?rev=3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb#3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb"
+source = "git+https://github.com/zcash/librustzcash?rev=cd2b9a6a27dd784df3d245cd047bfeade21d9430#cd2b9a6a27dd784df3d245cd047bfeade21d9430"
 dependencies = [
  "bech32",
  "bip32",
@@ -7397,7 +7398,7 @@ dependencies = [
  "zcash_address",
  "zcash_encoding",
  "zcash_protocol",
- "zcash_transparent",
+ "zcash_transparent 0.10.0",
  "zip32",
 ]
 
@@ -7415,9 +7416,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "zcash_pool_migration_backend"
-version = "0.1.0"
-source = "git+https://github.com/zcash/librustzcash?rev=3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb#3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb"
+name = "zcash_pool_migration"
+version = "0.1.0-alpha.1"
+source = "git+https://github.com/zcash/librustzcash?rev=cd2b9a6a27dd784df3d245cd047bfeade21d9430#cd2b9a6a27dd784df3d245cd047bfeade21d9430"
 dependencies = [
  "corez",
  "getset",
@@ -7429,14 +7430,44 @@ dependencies = [
  "shardtree",
  "zcash_client_backend",
  "zcash_keys",
- "zcash_primitives",
+ "zcash_primitives 0.30.0",
  "zcash_protocol",
 ]
 
 [[package]]
 name = "zcash_primitives"
 version = "0.29.0"
-source = "git+https://github.com/zcash/librustzcash?rev=3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb#3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdbeccc05bfe63b6dee9e989c6ff5027421741562a4853c36504dd621f6a81b1"
+dependencies = [
+ "blake2b_simd",
+ "block-buffer 0.11.0-rc.3",
+ "corez",
+ "crypto-common 0.2.0-rc.1",
+ "document-features",
+ "equihash",
+ "ff",
+ "hex",
+ "incrementalmerkletree",
+ "jubjub",
+ "memuse",
+ "nonempty",
+ "orchard",
+ "rand_core 0.6.4",
+ "redjubjub",
+ "sapling-crypto",
+ "sha2 0.10.9",
+ "zcash_encoding",
+ "zcash_note_encryption",
+ "zcash_protocol",
+ "zcash_script",
+ "zcash_transparent 0.9.0",
+]
+
+[[package]]
+name = "zcash_primitives"
+version = "0.30.0"
+source = "git+https://github.com/zcash/librustzcash?rev=cd2b9a6a27dd784df3d245cd047bfeade21d9430#cd2b9a6a27dd784df3d245cd047bfeade21d9430"
 dependencies = [
  "blake2b_simd",
  "block-buffer 0.11.0-rc.3",
@@ -7460,14 +7491,13 @@ dependencies = [
  "zcash_note_encryption",
  "zcash_protocol",
  "zcash_script",
- "zcash_transparent",
+ "zcash_transparent 0.10.0",
 ]
 
 [[package]]
 name = "zcash_proofs"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b91fb0b420fb66a765f1fa92ab7a6b631aa54c08415415ef6185256826e74fbd"
+version = "0.30.0"
+source = "git+https://github.com/zcash/librustzcash?rev=cd2b9a6a27dd784df3d245cd047bfeade21d9430#cd2b9a6a27dd784df3d245cd047bfeade21d9430"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -7482,13 +7512,13 @@ dependencies = [
  "sapling-crypto",
  "tracing",
  "xdg",
- "zcash_primitives",
+ "zcash_primitives 0.30.0",
 ]
 
 [[package]]
 name = "zcash_protocol"
-version = "0.10.0"
-source = "git+https://github.com/zcash/librustzcash?rev=3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb#3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb"
+version = "0.10.1"
+source = "git+https://github.com/zcash/librustzcash?rev=cd2b9a6a27dd784df3d245cd047bfeade21d9430#cd2b9a6a27dd784df3d245cd047bfeade21d9430"
 dependencies = [
  "corez",
  "document-features",
@@ -7526,7 +7556,32 @@ dependencies = [
 [[package]]
 name = "zcash_transparent"
 version = "0.9.0"
-source = "git+https://github.com/zcash/librustzcash?rev=3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb#3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72e0f8c142bed366ed5886dcfa8772ec90b5420cc127e6cdb76b6744c53a287b"
+dependencies = [
+ "bip32",
+ "bs58",
+ "corez",
+ "document-features",
+ "getset",
+ "hex",
+ "nonempty",
+ "ripemd 0.1.3",
+ "secp256k1",
+ "sha2 0.10.9",
+ "subtle",
+ "zcash_address",
+ "zcash_encoding",
+ "zcash_protocol",
+ "zcash_script",
+ "zcash_spec",
+ "zip32",
+]
+
+[[package]]
+name = "zcash_transparent"
+version = "0.10.0"
+source = "git+https://github.com/zcash/librustzcash?rev=cd2b9a6a27dd784df3d245cd047bfeade21d9430#cd2b9a6a27dd784df3d245cd047bfeade21d9430"
 dependencies = [
  "bip32",
  "bs58",
@@ -7596,7 +7651,7 @@ dependencies = [
  "zcash_client_backend",
  "zcash_client_sqlite",
  "zcash_keys",
- "zcash_primitives",
+ "zcash_primitives 0.29.0",
  "zcash_protocol",
  "zeroize",
  "zip32",
@@ -7674,7 +7729,7 @@ dependencies = [
 [[package]]
 name = "zip321"
 version = "0.9.0-rc.1"
-source = "git+https://github.com/zcash/librustzcash?rev=3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb#3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb"
+source = "git+https://github.com/zcash/librustzcash?rev=cd2b9a6a27dd784df3d245cd047bfeade21d9430#cd2b9a6a27dd784df3d245cd047bfeade21d9430"
 dependencies = [
  "base64",
  "nom",
@@ -7721,3 +7776,8 @@ dependencies = [
 name = "orchard"
 version = "0.15.0"
 source = "git+https://github.com/zcash/orchard.git?rev=3bd2b736d1273226595773265313fc3f3428af16#3bd2b736d1273226595773265313fc3f3428af16"
+
+[[patch.unused]]
+name = "zcash_encoding"
+version = "0.5.0"
+source = "git+https://github.com/zcash/librustzcash?rev=cd2b9a6a27dd784df3d245cd047bfeade21d9430#cd2b9a6a27dd784df3d245cd047bfeade21d9430"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ orchard = { version = "0.15", features = ["unstable-voting-circuits"] }
 pasta_curves = "0.5"
 ff = "0.13"
 sapling = { package = "sapling-crypto", version = "0.7", default-features = false }
-transparent = { package = "zcash_transparent", version = "0.9", default-features = false }
+transparent = { package = "zcash_transparent", version = "0.10", default-features = false }
 zcash_address = { version = "0.13" }
 zcash_client_backend = { version = "0.24.0-rc.1", features = [
     "lightwalletd-tonic-tls-webpki-roots",
@@ -31,17 +31,16 @@ zcash_client_backend = { version = "0.24.0-rc.1", features = [
 ] }
 zcash_client_sqlite = { version = "0.22.0-rc.1", features = ["orchard", "transparent-inputs", "unstable", "serde"] }
 zcash_note_encryption = "0.4.1"
-zcash_primitives = "0.29"
-zcash_proofs = "0.29"
+zcash_primitives = "0.30"
+zcash_proofs = "0.30"
 zcash_protocol = { version = "0.10", features = ["local-consensus"] }
-# Not on crates.io yet — the pool-migration engine lives on librustzcash main (its
-# SQLite store moved into `zcash_client_sqlite::pool_migration`, so the old separate
-# store crate is gone). Direct git dependency at the same rev as the
-# [patch.crates-io] family below so the whole graph stays one family instance.
-zcash_pool_migration_backend = { git = "https://github.com/zcash/librustzcash", rev = "3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb", features = ["wallet"] }
+# The pool-migration engine, renamed from `zcash_pool_migration_backend` and now an
+# alpha release on crates.io; it rides the same [patch.crates-io] rev as the rest of
+# the family below (its SQLite store lives in `zcash_client_sqlite::pool_migration`).
+zcash_pool_migration = { version = "0.1.0-alpha.1", features = ["wallet"] }
 zcash_script = "0.4"
 zip32 = "0.2"
-pczt = { version = "0.8.0-rc.1", features = ["prover", "orchard", "sapling", "signer"] }
+pczt = { version = "0.8", features = ["prover", "orchard", "sapling", "signer"] }
 shardtree = "0.7"
 
 # Keystone hardware-wallet batch signing for the Orchard migration flow.
@@ -129,31 +128,37 @@ lto = true
 
 # The Ironwood-era librustzcash family is not on crates.io yet; unreleased
 # sources ride [patch.crates-io] against the canonical repo — never direct
-# git+branch dependencies. The rev is current zcash/librustzcash main — the
-# same rev the zcash_voting workspace rides, so the whole graph resolves to a
-# single family instance. Bump it deliberately (build + OfflineTests green),
-# and delete the whole block at the 0.24-era crates.io release.
+# git+branch dependencies. The rev is a commit hash on
+# zcash/librustzcash's `feature/configurable-anchor-bucket-interval`, which is
+# what supplies the configurable anchor retention interval this SDK selects per
+# network in `rust/src/lib.rs`. Bump it deliberately (build + OfflineTests
+# green), and delete the whole block at the 0.24-era crates.io release.
 [patch.crates-io]
 zcash_voting = { git = "https://github.com/zodl-inc/zcash_voting.git", rev = "a4daaf77f793b35a98a3d811b920a01b95fbfa7a" }
 
-# Pin the whole librustzcash stack to a single git rev carrying the merged Ironwood
-# historical selector, pending a crates.io release. zcash_voting no longer hard-pins
-# librustzcash (it declares crates.io versions and patches from its own root), so this
-# workspace's patch governs the rev for the entire graph and everything resolves to one
-# copy. Bump this rev in one place to advance the stack.
-# librustzcash@3a10e7f itself patches orchard to the ZIP 374 deferred-anchor-builder
+# Pin the whole librustzcash stack to a single git rev, pending a crates.io release.
+# zcash_voting no longer hard-pins librustzcash (it declares crates.io versions and
+# patches from its own root), so this workspace's patch governs the rev for the entire
+# graph and everything resolves to one copy. Bump this rev in one place to advance the
+# stack — but note that this rev carries the zcash_primitives 0.30 / zcash_transparent
+# 0.10 releases, which zcash_voting's own `zcash_primitives = "0.29.0"` requirement
+# cannot accept; that pin has to move first or the graph splits into two
+# zcash_primitives copies.
+# librustzcash itself patches orchard to the ZIP 374 deferred-anchor-builder
 # rev below (unreleased); [patch] does not propagate to consumers, so this workspace
 # declares the identical rev. Drop when orchard releases it.
 orchard = { git = "https://github.com/zcash/orchard.git", rev = "3bd2b736d1273226595773265313fc3f3428af16" }
-equihash = { git = "https://github.com/zcash/librustzcash", rev = "3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb" }
-f4jumble = { git = "https://github.com/zcash/librustzcash", rev = "3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb" }
-pczt = { git = "https://github.com/zcash/librustzcash", rev = "3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb" }
-zcash_address = { git = "https://github.com/zcash/librustzcash", rev = "3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb" }
-zcash_client_backend = { git = "https://github.com/zcash/librustzcash", rev = "3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb" }
-zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash", rev = "3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb" }
-zcash_encoding = { git = "https://github.com/zcash/librustzcash", rev = "3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb" }
-zcash_keys = { git = "https://github.com/zcash/librustzcash", rev = "3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb" }
-zcash_primitives = { git = "https://github.com/zcash/librustzcash", rev = "3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb" }
-zcash_protocol = { git = "https://github.com/zcash/librustzcash", rev = "3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb" }
-zcash_transparent = { git = "https://github.com/zcash/librustzcash", rev = "3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb" }
-zip321 = { git = "https://github.com/zcash/librustzcash", rev = "3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb" }
+equihash = { git = "https://github.com/zcash/librustzcash", rev = "cd2b9a6a27dd784df3d245cd047bfeade21d9430" }
+f4jumble = { git = "https://github.com/zcash/librustzcash", rev = "cd2b9a6a27dd784df3d245cd047bfeade21d9430" }
+pczt = { git = "https://github.com/zcash/librustzcash", rev = "cd2b9a6a27dd784df3d245cd047bfeade21d9430" }
+zcash_address = { git = "https://github.com/zcash/librustzcash", rev = "cd2b9a6a27dd784df3d245cd047bfeade21d9430" }
+zcash_client_backend = { git = "https://github.com/zcash/librustzcash", rev = "cd2b9a6a27dd784df3d245cd047bfeade21d9430" }
+zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash", rev = "cd2b9a6a27dd784df3d245cd047bfeade21d9430" }
+zcash_encoding = { git = "https://github.com/zcash/librustzcash", rev = "cd2b9a6a27dd784df3d245cd047bfeade21d9430" }
+zcash_keys = { git = "https://github.com/zcash/librustzcash", rev = "cd2b9a6a27dd784df3d245cd047bfeade21d9430" }
+zcash_pool_migration = { git = "https://github.com/zcash/librustzcash", rev = "cd2b9a6a27dd784df3d245cd047bfeade21d9430" }
+zcash_primitives = { git = "https://github.com/zcash/librustzcash", rev = "cd2b9a6a27dd784df3d245cd047bfeade21d9430" }
+zcash_proofs = { git = "https://github.com/zcash/librustzcash", rev = "cd2b9a6a27dd784df3d245cd047bfeade21d9430" }
+zcash_protocol = { git = "https://github.com/zcash/librustzcash", rev = "cd2b9a6a27dd784df3d245cd047bfeade21d9430" }
+zcash_transparent = { git = "https://github.com/zcash/librustzcash", rev = "cd2b9a6a27dd784df3d245cd047bfeade21d9430" }
+zip321 = { git = "https://github.com/zcash/librustzcash", rev = "cd2b9a6a27dd784df3d245cd047bfeade21d9430" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -134,16 +134,16 @@ lto = true
 # network in `rust/src/lib.rs`. Bump it deliberately (build + OfflineTests
 # green), and delete the whole block at the 0.24-era crates.io release.
 [patch.crates-io]
-zcash_voting = { git = "https://github.com/zodl-inc/zcash_voting.git", rev = "a4daaf77f793b35a98a3d811b920a01b95fbfa7a" }
+zcash_voting = { git = "https://github.com/zodl-inc/zcash_voting.git", rev = "e5d885c2128f59ba39f44631dee537a0ade2f3fd" }
 
 # Pin the whole librustzcash stack to a single git rev, pending a crates.io release.
 # zcash_voting no longer hard-pins librustzcash (it declares crates.io versions and
 # patches from its own root), so this workspace's patch governs the rev for the entire
 # graph and everything resolves to one copy. Bump this rev in one place to advance the
-# stack — but note that this rev carries the zcash_primitives 0.30 / zcash_transparent
-# 0.10 releases, which zcash_voting's own `zcash_primitives = "0.29.0"` requirement
-# cannot accept; that pin has to move first or the graph splits into two
-# zcash_primitives copies.
+# stack. This rev carries the zcash_primitives 0.30 / zcash_transparent 0.10 releases,
+# and the zcash_voting pin above is on the matching 0.30 generation, so the patch
+# reaches it too and the graph stays single-copy. Keep the two in step: a zcash_voting
+# rev on the 0.29 generation cannot accept this patch and the graph splits.
 # librustzcash itself patches orchard to the ZIP 374 deferred-anchor-builder
 # rev below (unreleased); [patch] does not propagate to consumers, so this workspace
 # declares the identical rev. Drop when orchard releases it.

--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -165,6 +165,22 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   per-account owner (making re-locking idempotent), every selection path keeps
   excluding locked notes, and `zcashlc_migration_unlock_residual` still clears
   the account's locks wholesale.
+- The anchor bucket interval is now selected per network. Mainnet keeps the ZIP
+  318 grid (144 blocks); testnet and custom-parameter networks retain durable
+  anchor checkpoints every 12 blocks instead, so a pool migration crosses enough
+  anchor boundaries to be exercised in a test run. The transfer and preparation
+  delay distributions are derived from that interval, so the whole ZIP 318
+  schedule is compressed by the same factor rather than a short grid being
+  crossed with three-hour delays. Nothing crosses the FFI for this: every wallet
+  handle is opened with the interval its already-known `network_id` selects, so
+  the retention grid and the grid migrations anchor to cannot disagree. Existing
+  testnet wallets with a migration already in flight are unaffected — the
+  interval a migration was committed under is recorded with it and keeps being
+  retained until the run ends.
+- The pool-migration engine crate is now `zcash_pool_migration` (renamed from
+  `zcash_pool_migration_backend`) and is consumed from crates.io through the
+  same `[patch.crates-io]` family pin as the rest of librustzcash, rather than
+  as a standalone git dependency.
 
 ## 2.6.0-alpha.6 - 2026-06-26
 

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -42,6 +42,7 @@ use zcash_client_backend::{
         Account, AccountBirthday, AccountPurpose, CoinbaseFilter, InputSource, MaxSpendMode,
         SeedRelevance, TransactionDataRequest, TransactionStatus, TransparentKeyOrigin,
         WalletCommitmentTrees, WalletRead, WalletWrite, Zip32Derivation,
+        anchor_retention::AnchorRetentionInterval,
         chain::{CommitmentTreeRoot, scan_cached_blocks},
         scanning::ScanPriority,
         wallet::{
@@ -72,6 +73,7 @@ use zcash_client_sqlite::{
 use zcash_primitives::{
     block::BlockHash,
     merkle_tree::HashSer,
+    transaction::builder::BundlePadding,
     transaction::{Transaction, TxId},
 };
 use zcash_proofs::prover::LocalTxProver;
@@ -126,7 +128,38 @@ where
     }
 }
 
+/// The anchor bucket interval used on every network other than production mainnet: 12 blocks, so
+/// that a ZIP 318 pool migration passes through enough anchor boundaries to be exercised end to
+/// end in a test run instead of over days of chain.
+///
+/// Shortening the grid also shortens the transfer and preparation delays, which the migration
+/// backend derives from it, so this is the only value to choose.
+const TEST_ANCHOR_RETENTION_INTERVAL: AnchorRetentionInterval =
+    AnchorRetentionInterval::custom(NonZeroU32::new(12).expect("12 is nonzero"));
+
+/// The grid on which a wallet on `network` retains note commitment tree checkpoints as durable
+/// anchors, and correspondingly the grid its pool migrations anchor their transfers to.
+///
+/// Production mainnet gets the ZIP 318 interval, which every wallet on that network must share:
+/// the anonymity set a boundary anchor provides is exactly the set of transfers that chose the same
+/// boundary, so a wallet retaining a different grid than its peers is distinguishable from them.
+/// Testnet and custom-parameter networks — which exist to exercise the migration, not to hide in a
+/// crowd — get [`TEST_ANCHOR_RETENTION_INTERVAL`].
+pub(crate) fn anchor_retention_interval(network: NetworkParams) -> AnchorRetentionInterval {
+    match network {
+        NetworkParams::Standard(MainNetwork) => AnchorRetentionInterval::ZIP_318,
+        NetworkParams::Standard(TestNetwork) | NetworkParams::Custom { .. } => {
+            TEST_ANCHOR_RETENTION_INTERVAL
+        }
+    }
+}
+
 /// Helper method for construcing a WalletDb value from path data provided over the FFI.
+///
+/// The returned handle retains its durable anchor checkpoints on the interval
+/// [`anchor_retention_interval`] selects for `network`, which is also the grid the next pool
+/// migration planned over this wallet will anchor to. Every wallet handle the FFI hands out is
+/// built here, so the two cannot be configured inconsistently.
 ///
 /// # Safety
 ///
@@ -145,6 +178,7 @@ unsafe fn wallet_db(
         slice::from_raw_parts(db_data, db_data_len)
     }));
     WalletDb::for_path(db_data, network, SystemClock, OsRng)
+        .map(|db| db.with_anchor_retention_interval(anchor_retention_interval(network)))
         .map_err(|e| anyhow!("Error opening wallet database connection: {}", e))
 }
 
@@ -2789,9 +2823,9 @@ pub unsafe extern "C" fn zcashlc_create_pczt_from_proposal(
                 OvkPolicy::Sender,
                 &proposal,
                 // Use the transaction's default expiry height and the default Orchard
-                // bundle type; the SDK does not expose overrides for these.
+                // bundle padding; the SDK does not expose overrides for these.
                 None,
-                orchard::builder::BundleType::DEFAULT,
+                BundlePadding::DEFAULT,
             )
             .map_err(|e| anyhow!("Error creating PCZT from single-step proposal: {}", e))?;
 
@@ -4476,4 +4510,51 @@ pub(crate) fn parse_optional_height(value: i64) -> anyhow::Result<Option<BlockHe
         -1 => None,
         _ => Some(BlockHeight::try_from(value)?),
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Only the production network gets the ZIP 318 grid, whose anonymity set depends on every
+    /// wallet sharing it. Testnet gets the shortened grid, so a migration passes through anchor
+    /// boundaries fast enough to be exercised.
+    #[test]
+    fn only_mainnet_retains_anchors_on_the_zip_318_grid() {
+        assert_eq!(
+            anchor_retention_interval(NetworkParams::Standard(MainNetwork)),
+            AnchorRetentionInterval::ZIP_318,
+        );
+        assert_eq!(
+            anchor_retention_interval(NetworkParams::Standard(TestNetwork)),
+            TEST_ANCHOR_RETENTION_INTERVAL,
+        );
+        assert_eq!(TEST_ANCHOR_RETENTION_INTERVAL.block_count().get(), 12);
+    }
+
+    /// A custom-parameter network is a test deployment even when it borrows mainnet's address
+    /// encoding, so it must not inherit the production grid along with that identity.
+    #[test]
+    fn a_mainnet_based_custom_network_is_not_the_production_network() {
+        let height = Some(BlockHeight::from_u32(1));
+        let custom = NetworkParams::Custom {
+            base: NetworkType::Main,
+            local: LocalNetwork {
+                overwinter: height,
+                sapling: height,
+                blossom: height,
+                heartwood: height,
+                canopy: height,
+                nu5: height,
+                nu6: height,
+                nu6_1: height,
+                nu6_2: height,
+                nu6_3: height,
+            },
+        };
+        assert_eq!(
+            anchor_retention_interval(custom),
+            TEST_ANCHOR_RETENTION_INTERVAL,
+        );
+    }
 }

--- a/rust/src/migration.rs
+++ b/rust/src/migration.rs
@@ -1,5 +1,5 @@
 //! FFI over the final Orchard→Ironwood pool-migration engine
-//! ([`zcash_pool_migration_backend`] + the `zcash_client_sqlite::pool_migration` store).
+//! ([`zcash_pool_migration`] + the `zcash_client_sqlite::pool_migration` store).
 //!
 //! The engine is a set of free functions over traits — [`crate::migration_engine::Backend`] wires
 //! this SDK's wallet database (and the account-keyed migration store living inside it) into them;
@@ -71,11 +71,11 @@ use zcash_protocol::consensus::{
 use zcash_protocol::value::Zatoshis;
 use zcash_protocol::{PoolType, ShieldedPool, TxId};
 
-use zcash_pool_migration_backend::engine::{
+use zcash_pool_migration::engine::{
     self, MigrationPlan, MigrationState, MigrationStatus, MigrationTransaction, MigrationTxId,
     MigrationTxKind, MigrationTxState, PoolMigrationRead, PoolMigrationWrite,
 };
-use zcash_pool_migration_backend::wallet::WalletMigrationProver;
+use zcash_pool_migration::wallet::WalletMigrationProver;
 
 use crate::migration_engine::{Backend, MigrationWallet};
 use crate::migration_finalize;
@@ -380,7 +380,7 @@ fn compute_plan(ctx: &mut CallCtx) -> anyhow::Result<Option<(MigrationPlan, Bloc
 ///   funding-note order differ from broadcast order.
 fn schedule_rows(
     funding_notes: &[Zatoshis],
-    schedule: &[zcash_pool_migration_backend::scheduling::Schedule],
+    schedule: &[zcash_pool_migration::scheduling::Schedule],
     prep_tx_count: u32,
 ) -> anyhow::Result<Vec<(MigrationTxId, Zatoshis, BlockHeight, BlockHeight)>> {
     if funding_notes.len() != schedule.len() {
@@ -640,6 +640,9 @@ fn commit_or_resume(
             state.note_split().clone(),
             state.preparation().clone(),
             transactions,
+            // Rebuilding transfers does not re-plan the run, so it stays on the grid it was
+            // committed under.
+            state.anchor_bucket_interval(),
         );
         let mut backend = Backend::new(&ctx.wallet, ctx.account, None, &mut ctx.store_conn)?;
         backend.replace_migration(&state)?;
@@ -1439,7 +1442,7 @@ fn marshal_state(
 /// The account's live spendable Orchard balance (what is still in the old pool).
 fn remaining_orchard(ctx: &mut CallCtx) -> anyhow::Result<Zatoshis> {
     let backend = Backend::new(&ctx.wallet, ctx.account, None, &mut ctx.store_conn)?;
-    use zcash_pool_migration_backend::engine::MigrationBackend;
+    use zcash_pool_migration::engine::MigrationBackend;
     let values = backend.spendable_orchard_note_values()?;
     values
         .into_iter()
@@ -2212,6 +2215,7 @@ pub unsafe extern "C" fn zcashlc_migration_restart_step(
                         state.note_split().clone(),
                         state.preparation().clone(),
                         state.transactions().clone(),
+                        state.anchor_bucket_interval(),
                     );
                     backend.replace_migration(&cancelled)?;
                 }
@@ -2742,9 +2746,9 @@ mod tests {
     use super::*;
     use rand::SeedableRng;
     use rand::rngs::StdRng;
-    use zcash_pool_migration_backend::note_splitting::NoteSplitPlan;
-    use zcash_pool_migration_backend::preparation::PreparationPlan;
-    use zcash_pool_migration_backend::scheduling;
+    use zcash_pool_migration::note_splitting::NoteSplitPlan;
+    use zcash_pool_migration::preparation::PreparationPlan;
+    use zcash_pool_migration::scheduling::{self, AnchorBucketInterval, SchedulingParams};
 
     fn zat(v: u64) -> Zatoshis {
         Zatoshis::from_u64(v).unwrap()
@@ -2918,6 +2922,7 @@ mod tests {
             .unwrap(),
             PreparationPlan::from_parts(Vec::new(), Vec::new()),
             transactions,
+            AnchorBucketInterval::ZIP_318,
         )
     }
 
@@ -3028,7 +3033,7 @@ mod tests {
     #[test]
     fn schedule_rows_sort_chronologically_with_prep_offset() {
         let mut rng = StdRng::seed_from_u64(7);
-        let schedule = scheduling::schedule(h(1_000), 5, &mut rng);
+        let schedule = scheduling::schedule(&SchedulingParams::ZIP_318, h(1_000), 5, &mut rng);
         let amounts: Vec<Zatoshis> = (1..=5).map(|i| zat(i * 100_000_000)).collect();
         let rows = schedule_rows(&amounts, &schedule, 3).unwrap();
         assert_eq!(rows.len(), 5);
@@ -3050,7 +3055,7 @@ mod tests {
     #[test]
     fn schedule_rows_reject_length_mismatch() {
         let mut rng = StdRng::seed_from_u64(7);
-        let schedule = scheduling::schedule(h(1_000), 3, &mut rng);
+        let schedule = scheduling::schedule(&SchedulingParams::ZIP_318, h(1_000), 3, &mut rng);
         let amounts = vec![zat(100)];
         assert!(schedule_rows(&amounts, &schedule, 0).is_err());
     }
@@ -3166,6 +3171,7 @@ mod tests {
             .unwrap(),
             PreparationPlan::from_parts(Vec::new(), Vec::new()),
             transactions,
+            AnchorBucketInterval::ZIP_318,
         );
 
         let schedule_ptr =
@@ -3509,7 +3515,7 @@ mod tests {
         )
         .into_option()
         .expect("valid fixture note parts");
-        zcash_pool_migration_backend::build::build_transfer_pczt(
+        zcash_pool_migration::build::build_transfer_pczt(
             &MAIN_NETWORK,
             target_height,
             expiry_height,
@@ -3727,6 +3733,7 @@ mod tests {
             base.note_split().clone(),
             base.preparation().clone(),
             transactions,
+            base.anchor_bucket_interval(),
         );
         store_fixture_state(&path, &account, &state);
 
@@ -3782,8 +3789,8 @@ mod tests {
 
     // ----- prove dispatch (kind routing + transient/hard error mapping) -----
 
-    use zcash_pool_migration_backend::engine::MigrationProver;
-    use zcash_pool_migration_backend::wallet::WalletProveError;
+    use zcash_pool_migration::engine::MigrationProver;
+    use zcash_pool_migration::wallet::WalletProveError;
     use zcash_protocol::consensus::BranchId;
 
     /// The prover error type the dispatch tests fail with: the REAL upstream
@@ -3823,6 +3830,10 @@ mod tests {
             self.calls.push(ProveCall::Preparation(anchor));
             Ok(pczt)
         }
+
+        fn anchor_bucket_interval(&self) -> AnchorBucketInterval {
+            AnchorBucketInterval::ZIP_318
+        }
     }
 
     /// A test prover that fails its one expected call with the configured error.
@@ -3847,6 +3858,10 @@ mod tests {
             _anchor: BlockHeight,
         ) -> Result<pczt::Pczt, Self::Error> {
             Err(self.error.take().expect("the prover is consulted once"))
+        }
+
+        fn anchor_bucket_interval(&self) -> AnchorBucketInterval {
+            AnchorBucketInterval::ZIP_318
         }
     }
 
@@ -3903,6 +3918,7 @@ mod tests {
             base.note_split().clone(),
             base.preparation().clone(),
             transactions,
+            base.anchor_bucket_interval(),
         )
     }
 
@@ -4163,6 +4179,7 @@ mod tests {
             base.note_split().clone(),
             base.preparation().clone(),
             transactions,
+            base.anchor_bucket_interval(),
         )
     }
 

--- a/rust/src/migration_engine.rs
+++ b/rust/src/migration_engine.rs
@@ -1,6 +1,6 @@
 //! The adapter wiring this SDK's wallet database into the pool-migration engine's traits.
 //!
-//! [`zcash_pool_migration_backend`]'s engine works over four traits — `MigrationBackend` (notes and
+//! [`zcash_pool_migration`]'s engine works over four traits — `MigrationBackend` (notes and
 //! chain tip), `MigrationCrypto` (viewing key, note plaintexts, signing), and `PoolMigrationRead` /
 //! `PoolMigrationWrite` (the store). The crate ships its own `wallet::WalletMigration` adapter, but
 //! that adapter requires a `UnifiedSpendingKey` unconditionally (it derives the Orchard FVK from
@@ -32,11 +32,12 @@ use zcash_client_sqlite::AccountUuid;
 use zcash_client_sqlite::pool_migration::orchard_ironwood::PoolMigrations;
 use zcash_client_sqlite::util::SystemClock;
 use zcash_keys::keys::UnifiedSpendingKey;
-use zcash_pool_migration_backend::build::sign_pczt;
-use zcash_pool_migration_backend::engine::{
+use zcash_pool_migration::build::sign_pczt;
+use zcash_pool_migration::engine::{
     MigrationBackend, MigrationCrypto, MigrationState, MigrationTxId, MigrationTxState,
     PoolMigrationRead, PoolMigrationWrite,
 };
+use zcash_pool_migration::scheduling::SchedulingParams;
 use zcash_protocol::ShieldedPool;
 use zcash_protocol::consensus::BlockHeight;
 use zcash_protocol::value::Zatoshis;
@@ -153,6 +154,17 @@ impl MigrationBackend for Backend<'_> {
             .chain_height()
             .map_err(|e| anyhow!("chain height lookup failed: {e}"))?
             .ok_or_else(|| anyhow!("the wallet has no chain tip yet; sync first"))
+    }
+
+    /// The anchor bucket grid is the wallet's own anchor retention interval (selected per network
+    /// in [`crate::wallet_db`]), so a transfer can only anchor to a boundary whose checkpoint this
+    /// wallet retains; the delay distributions are derived from that interval by the ZIP 318
+    /// ratios, which reproduces the specified schedule exactly on the standard 144-block grid and
+    /// compresses it by the same factor on a shortened one.
+    fn scheduling_params(&self) -> SchedulingParams {
+        SchedulingParams::new_with_default_distributions(
+            self.wallet.anchor_retention_interval().into(),
+        )
     }
 }
 

--- a/rust/src/migration_finalize.rs
+++ b/rust/src/migration_finalize.rs
@@ -1,6 +1,6 @@
 //! Prove-at-broadcast-time support for the migration engine (ZIP 374 deferred anchor/witness).
 //!
-//! The engine (`zcash_pool_migration_backend`) commits every migration transaction fully built and
+//! The engine (`zcash_pool_migration`) commits every migration transaction fully built and
 //! signed, with its Orchard spend witnesses and anchors left unset — the durable artifact in
 //! `MigrationTransaction::pczt()` never changes after commit. At proving time this module routes
 //! each due transaction through the UPSTREAM prover: [`prove_due_transaction`] dispatches on the
@@ -19,9 +19,10 @@
 //!   instead of timestamping the wallet's recent activity with a fresh anchor. A transfer with no
 //!   stored boundary is a corrupt store and a HARD error — never a fallback to the natural
 //!   anchor. Boundary checkpoints stay durably witnessable because upstream anchor-checkpoint
-//!   retention (`ANCHOR_RETENTION_INTERVAL`, active from NU6.3 activation) retains every
-//!   144th-block checkpoint — the same 144-block grid the engine draws boundaries on
-//!   (`scheduling::BOUNDARY_MODULUS`).
+//!   retention (active from NU6.3 activation) keeps every boundary of the wallet's anchor
+//!   retention interval — necessarily the same grid the engine draws boundaries on, since the
+//!   engine reads that interval back off the wallet. [`crate::anchor_retention_interval`] is where
+//!   the SDK selects it per network.
 //! - PREPARATIONS carry no drawn boundary (they anchor to their already-mined dependencies, not
 //!   to a bucketed boundary) and prove against the wallet's current natural anchor
 //!   ([`natural_anchor_height`]) via `engine::prove_preparation`.
@@ -36,10 +37,10 @@
 
 use anyhow::anyhow;
 use zcash_client_backend::data_api::WalletRead;
-use zcash_pool_migration_backend::engine::{
+use zcash_pool_migration::engine::{
     self, MigrationProver, MigrationState, MigrationTxId, MigrationTxKind,
 };
-use zcash_pool_migration_backend::wallet::WalletProveError;
+use zcash_pool_migration::wallet::WalletProveError;
 use zcash_protocol::consensus::BlockHeight;
 
 use crate::migration::proving_unavailable;

--- a/rust/src/migration_keystone.rs
+++ b/rust/src/migration_keystone.rs
@@ -36,7 +36,7 @@ use ur_registry::zcash::zcash_sign_batch::ZcashSignBatch;
 /// PCZT with the account's ZIP 32 derivation path, so an external signer (Keystone) can derive
 /// its own full viewing key and recognize which of its accounts a spend belongs to.
 ///
-/// This SDK's engine call (`zcash_pool_migration_backend::engine::build_preparation_unsigned`,
+/// This SDK's engine call (`zcash_pool_migration::engine::build_preparation_unsigned`,
 /// driven by `migration.rs`'s `commit_or_resume`) never sets this metadata — it only runs the
 /// shared `Creator`/`IoFinalizer` plumbing, with no `Updater` step for spend derivation (unlike
 /// `zcash_client_backend::data_api::wallet::create_pczt_from_proposal`, which sets it for
@@ -335,7 +335,7 @@ mod tests {
     use shardtree::store::memory::MemoryShardStore;
     use ur_registry::zcash::zcash_sign_batch::ZcashSignBatch;
     use zcash_note_encryption::try_note_decryption;
-    use zcash_primitives::transaction::builder::{BuildConfig, Builder, PcztResult};
+    use zcash_primitives::transaction::builder::{BuildConfig, Builder, BundlePadding, PcztResult};
     use zcash_primitives::transaction::fees::zip317;
     use zcash_protocol::consensus::{BlockHeight, Network};
     use zcash_protocol::memo::{Memo, MemoBytes};
@@ -414,8 +414,8 @@ mod tests {
                 sapling_anchor: None,
                 orchard_anchor: Some(anchor),
                 ironwood_anchor: None,
-                orchard_bundle_type: orchard::builder::BundleType::DEFAULT,
-                ironwood_bundle_type: orchard::builder::BundleType::DEFAULT,
+                orchard_padding: BundlePadding::DEFAULT,
+                ironwood_padding: BundlePadding::DEFAULT,
             },
         );
         builder

--- a/rust/src/migration_plan_cache.rs
+++ b/rust/src/migration_plan_cache.rs
@@ -34,7 +34,7 @@ use std::sync::{Mutex, OnceLock};
 
 use rand::RngCore;
 use rand::rngs::OsRng;
-use zcash_pool_migration_backend::engine::MigrationPlan;
+use zcash_pool_migration::engine::MigrationPlan;
 
 /// Opaque identifier of one cached [`MigrationPlan`]. Drawn fresh (randomly, never zero) for
 /// every plan, so a handle from an earlier proposal can never accidentally match a later one.

--- a/rust/src/voting/helpers.rs
+++ b/rust/src/voting/helpers.rs
@@ -64,7 +64,9 @@ pub(super) fn json_to_boxed_slice<T: Serialize>(
     Ok(crate::ffi::BoxedSlice::some(json))
 }
 
-/// Open the wallet database.
+/// Open the wallet database, retaining durable anchor checkpoints on the same interval every other
+/// wallet handle in this crate uses for `network_id` (see [`crate::anchor_retention_interval`]), so
+/// that scanning through this path keeps the boundaries a pool migration will need.
 pub(super) fn open_wallet_db(
     wallet_db_path: &str,
     network_id: u32,
@@ -78,6 +80,7 @@ pub(super) fn open_wallet_db(
 > {
     let network = crate::parse_network(network_id)?;
     zcash_client_sqlite::WalletDb::for_path(wallet_db_path, network, SystemClock, rand::rngs::OsRng)
+        .map(|db| db.with_anchor_retention_interval(crate::anchor_retention_interval(network)))
         .map_err(|e| anyhow!("failed to open wallet DB: {}", e))
 }
 


### PR DESCRIPTION
Closes #1835. Resolves MOB-1523

Depends on zcash/librustzcash#2759, which makes the ZIP 318 anchor bucketing interval configurable. The `[patch.crates-io]` block is pinned to that PR's tip, `cd2b9a6a27dd784df3d245cd047bfeade21d9430`.

## What this does

`anchor_retention_interval(NetworkParams)` selects the grid: `AnchorRetentionInterval::ZIP_318` on mainnet, a 12-block interval on testnet. `wallet_db()` applies it, and since that helper builds every wallet handle the FFI hands out, the retention grid and the migration grid cannot be configured apart. `voting/helpers.rs`'s `open_wallet_db` applies the same interval so the voting path retains the same boundaries.

No Swift changes. `network_id` is already plumbed across the FFI for consensus parameters, so the interval is derived on the Rust side; plumbing a second value from Swift would be a source of truth that could drift from the grid the wallet actually retains.

**Worth a reviewer's opinion:** custom-parameter networks (regtest, and the modified-mainnet backends used for Ironwood testing) get the 12-block grid, even though `Custom { .. }` can carry `base: NetworkType::Main`. The reasoning is that a test deployment is not the production anonymity set. Say if you would rather custom networks inherit mainnet's grid.

## Why `scheduling_params` had to be implemented here

`MigrationBackend::scheduling_params` is a new required trait method upstream. This SDK does not use `zcash_pool_migration::wallet::WalletMigration` — `migration_engine.rs` has its own adapter, because `WalletMigration` requires a `UnifiedSpendingKey` that a UFVK-imported Keystone account does not have. The implementation mirrors `WalletMigration`'s: it derives the delay distributions from the wallet's own retention interval, so the grid remains the single configured value.

## Dependency changes

Bumping the pin pulls in a sizeable delta, so this also carries:

- `zcash_pool_migration_backend` renamed to `zcash_pool_migration` (now published as `0.1.0-alpha.1`). It was this repo's one remaining direct git dependency; it is now a version requirement redirected by the patch block, so every librustzcash crate goes through `[patch.crates-io]`.
- `zcash_proofs` added to the patch block; requirements raised to admit the patched versions — `zcash_primitives`/`zcash_proofs` 0.29→0.30, `zcash_transparent` 0.9→0.10, `pczt` 0.8.0-rc.1→0.8
- `MigrationState::from_parts` gained an `AnchorBucketInterval` argument; production sites pass `state.anchor_bucket_interval()`, so a rebuild or cancel keeps the grid its run was committed under
- `scheduling::schedule` takes `&SchedulingParams`; `BundleType` became `BundlePadding` in `BuildConfig::Standard` and `create_pczt_from_proposal`

## The `zcash_voting` pin moved too

The previous fork rev required `zcash_primitives = "0.29.0"`, which the patched librustzcash rev supplies as 0.30.0, so cargo resolved two `zcash_primitives` copies and `zcash_voting` failed to compile — a `PcztParts<Network>` from 0.29 handed to a 0.30-based `pczt`. The pin now points at `zodl-inc/zcash_voting` `e5d885c2`, which is on the 0.30 generation, so the patch reaches it and the graph stays single-copy.

Keep that pin in step with the patch block: a rev on the 0.29 generation cannot accept the patched librustzcash and splits the graph again.

## Verification

On the tree as committed (no local modifications):

- `cargo fmt --check`: clean
- `cargo check --all-targets`: no errors (4 pre-existing "never used" warnings in `voting/`, present at baseline)
- `cargo test`: `72 passed; 0 failed; 0 ignored` (baseline 70; the 2 new ones cover the network-to-interval mapping)
- `cargo tree -d`: no duplicated zcash crates

**Not verified: anything Swift.** There is no Swift/Xcode toolchain on the machine this was prepared on, so `swift test --filter OfflineTests` and the XCFramework build were not run. No `extern "C"` signatures changed, so the cbindgen-generated header should be unchanged, but that was not confirmed by running the generator.

## Note for reviewers

An in-flight **testnet** migration committed under the 144-block grid will now fail proving with `ProveError::AnchorIntervalMismatch` and must be restarted. The upstream change records the grid a migration was committed under and refuses to prove against a different one, rather than letting it fail later as an unexplained missing checkpoint. Mainnet is unaffected.

---
Opened with Claude Code assistance.

