### PR TITLE
CI: authorize cargo against the private slipstream repository

### DIFF
--- a/.github/actions/authorize-slipstream/action.yml
+++ b/.github/actions/authorize-slipstream/action.yml
@@ -1,0 +1,57 @@
+name: "Authorize cargo against the private slipstream repository"
+description: >-
+  Mints a short-lived read token for zodl-inc/slipstream and points cargo's git fetches at it.
+  `slipstream-core` is a git dependency on that private repo, and cargo fetches the source while
+  resolving the dependency graph — before feature selection — so every job that runs cargo needs
+  read access even though the `slipstream` feature is off by default. Without it cargo reports
+  "revision ... not found / failed to authenticate".
+
+  A no-op when the inputs are empty, which is what happens on pull requests from forks: secrets
+  are unavailable there by design, so those runs still cannot build the Rust library. Fixing that
+  would mean making dependency resolution not require the private repo, which no credential can do.
+
+inputs:
+  app-id:
+    description: >-
+      App ID of the GitHub App holding Contents:Read on zodl-inc/slipstream. Leave empty to skip
+      the credential setup entirely.
+    required: false
+    default: ""
+  app-private-key:
+    description: "PEM-encoded private key for the App identified by app-id."
+    required: false
+    default: ""
+
+runs:
+  using: "composite"
+  steps:
+    - name: Mint a read token for the private slipstream repository
+      id: token
+      if: inputs.app-id != '' && inputs.app-private-key != ''
+      uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1
+      with:
+        app-id: ${{ inputs.app-id }}
+        private-key: ${{ inputs.app-private-key }}
+        # The App is installed on zodl-inc, not on this repository's owner, so the installation
+        # to mint against has to be named explicitly.
+        owner: zodl-inc
+        repositories: slipstream
+        # Narrow the minted token to exactly what cargo needs, rather than inheriting whatever
+        # the App's installation happens to hold. Fetching a git dependency is a read of repository
+        # contents and nothing more.
+        permission-contents: read
+
+    - name: Point cargo's git fetches at the token
+      if: steps.token.outputs.token != ''
+      shell: bash
+      env:
+        SLIPSTREAM_TOKEN: ${{ steps.token.outputs.token }}
+      run: |
+        # The rewrite is scoped to the zodl-inc org: the token is never offered to github.com
+        # generally, so the other git dependencies (librustzcash and friends) keep fetching
+        # anonymously. libgit2, cargo's default git transport, ignores `insteadOf` rewrites
+        # altogether, hence handing the fetch to the git CLI.
+        git config --global \
+          url."https://x-access-token:${SLIPSTREAM_TOKEN}@github.com/zodl-inc/".insteadOf \
+          "https://github.com/zodl-inc/"
+        echo "CARGO_NET_GIT_FETCH_WITH_CLI=true" >> "$GITHUB_ENV"

--- a/.github/workflows/build-ffi.yml
+++ b/.github/workflows/build-ffi.yml
@@ -24,6 +24,12 @@ jobs:
       - name: Select Xcode
         run: sudo xcode-select -s /Applications/Xcode_16.0.app
 
+      - name: Authorize cargo against the private slipstream repository
+        uses: ./.github/actions/authorize-slipstream
+        with:
+          app-id: ${{ secrets.SLIPSTREAM_APP_ID }}
+          app-private-key: ${{ secrets.SLIPSTREAM_APP_PRIVATE_KEY }}
+
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
@@ -31,7 +37,28 @@ jobs:
           targets: aarch64-apple-ios, x86_64-apple-ios, aarch64-apple-ios-sim, x86_64-apple-darwin, aarch64-apple-darwin
 
       - name: Cache Cargo
