### PR TITLE
[#1806] Orchard-to-Ironwood pool migration proposal (send max)

### DIFF
--- a/Sources/ZcashLightClientKit/ClosureSynchronizer.swift
+++ b/Sources/ZcashLightClientKit/ClosureSynchronizer.swift
@@ -57,6 +57,13 @@ public protocol ClosureSynchronizer {
         completion: @escaping (Result<Proposal, Error>) -> Void
     )
 
+    /// Creates a proposal that migrates the account's entire Orchard balance into the Ironwood pool.
+    /// Fails unless NU6.3 is active at the chain tip.
+    func proposeOrchardToIronwoodMigration(
+        accountUUID: AccountUUID,
+        completion: @escaping (Result<Proposal, Error>) -> Void
+    )
+
     /// Creates a proposal for shielding any transparent funds received by the given account.
     ///
     /// - Parameter accountUUID: the account from which to shield funds.

--- a/Sources/ZcashLightClientKit/CombineSynchronizer.swift
+++ b/Sources/ZcashLightClientKit/CombineSynchronizer.swift
@@ -54,6 +54,10 @@ public protocol CombineSynchronizer {
         memo: Memo?
     ) -> SinglePublisher<Proposal, Error>
 
+    /// Creates a proposal that migrates the account's entire Orchard balance into the Ironwood pool.
+    /// Fails unless NU6.3 is active at the chain tip.
+    func proposeOrchardToIronwoodMigration(accountUUID: AccountUUID) -> SinglePublisher<Proposal, Error>
+
     /// Creates a proposal for shielding any transparent funds received by the given account.
     ///
     /// - Parameter accountUUID: the account from which to shield funds.

--- a/Sources/ZcashLightClientKit/Rust/ZcashRustBackend.swift
+++ b/Sources/ZcashLightClientKit/Rust/ZcashRustBackend.swift
@@ -315,6 +315,34 @@ struct ZcashRustBackend: ZcashRustBackendWelding {
     }
 
     @DBActor
+    func proposeOrchardToIronwoodMigration(accountUUID: AccountUUID) async throws -> FfiProposal {
+        let dbDataPtr = dbData.0
+        let dbDataLen = dbData.1
+        let account = accountUUID.id
+        let networkId = networkType.networkId
+
+        let proposal = zcashlc_propose_orchard_to_ironwood_migration(
+            dbDataPtr,
+            dbDataLen,
+            account,
+            networkId
+        )
+
+        guard let proposal else {
+            throw ZcashError.rustCreateToAddress(
+                lastErrorMessage(fallback: "`proposeOrchardToIronwoodMigration` failed with unknown error")
+            )
+        }
+
+        defer { zcashlc_free_boxed_slice(proposal) }
+
+        return try FfiProposal(serializedBytes: Data(
+            bytes: proposal.pointee.ptr,
+            count: Int(proposal.pointee.len)
+        ))
+    }
+
+    @DBActor
     func proposeTransferFromURI(
         _ uri: String,
         accountUUID: AccountUUID

--- a/Sources/ZcashLightClientKit/Rust/ZcashRustBackendWelding.swift
+++ b/Sources/ZcashLightClientKit/Rust/ZcashRustBackendWelding.swift
@@ -263,6 +263,15 @@ protocol ZcashRustBackendWelding {
         memo: MemoBytes?
     ) async throws -> FfiProposal
 
+    /// Proposes migrating the account's entire Orchard balance into the Ironwood pool.
+    ///
+    /// Sends the maximum from Orchard to the account's own internal receiver so nothing is
+    /// stranded when the Orchard turnstile closes at NU6.3. Fails unless NU6.3 is active.
+    ///
+    /// - Parameter accountUUID: the account whose Orchard balance is migrated.
+    /// - Throws: `rustCreateToAddress`.
+    func proposeOrchardToIronwoodMigration(accountUUID: AccountUUID) async throws -> FfiProposal
+
     /// Select transaction inputs, compute fees, and construct a proposal for a transaction
     /// that can then be authorized and made ready for submission to the network with
     /// `createProposedTransaction` from a valid [ZIP-321](https://zips.z.cash/zip-0321) Payment Request UR

--- a/Sources/ZcashLightClientKit/Synchronizer.swift
+++ b/Sources/ZcashLightClientKit/Synchronizer.swift
@@ -194,6 +194,17 @@ public protocol Synchronizer: AnyObject {
         memo: Memo?
     ) async throws -> Proposal
 
+    /// Creates a proposal that migrates the account's entire Orchard balance into the Ironwood pool.
+    ///
+    /// NU6.3 introduces the Orchard turnstile: value may leave the Orchard pool but never re-enter
+    /// it, so Orchard funds must be moved across once and in full. This spends every Orchard note and
+    /// sends the maximum to the account's own internal receiver, with the fee computed so no change
+    /// returns to Orchard. Sapling and transparent funds are untouched. Fails unless NU6.3 is active
+    /// at the chain tip.
+    ///
+    /// - Parameter accountUUID: the account whose Orchard balance is migrated.
+    func proposeOrchardToIronwoodMigration(accountUUID: AccountUUID) async throws -> Proposal
+
     /// Creates a proposal for shielding any transparent funds received by the given account.
     ///
     /// - Parameter accountUUID: the account for which to shield funds.

--- a/Sources/ZcashLightClientKit/Synchronizer/ClosureSDKSynchronizer.swift
+++ b/Sources/ZcashLightClientKit/Synchronizer/ClosureSDKSynchronizer.swift
@@ -127,6 +127,15 @@ extension ClosureSDKSynchronizer: ClosureSynchronizer {
         }
     }
 
+    public func proposeOrchardToIronwoodMigration(
+        accountUUID: AccountUUID,
+        completion: @escaping (Result<Proposal, Error>) -> Void
+    ) {
+        AsyncToClosureGateway.executeThrowingAction(completion) {
+            try await self.synchronizer.proposeOrchardToIronwoodMigration(accountUUID: accountUUID)
+        }
+    }
+
     public func proposeShielding(
         accountUUID: AccountUUID,
         shieldingThreshold: Zatoshi,

--- a/Sources/ZcashLightClientKit/Synchronizer/CombineSDKSynchronizer.swift
+++ b/Sources/ZcashLightClientKit/Synchronizer/CombineSDKSynchronizer.swift
@@ -94,6 +94,12 @@ extension CombineSDKSynchronizer: CombineSynchronizer {
         }
     }
 
+    public func proposeOrchardToIronwoodMigration(accountUUID: AccountUUID) -> SinglePublisher<Proposal, Error> {
+        AsyncToCombineGateway.executeThrowingAction() {
+            try await self.synchronizer.proposeOrchardToIronwoodMigration(accountUUID: accountUUID)
+        }
+    }
+
     public func proposefulfillingPaymentURI(
         _ uri: String,
         accountUUID: AccountUUID

--- a/Sources/ZcashLightClientKit/Synchronizer/SDKSynchronizer.swift
+++ b/Sources/ZcashLightClientKit/Synchronizer/SDKSynchronizer.swift
@@ -423,6 +423,12 @@ public class SDKSynchronizer: Synchronizer {
         return proposal
     }
 
+    public func proposeOrchardToIronwoodMigration(accountUUID: AccountUUID) async throws -> Proposal {
+        try throwIfUnprepared()
+
+        return try await transactionEncoder.proposeOrchardToIronwoodMigration(accountUUID: accountUUID)
+    }
+
     public func proposeShielding(
         accountUUID: AccountUUID,
         shieldingThreshold: Zatoshi,

--- a/Sources/ZcashLightClientKit/Transaction/TransactionEncoder.swift
+++ b/Sources/ZcashLightClientKit/Transaction/TransactionEncoder.swift
@@ -35,6 +35,9 @@ protocol TransactionEncoder {
         memoBytes: MemoBytes?
     ) async throws -> Proposal
 
+    /// Proposes migrating the account's entire Orchard balance into the Ironwood pool.
+    func proposeOrchardToIronwoodMigration(accountUUID: AccountUUID) async throws -> Proposal
+
     /// Creates a proposal for shielding any transparent funds received by the given account.
     ///
     /// - Parameter accountUUID:the account from which to shield funds.

--- a/Sources/ZcashLightClientKit/Transaction/WalletTransactionEncoder.swift
+++ b/Sources/ZcashLightClientKit/Transaction/WalletTransactionEncoder.swift
@@ -77,6 +77,12 @@ class WalletTransactionEncoder: TransactionEncoder {
         return Proposal(inner: proposal)
     }
 
+    func proposeOrchardToIronwoodMigration(accountUUID: AccountUUID) async throws -> Proposal {
+        let proposal = try await rustBackend.proposeOrchardToIronwoodMigration(accountUUID: accountUUID)
+
+        return Proposal(inner: proposal)
+    }
+
     func proposeShielding(
         accountUUID: AccountUUID,
         shieldingThreshold: Zatoshi,

--- a/Tests/OfflineTests/BroadcasterTests.swift
+++ b/Tests/OfflineTests/BroadcasterTests.swift
@@ -384,6 +384,10 @@ private final class StubTransactionEncoder: TransactionEncoder {
         fatalError("Unused in test")
     }
 
+    func proposeOrchardToIronwoodMigration(accountUUID: AccountUUID) async throws -> Proposal {
+        fatalError("Unused in test")
+    }
+
     func proposeShielding(
         accountUUID: AccountUUID,
         shieldingThreshold: Zatoshi,

--- a/Tests/TestUtils/Sourcery/GeneratedMocks/AutoMockable.generated.swift
+++ b/Tests/TestUtils/Sourcery/GeneratedMocks/AutoMockable.generated.swift
@@ -1731,6 +1731,30 @@ class SynchronizerMock: Synchronizer {
         }
     }
 
+    // MARK: - proposeOrchardToIronwoodMigration
+
+    var proposeOrchardToIronwoodMigrationAccountUUIDThrowableError: Error?
+    var proposeOrchardToIronwoodMigrationAccountUUIDCallsCount = 0
+    var proposeOrchardToIronwoodMigrationAccountUUIDCalled: Bool {
+        return proposeOrchardToIronwoodMigrationAccountUUIDCallsCount > 0
+    }
+    var proposeOrchardToIronwoodMigrationAccountUUIDReceivedAccountUUID: AccountUUID?
+    var proposeOrchardToIronwoodMigrationAccountUUIDReturnValue: Proposal!
+    var proposeOrchardToIronwoodMigrationAccountUUIDClosure: ((AccountUUID) async throws -> Proposal)?
+
+    func proposeOrchardToIronwoodMigration(accountUUID: AccountUUID) async throws -> Proposal {
+        if let error = proposeOrchardToIronwoodMigrationAccountUUIDThrowableError {
+            throw error
+        }
+        proposeOrchardToIronwoodMigrationAccountUUIDCallsCount += 1
+        proposeOrchardToIronwoodMigrationAccountUUIDReceivedAccountUUID = accountUUID
+        if let closure = proposeOrchardToIronwoodMigrationAccountUUIDClosure {
+            return try await closure(accountUUID)
+        } else {
+            return proposeOrchardToIronwoodMigrationAccountUUIDReturnValue
+        }
+    }
+
     // MARK: - proposeShielding
 
     var proposeShieldingAccountUUIDShieldingThresholdMemoTransparentReceiverThrowableError: Error?
@@ -3722,6 +3746,30 @@ class ZcashRustBackendWeldingMock: ZcashRustBackendWelding {
             return try await closure(accountUUID, address, value, memo)
         } else {
             return proposeTransferAccountUUIDToValueMemoReturnValue
+        }
+    }
+
+    // MARK: - proposeOrchardToIronwoodMigration
+
+    var proposeOrchardToIronwoodMigrationAccountUUIDThrowableError: Error?
+    var proposeOrchardToIronwoodMigrationAccountUUIDCallsCount = 0
+    var proposeOrchardToIronwoodMigrationAccountUUIDCalled: Bool {
+        return proposeOrchardToIronwoodMigrationAccountUUIDCallsCount > 0
+    }
+    var proposeOrchardToIronwoodMigrationAccountUUIDReceivedAccountUUID: AccountUUID?
+    var proposeOrchardToIronwoodMigrationAccountUUIDReturnValue: FfiProposal!
+    var proposeOrchardToIronwoodMigrationAccountUUIDClosure: ((AccountUUID) async throws -> FfiProposal)?
+
+    func proposeOrchardToIronwoodMigration(accountUUID: AccountUUID) async throws -> FfiProposal {
+        if let error = proposeOrchardToIronwoodMigrationAccountUUIDThrowableError {
+            throw error
+        }
+        proposeOrchardToIronwoodMigrationAccountUUIDCallsCount += 1
+        proposeOrchardToIronwoodMigrationAccountUUIDReceivedAccountUUID = accountUUID
+        if let closure = proposeOrchardToIronwoodMigrationAccountUUIDClosure {
+            return try await closure(accountUUID)
+        } else {
+            return proposeOrchardToIronwoodMigrationAccountUUIDReturnValue
         }
     }
 

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -90,6 +90,7 @@ use zip32::fingerprint::SeedFingerprint;
 mod derivation;
 mod eip681;
 mod ffi;
+mod migration;
 mod tor;
 // Voting is gated off on the Ironwood (NU6.3) deps: zcash_voting cannot resolve
 // against orchard 0.15 (see Cargo.toml). Re-enable with the `voting` feature
@@ -2250,6 +2251,45 @@ pub unsafe extern "C" fn zcashlc_propose_transfer(
 
         let encoded = Proposal::from_standard_proposal(&proposal).encode_to_vec();
 
+        Ok(ffi::BoxedSlice::some(encoded))
+    });
+    unwrap_exc_or_null(res)
+}
+
+/// Proposes migrating the account's entire Orchard balance into the Ironwood pool.
+///
+/// Sends the maximum from Orchard to the account's own internal Orchard receiver,
+/// with the fee computed so nothing is left over. Fails unless NU6.3 is active at
+/// the chain tip. See [`crate::migration::propose_orchard_to_ironwood`].
+///
+/// # Safety
+///
+/// - `db_data` must be non-null and valid for reads for `db_data_len` bytes, and it must have an
+///   alignment of `1`. Its contents must be a string representing a valid system path in the
+///   operating system's preferred representation.
+/// - The memory referenced by `db_data` must not be mutated for the duration of the function call.
+/// - The total size `db_data_len` must be no larger than `isize::MAX`. See the safety
+///   documentation of pointer::offset.
+/// - `account_uuid_bytes` must be non-null and valid for reads for 16 bytes, and it must have an alignment
+///   of `1`.
+/// - Call [`zcashlc_free_boxed_slice`] to free the memory associated with the returned
+///   pointer when done using it.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn zcashlc_propose_orchard_to_ironwood_migration(
+    db_data: *const u8,
+    db_data_len: usize,
+    account_uuid_bytes: *const u8,
+    network_id: u32,
+) -> *mut ffi::BoxedSlice {
+    let res = catch_panic(|| {
+        let network = parse_network(network_id)?;
+        let mut db_data = unsafe { wallet_db(db_data, db_data_len, network)? };
+        let account_uuid = account_uuid_from_bytes(account_uuid_bytes)?;
+
+        let proposal =
+            migration::propose_orchard_to_ironwood(&mut db_data, &network, account_uuid)?;
+
+        let encoded = Proposal::from_standard_proposal(&proposal).encode_to_vec();
         Ok(ffi::BoxedSlice::some(encoded))
     });
     unwrap_exc_or_null(res)

--- a/rust/src/migration.rs
+++ b/rust/src/migration.rs
@@ -1,0 +1,95 @@
+//! Orchard to Ironwood pool migration.
+//!
+//! Builds on the upstream `propose_send_max_transfer`, which spends the entire
+//! spendable balance of a chosen set of shielded pools to one recipient with
+//! the fee computed so nothing is left over. This module only pins the
+//! parameters that make that call the pool migration; it is not a general
+//! send-max and none is exposed.
+
+use anyhow::anyhow;
+use rand::rngs::OsRng;
+use zcash_address::{ToAddress, ZcashAddress, unified, unified::Encoding as _};
+use zcash_client_backend::{
+    data_api::{
+        Account as _, InputSource, MaxSpendMode, WalletRead,
+        wallet::{ConfirmationsPolicy, propose_send_max_transfer},
+    },
+    fees::StandardFeeRule,
+    proposal::Proposal,
+};
+use zcash_client_sqlite::{AccountUuid, WalletDb, util::SystemClock};
+use zcash_protocol::{
+    ShieldedPool,
+    consensus::{Network, NetworkUpgrade, Parameters},
+    memo::MemoBytes,
+};
+
+type Db = WalletDb<rusqlite::Connection, Network, SystemClock, OsRng>;
+
+type MigrationProposal = Proposal<StandardFeeRule, <Db as InputSource>::NoteRef>;
+
+/// Proposes migrating the account's entire Orchard balance into the Ironwood
+/// pool, sending the maximum from Orchard to the account's own internal Orchard
+/// receiver so nothing is left behind when the Orchard turnstile closes at
+/// NU6.3. Sapling and transparent funds are untouched.
+///
+/// Fails unless NU6.3 is active at the chain tip: before activation the same
+/// call builds an Orchard-pool output (a fee-costing self-send that migrates
+/// nothing). Uses `MaxSpendMode::Everything` so it fails rather than silently
+/// migrating only the spendable subset.
+pub(crate) fn propose_orchard_to_ironwood(
+    db_data: &mut Db,
+    network: &Network,
+    account: AccountUuid,
+) -> anyhow::Result<MigrationProposal> {
+    let chain_tip = db_data
+        .chain_height()
+        .map_err(|e| anyhow!("Error reading the chain tip: {}", e))?
+        .ok_or_else(|| anyhow!("Wallet has not yet scanned any blocks."))?;
+    match network.activation_height(NetworkUpgrade::Nu6_3) {
+        Some(h) if chain_tip >= h => (),
+        _ => {
+            return Err(anyhow!(
+                "Ironwood (NU6.3) is not active yet; there is nothing to migrate to."
+            ));
+        }
+    }
+
+    let orchard_fvk = db_data
+        .get_account(account)
+        .map_err(|e| anyhow!("Error looking up account: {}", e))?
+        .ok_or_else(|| anyhow!("Unknown account."))?
+        .ufvk()
+        .and_then(|ufvk| ufvk.orchard())
+        .cloned()
+        .ok_or_else(|| anyhow!("Account has no Orchard full viewing key."))?;
+
+    // Internal scope: funds return to the account as change, not an external payment.
+    let receiver = orchard_fvk.address_at(0u32, orchard::keys::Scope::Internal);
+    let recipient = ZcashAddress::from_unified(
+        network.network_type(),
+        unified::Address::try_from_items(vec![unified::Receiver::Orchard(
+            receiver.to_raw_address_bytes(),
+        )])
+        .map_err(|e| anyhow!("Unable to construct the migration recipient: {}", e))?,
+    );
+
+    let spend_pools = [ShieldedPool::Orchard];
+    let fee_rule = StandardFeeRule::Zip317;
+    let memo: Option<MemoBytes> = None;
+    let mode = MaxSpendMode::Everything;
+    let confirmations_policy = ConfirmationsPolicy::default();
+
+    propose_send_max_transfer::<_, _, _, std::convert::Infallible>(
+        db_data,
+        network,
+        account,
+        &spend_pools,
+        &fee_rule,
+        recipient,
+        memo,
+        mode,
+        confirmations_policy,
+    )
+    .map_err(|e| anyhow!("Error creating the migration proposal: {}", e))
+}


### PR DESCRIPTION
Adds `Synchronizer.proposeOrchardToIronwoodMigration(accountUUID:)` (plus the
closure and Combine facades): a proposal that migrates the account's entire
Orchard balance into the Ironwood pool before the Orchard turnstile closes at
NU6.3. Mirrors the Android SDK's feature/send-max-2.5.x (PR #2030).

Stacked on the Ironwood support branch (`feature/ironwood-support-2.5.3`).

## What it does

Spends every Orchard note and sends the maximum to the account's own internal
Orchard receiver, with the fee computed so no change returns to Orchard.
Sapling and transparent funds are untouched. Fails unless NU6.3 is active at
the chain tip (before activation the same call would build an Orchard output, a
fee-costing self-send that migrates nothing).

## Reuse

The generic capability is upstream and is not reimplemented:
`propose_send_max_transfer` already spends the whole balance of a chosen set of
pools with the fee computed to leave nothing over. `rust/src/migration.rs` only
pins the parameters (Orchard-only, `MaxSpendMode::Everything`, the internal
receiver) that make that call the migration, exposed through the new
`zcashlc_propose_orchard_to_ironwood_migration` FFI. There is no general
send-max in the SDK's API.

Gates: `cargo build` green, `swift build` green, OfflineTests 325/0.