-        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        with:
+          # Deliberately enumerated rather than caching `~/.cargo` wholesale (which is what
+          # Swatinem/rust-cache did): that includes `~/.cargo/git`, where cargo keeps its clone of
+          # the PRIVATE zodl-inc/slipstream repo. This repository is public, and GitHub lets
+          # workflow runs from forked pull requests restore caches created on the base branch — a
+          # cached clone would hand fork PRs the private source without their ever holding the App
+          # credential. Re-cloning one small repo per run is the cost of keeping it out.
+          #
+          # `registry/` is crates.io content and safe to cache. `target/` still holds
+          # slipstream-core's compiled rlib/rmeta, which is a far smaller disclosure than the source
+          # tree and too expensive to rebuild every run; dropping it too would require solving the
+          # public-repo/private-dependency problem properly instead.
+          path: |
+            target
+            ~/.cargo/bin
+            ~/.cargo/registry/index
+            ~/.cargo/registry/cache
+            ~/.cargo/registry/src
+          key: ${{ runner.os }}-cargo-v1-${{ hashFiles('Cargo.lock', 'Cargo.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-v1-
 
       - name: Build and upload draft release
         env:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -122,6 +122,13 @@ jobs:
         path: BuildSupport/products/libzcashlc.xcframework
         key: ffi-xcframework-macos-only-${{ runner.os }}-${{ steps.ffi-hash.outputs.hash }}
 
+    - name: Authorize cargo against the private slipstream repository
+      if: matrix.language == 'swift' && steps.cache-ffi.outputs.cache-hit != 'true'
+      uses: ./.github/actions/authorize-slipstream
+      with:
+        app-id: ${{ secrets.SLIPSTREAM_APP_ID }}
+        app-private-key: ${{ secrets.SLIPSTREAM_APP_PRIVATE_KEY }}
+
     - name: Setup Rust
       if: matrix.language == 'swift' && steps.cache-ffi.outputs.cache-hit != 'true'
       uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
@@ -131,7 +138,28 @@ jobs:
 
     - name: Cache Cargo
       if: matrix.language == 'swift' && steps.cache-ffi.outputs.cache-hit != 'true'
-      uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
+      uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+      with:
+        # Deliberately enumerated rather than caching `~/.cargo` wholesale (which is what
+        # Swatinem/rust-cache did): that includes `~/.cargo/git`, where cargo keeps its clone of
+        # the PRIVATE zodl-inc/slipstream repo. This repository is public, and GitHub lets
+        # workflow runs from forked pull requests restore caches created on the base branch — a
+        # cached clone would hand fork PRs the private source without their ever holding the App
+        # credential. Re-cloning one small repo per run is the cost of keeping it out.
+        #
+        # `registry/` is crates.io content and safe to cache. `target/` still holds
+        # slipstream-core's compiled rlib/rmeta, which is a far smaller disclosure than the source
+        # tree and too expensive to rebuild every run; dropping it too would require solving the
+        # public-repo/private-dependency problem properly instead.
+        path: |
+          target
+          ~/.cargo/bin
+          ~/.cargo/registry/index
+          ~/.cargo/registry/cache
+          ~/.cargo/registry/src
+        key: ${{ runner.os }}-cargo-v1-${{ hashFiles('Cargo.lock', 'Cargo.toml') }}
+        restore-keys: |
+          ${{ runner.os }}-cargo-v1-
 
     - name: Build FFI for macOS
       if: matrix.language == 'swift' && steps.cache-ffi.outputs.cache-hit != 'true'

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -45,6 +45,13 @@ jobs:
         path: BuildSupport/products/libzcashlc.xcframework
         key: ffi-xcframework-macos-only-${{ runner.os }}-${{ steps.ffi-hash.outputs.hash }}
 
+    - name: Authorize cargo against the private slipstream repository
+      if: steps.cache-ffi.outputs.cache-hit != 'true'
+      uses: ./.github/actions/authorize-slipstream
+      with:
+        app-id: ${{ secrets.SLIPSTREAM_APP_ID }}
+        app-private-key: ${{ secrets.SLIPSTREAM_APP_PRIVATE_KEY }}
+
     # Only set up Rust if we need to build FFI
     - name: Setup Rust
       if: steps.cache-ffi.outputs.cache-hit != 'true'
@@ -53,10 +60,30 @@ jobs:
         toolchain: stable
         targets: aarch64-apple-darwin, x86_64-apple-darwin
 
-    # Cache Cargo dependencies (only if building FFI)
     - name: Cache Cargo
       if: steps.cache-ffi.outputs.cache-hit != 'true'
-      uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
+      uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+      with:
+        # Deliberately enumerated rather than caching `~/.cargo` wholesale (which is what
+        # Swatinem/rust-cache did): that includes `~/.cargo/git`, where cargo keeps its clone of
+        # the PRIVATE zodl-inc/slipstream repo. This repository is public, and GitHub lets
+        # workflow runs from forked pull requests restore caches created on the base branch — a
+        # cached clone would hand fork PRs the private source without their ever holding the App
+        # credential. Re-cloning one small repo per run is the cost of keeping it out.
+        #
+        # `registry/` is crates.io content and safe to cache. `target/` still holds
+        # slipstream-core's compiled rlib/rmeta, which is a far smaller disclosure than the source
+        # tree and too expensive to rebuild every run; dropping it too would require solving the
+        # public-repo/private-dependency problem properly instead.
+        path: |
+          target
+          ~/.cargo/bin
+          ~/.cargo/registry/index
+          ~/.cargo/registry/cache
+          ~/.cargo/registry/src
+        key: ${{ runner.os }}-cargo-v1-${{ hashFiles('Cargo.lock', 'Cargo.toml') }}
+        restore-keys: |
+          ${{ runner.os }}-cargo-v1-
 
     # Build FFI for macOS only (sufficient for running tests)
     - name: Build FFI for macOS


### PR DESCRIPTION
Closes #1839. Resolves MOB-1529

Ports zcash/zcash-android-wallet-sdk@2e9a97d to this repository, with three differences forced by how this repo's CI is shaped.

## The failure

Once `slipstream-core` becomes a git dependency on the private `zodl-inc/slipstream` repo, every workflow that compiles Rust fails to resolve it. Cargo fetches that source while resolving the dependency graph — before feature selection — so the off-by-default `slipstream` feature does not spare it. This repository's Actions token cannot read `zodl-inc`, and cargo surfaces the 404 as `revision ... not found` / `failed to authenticate`.

## The fix

Mint an installation token from a GitHub App holding `Contents: Read` on `zodl-inc/slipstream`, then scope a `url.insteadOf` rewrite to that org so the token is never offered to the librustzcash git dependencies. libgit2, cargo's default transport, ignores `insteadOf` rewrites entirely, hence `CARGO_NET_GIT_FETCH_WITH_CLI=true`.

It is a no-op when the secrets are empty. Pull requests from forks receive none by design and so still cannot build the Rust library; fixing that would mean making resolution not require the private repo, which no credential can do.

## Three differences from the Android port

**A composite action, because there was nothing to extend.** Android added its steps to an existing `.github/actions/setup`. This repository has no composite actions, and three workflows compile Rust — `swift.yml`, `codeql.yml`, `build-ffi.yml` — so the alternative was repeating ~25 lines three times. `.github/actions/authorize-slipstream` holds it once.

**`Swatinem/rust-cache` had to be replaced.** It caches `~/.cargo/git`, where cargo keeps its clone of the private repo. This repository is public, and GitHub lets workflow runs from forked pull requests restore caches created on the base branch — so a cached clone would hand fork PRs the private source without their ever holding the App credential. The replacement enumerates `target/` and the crates.io registry directories explicitly.

No key-version bump was needed here, unlike Android's v2→v3: rust-cache's keys live in its own namespace, so `restore-keys` cannot prefix-match them and go on reinstating `~/.cargo/git`.

**The minted token pins `permission-contents: read`.** This repository runs `zizmor` on pull requests, and it flags the unpinned mint as `error[github-app]: app token inherits blanket installation permissions`. Pinning it is correct regardless — fetching a git dependency is a read of repository contents and nothing more. **The Android commit has the same gap and should get the same line.**

## Secrets

`SLIPSTREAM_APP_ID` and `SLIPSTREAM_APP_PRIVATE_KEY` are already configured on this repository.

## Verification

- All workflow and action YAML parses.
- `zizmor --offline` reports **no findings** on the new action or on the three workflows changed here. The remaining repository-wide findings (`swiftlint.yml`'s unpinned `actions/checkout@v1` and `norio-nomura/action-swiftlint@3.2.1`, plus an `excessive-permissions` and an `artipacked` warning) are pre-existing and untouched.

**The CI path itself is not verified** — that needs a real run with the secrets present, which this pull request is the first opportunity for. Watch that the Rust-compiling jobs get past dependency resolution.

---
Opened with Claude Code assistance.
