### PR TITLE
[#1806] Prepare for the next librustzcash crates release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -203,6 +203,8 @@ dependencies = [
  "tor-dirmgr",
  "tor-error",
  "tor-guardmgr",
+ "tor-hsclient",
+ "tor-hscrypto",
  "tor-keymgr",
  "tor-linkspec",
  "tor-llcrypto",
@@ -3145,9 +3147,9 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pczt"
-version = "0.8.0-rc.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8fb3f5ea64b891d40cff8182aca0bd7d063c9460920546fe7066860b781de91"
+checksum = "1d3935cce17fdfba4d70187a2075302e0d576192629e93579c8ac5086948bb15"
 dependencies = [
  "blake2b_simd",
  "bls12_381",
@@ -5042,6 +5044,7 @@ dependencies = [
  "tor-bytes",
  "tor-cert",
  "tor-error",
+ "tor-hscrypto",
  "tor-linkspec",
  "tor-llcrypto",
  "tor-memquota",
@@ -5241,6 +5244,7 @@ dependencies = [
  "thiserror 2.0.19",
  "tor-circmgr",
  "tor-error",
+ "tor-hscrypto",
  "tor-linkspec",
  "tor-llcrypto",
  "tor-netdoc",
@@ -5397,6 +5401,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "tor-hsclient"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6c0438676badc6265d6f34ce91c9b50fdb4dfe89ab85795f013fbfa80614304"
+dependencies = [
+ "async-trait",
+ "derive-deftly",
+ "derive_more",
+ "educe",
+ "either",
+ "futures",
+ "itertools 0.14.0",
+ "oneshot-fused-workaround",
+ "postage",
+ "rand 0.9.5",
+ "retry-error",
+ "safelog",
+ "slotmap-careful",
+ "strum",
+ "thiserror 2.0.19",
+ "tor-async-utils",
+ "tor-basic-utils",
+ "tor-bytes",
+ "tor-cell",
+ "tor-checkable",
+ "tor-circmgr",
+ "tor-config",
+ "tor-dirclient",
+ "tor-error",
+ "tor-hscrypto",
+ "tor-keymgr",
+ "tor-linkspec",
+ "tor-llcrypto",
+ "tor-memquota",
+ "tor-netdir",
+ "tor-netdoc",
+ "tor-persist",
+ "tor-proto",
+ "tor-protover",
+ "tor-rtcompat",
+ "tracing",
+]
+
+[[package]]
 name = "tor-hscrypto"
 version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5421,6 +5469,7 @@ dependencies = [
  "tor-error",
  "tor-key-forge",
  "tor-llcrypto",
+ "tor-memquota",
  "tor-units",
  "void",
 ]
@@ -5608,7 +5657,9 @@ dependencies = [
  "async-trait",
  "bitflags",
  "derive_more",
+ "digest 0.10.7",
  "futures",
+ "hex",
  "humantime",
  "itertools 0.14.0",
  "num_enum",
@@ -5616,8 +5667,10 @@ dependencies = [
  "serde",
  "strum",
  "thiserror 2.0.19",
+ "time",
  "tor-basic-utils",
  "tor-error",
+ "tor-hscrypto",
  "tor-linkspec",
  "tor-llcrypto",
  "tor-netdoc",
@@ -5648,6 +5701,7 @@ dependencies = [
  "memchr",
  "paste",
  "phf",
+ "rand 0.9.5",
  "serde",
  "serde_with",
  "signature",
@@ -5663,8 +5717,11 @@ dependencies = [
  "tor-cert",
  "tor-checkable",
  "tor-error",
+ "tor-hscrypto",
+ "tor-linkspec",
  "tor-llcrypto",
  "tor-protover",
+ "tor-units",
  "void",
  "weak-table",
  "zeroize",
@@ -5746,6 +5803,7 @@ dependencies = [
  "tor-checkable",
  "tor-config",
  "tor-error",
+ "tor-hscrypto",
  "tor-linkspec",
  "tor-llcrypto",
  "tor-log-ratelim",
@@ -6680,9 +6738,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_client_backend"
-version = "0.24.0-rc.1"
+version = "0.24.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb0d78dcc345c36086112886223f6f1d6d224802808f15ac4f3ef144677029a1"
+checksum = "f489078672c0f4399b731cb5d4cd934c7820c51de2b4a1e7d2594857916250f0"
 dependencies = [
  "arti-client",
  "base64",
@@ -6748,9 +6806,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_client_sqlite"
-version = "0.22.0-rc.1"
+version = "0.22.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aa9b039e66a3b79f2de45ebf86cd82545232d332631a84f7c017ae21572b8de"
+checksum = "35a2d018a15b2e4374a08f2472f8d4309079cbbfa2f697fbfb864ef6bacd4792"
 dependencies = [
  "bip32",
  "bitflags",
@@ -6786,6 +6844,7 @@ dependencies = [
  "zcash_client_backend",
  "zcash_encoding",
  "zcash_keys",
+ "zcash_pool_migration",
  "zcash_primitives",
  "zcash_protocol",
  "zcash_script",
@@ -6806,9 +6865,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_keys"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36391ebfce7df2510c6564f79e608ed93f1c0692c6464e2397b248e06dae3912"
+checksum = "cc842e024fe37e52cfd3920826c4a28cc2a023fc9d77351d9c0f310becae3eb7"
 dependencies = [
  "bech32",
  "bip32",
@@ -6848,10 +6907,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "zcash_primitives"
-version = "0.29.0"
+name = "zcash_pool_migration"
+version = "0.1.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdbeccc05bfe63b6dee9e989c6ff5027421741562a4853c36504dd621f6a81b1"
+checksum = "852d7e66febd7ec83aa7fbd254a33872bf1c4cd072bdc74f65f253ec3a2ef8f4"
+dependencies = [
+ "corez",
+ "getset",
+ "libm",
+ "rand_core 0.6.4",
+ "zcash_primitives",
+ "zcash_protocol",
+]
+
+[[package]]
+name = "zcash_primitives"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34ca4de11896f704ffe6319c2cd7bc8fc6ab31a55cec80d26def15c009d83678"
 dependencies = [
  "blake2b_simd",
  "block-buffer 0.11.0-rc.3",
@@ -6880,9 +6953,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_proofs"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b91fb0b420fb66a765f1fa92ab7a6b631aa54c08415415ef6185256826e74fbd"
+checksum = "ea125021aaa749e966989c7f7aaa18afe2f89474573f5f0dfac8b98083a6d095"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -6941,9 +7014,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_transparent"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72e0f8c142bed366ed5886dcfa8772ec90b5420cc127e6cdb76b6744c53a287b"
+checksum = "547c012778bae17f58007731af074d638aa146ab0ecfc120adebf23d049aff6c"
 dependencies = [
  "bip32",
  "bs58",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,9 +19,9 @@ orchard = { version = "0.15" }
 pasta_curves = "0.5"
 ff = "0.13"
 sapling = { package = "sapling-crypto", version = "0.7", default-features = false }
-transparent = { package = "zcash_transparent", version = "0.9", default-features = false }
+transparent = { package = "zcash_transparent", version = "0.10", default-features = false }
 zcash_address = { version = "0.13" }
-zcash_client_backend = { version = "0.24.0-rc.1", features = [
+zcash_client_backend = { version = "0.24.0-rc.2", features = [
     "lightwalletd-tonic-tls-webpki-roots",
     "orchard",
     "pczt",
@@ -29,17 +29,14 @@ zcash_client_backend = { version = "0.24.0-rc.1", features = [
     "transparent-inputs",
     "unstable",
 ] }
-zcash_client_sqlite = { version = "0.22.0-rc.1", features = ["orchard", "transparent-inputs", "unstable", "serde"] }
+zcash_client_sqlite = { version = "0.22.0-rc.2", features = ["orchard", "transparent-inputs", "unstable", "serde"] }
 zcash_note_encryption = "0.4.1"
-zcash_primitives = "0.29"
-zcash_proofs = "0.29"
+zcash_primitives = "0.30"
+zcash_proofs = "0.30"
 zcash_protocol = "0.10"
 zcash_script = "0.4"
 zip32 = "0.2"
-# Pinned exactly: 0.8.0 pulls zcash_transparent 0.10 / zcash_primitives 0.30,
-# which duplicates the 0.9 / 0.29 the rest of the graph uses and breaks the
-# build. The rc.1 depends on the matching 0.9 / 0.29.
-pczt = { version = "=0.8.0-rc.1", features = ["prover", "orchard", "sapling"] }
+pczt = { version = "0.8.0", features = ["prover", "orchard", "sapling"] }
 
 # EIP-681
 eip681 = "0.1.0"
@@ -97,7 +94,7 @@ xz2 = { version = "0.1", features = ["static"] }
 #     "client-pir",
 #     "client-tree-sync",
 # ] }
-zcash_keys = { version = "0.15", features = ["orchard"] }
+zcash_keys = { version = "0.16", features = ["orchard"] }
 
 [features]
 default = []

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -47,7 +47,7 @@ use zcash_client_backend::{
         wallet::{
             self, SpendingKeys, create_pczt_from_proposal, create_proposed_transactions,
             decrypt_and_store_transaction, extract_and_store_transaction_from_pczt,
-            input_selection::{GreedyInputSelector, SpendPolicy},
+            input_selection::{GreedyInputSelector, LockFilter, LockedInputPolicy, SpendPolicy},
             propose_send_max_transfer, propose_shielding, propose_transfer,
         },
     },
@@ -1034,6 +1034,7 @@ pub unsafe extern "C" fn zcashlc_get_verified_transparent_balance(
                 target,
                 confirmations_policy,
                 CoinbaseFilter::AllTransparentOutputs,
+                LockFilter::Policy(&LockedInputPolicy::Exclude),
             )
             .map_err(|e| anyhow!("Error while fetching verified transparent balance: {}", e))?;
         let amount = utxos
@@ -1098,6 +1099,7 @@ pub unsafe extern "C" fn zcashlc_get_verified_transparent_balance_for_account(
                         target,
                         confirmations_policy,
                         CoinbaseFilter::AllTransparentOutputs,
+                        LockFilter::Policy(&LockedInputPolicy::Exclude),
                     )
                     .map_err(|e| {
                         anyhow!("Error while fetching verified transparent balance: {}", e)
@@ -1149,6 +1151,7 @@ pub unsafe extern "C" fn zcashlc_get_total_transparent_balance(
                 target,
                 wallet::ConfirmationsPolicy::new_symmetrical(NonZeroU32::MIN, true),
                 CoinbaseFilter::AllTransparentOutputs,
+                LockFilter::Policy(&LockedInputPolicy::Exclude),
             )
             .map_err(|e| anyhow!("Error while fetching total transparent balance: {}", e))?
             .iter()
@@ -2235,6 +2238,7 @@ pub unsafe extern "C" fn zcashlc_propose_transfer(
         .map_err(|e| anyhow!("Error creating transaction request: {:?}", e))?;
 
         let spend_policy = SpendPolicy::default();
+        let lock_inputs = None;
         let proposed_version = None;
         let proposal = propose_transfer::<_, _, _, _, Infallible>(
             &mut db_data,
@@ -2245,6 +2249,7 @@ pub unsafe extern "C" fn zcashlc_propose_transfer(
             req,
             wallet::ConfirmationsPolicy::try_from(confirmations_policy)?,
             &spend_policy,
+            lock_inputs,
             proposed_version,
         )
         .map_err(|e| anyhow!("Error while sending funds: {}", e))?;
@@ -2352,6 +2357,8 @@ pub unsafe extern "C" fn zcashlc_propose_send_max_transfer(
         };
 
         let confirmation_policy = wallet::ConfirmationsPolicy::try_from(confirmations_policy)?;
+        let locked_input_policy = LockedInputPolicy::Exclude;
+        let lock_inputs = None;
 
         let proposal = propose_send_max_transfer::<_, _, _, Infallible>(
             &mut db_data,
@@ -2363,6 +2370,8 @@ pub unsafe extern "C" fn zcashlc_propose_send_max_transfer(
             memo,
             mode,
             confirmation_policy,
+            &locked_input_policy,
+            lock_inputs,
         )
         .map_err(|e| anyhow!("Error while sending funds: {}", e))?;
 
@@ -2417,6 +2426,7 @@ pub unsafe extern "C" fn zcashlc_propose_transfer_from_uri(
             .map_err(|e| anyhow!("Error creating transaction request: {:?}", e))?;
 
         let spend_policy = SpendPolicy::default();
+        let lock_inputs = None;
         let proposed_version = None;
         let proposal = propose_transfer::<_, _, _, _, Infallible>(
             &mut db_data,
@@ -2427,6 +2437,7 @@ pub unsafe extern "C" fn zcashlc_propose_transfer_from_uri(
             req,
             wallet::ConfirmationsPolicy::try_from(confirmations_policy)?,
             &spend_policy,
+            lock_inputs,
             proposed_version,
         )
         .map_err(|e| anyhow!("Error while sending funds: {}", e))?;
@@ -2625,6 +2636,7 @@ pub unsafe extern "C" fn zcashlc_propose_shielding(
         };
 
         let (change_strategy, input_selector) = zip317_helper(Some(memo_bytes));
+        let lock_inputs = None;
         let proposal = propose_shielding::<_, _, _, _, Infallible>(
             &mut db_data,
             &network,
@@ -2635,6 +2647,7 @@ pub unsafe extern "C" fn zcashlc_propose_shielding(
             account_uuid,
             confirmations_policy,
             CoinbaseFilter::AllTransparentOutputs,
+            lock_inputs,
         )
         .map_err(|e| anyhow!("Error while shielding transaction: {}", e))?;
 
@@ -2727,6 +2740,7 @@ pub unsafe extern "C" fn zcashlc_create_proposed_transactions(
         }));
 
         let prover = LocalTxProver::new(spend_params, output_params);
+        let expiry_height = None;
 
         let txids = create_proposed_transactions::<_, _, Infallible, _, Infallible, _>(
             &mut db_data,
@@ -2736,6 +2750,7 @@ pub unsafe extern "C" fn zcashlc_create_proposed_transactions(
             &SpendingKeys::from_unified_spending_key(usk),
             OvkPolicy::Sender,
             &proposal,
+            expiry_height,
         )
         .map_err(|e| anyhow!("Error while sending funds: {}", e))?;
 
@@ -2803,7 +2818,7 @@ pub unsafe extern "C" fn zcashlc_create_pczt_from_proposal(
 
         if proposal.steps().len() == 1 {
             let target_expiry_height = None;
-            let orchard_pool_bundle_type = orchard::builder::BundleType::DEFAULT;
+            let orchard_pool_padding = zcash_primitives::transaction::builder::BundlePadding::DEFAULT;
             let pczt = create_pczt_from_proposal::<_, _, Infallible, _, Infallible, _>(
                 &mut db_data,
                 &network,
@@ -2811,7 +2826,7 @@ pub unsafe extern "C" fn zcashlc_create_pczt_from_proposal(
                 OvkPolicy::Sender,
                 &proposal,
                 target_expiry_height,
-                orchard_pool_bundle_type,
+                orchard_pool_padding,
             )
             .map_err(|e| anyhow!("Error creating PCZT from single-step proposal: {}", e))?;
 

--- a/rust/src/migration.rs
+++ b/rust/src/migration.rs
@@ -12,7 +12,7 @@ use zcash_address::{ToAddress, ZcashAddress, unified, unified::Encoding as _};
 use zcash_client_backend::{
     data_api::{
         Account as _, InputSource, MaxSpendMode, WalletRead,
-        wallet::{ConfirmationsPolicy, propose_send_max_transfer},
+        wallet::{ConfirmationsPolicy, input_selection::LockedInputPolicy, propose_send_max_transfer},
     },
     fees::StandardFeeRule,
     proposal::Proposal,
@@ -79,6 +79,8 @@ pub(crate) fn propose_orchard_to_ironwood(
     let memo: Option<MemoBytes> = None;
     let mode = MaxSpendMode::Everything;
     let confirmations_policy = ConfirmationsPolicy::default();
+    let locked_input_policy = LockedInputPolicy::Exclude;
+    let lock_inputs = None;
 
     propose_send_max_transfer::<_, _, _, std::convert::Infallible>(
         db_data,
@@ -90,6 +92,8 @@ pub(crate) fn propose_orchard_to_ironwood(
         memo,
         mode,
         confirmations_policy,
+        &locked_input_policy,
+        lock_inputs,
     )
     .map_err(|e| anyhow!("Error creating the migration proposal: {}", e))
 }

--- a/rust/src/tor.rs
+++ b/rust/src/tor.rs
@@ -93,7 +93,9 @@ impl TorRuntime {
     pub(crate) fn connect_to_lightwalletd(&self, endpoint: Uri) -> anyhow::Result<LwdConn> {
         let Self { runtime, client } = self.isolated_client();
 
-        let conn = runtime.block_on(async { client.connect_to_lightwalletd(endpoint).await })?;
+        let allow_onion_services = false;
+        let conn =
+            runtime.block_on(async { client.connect_to_lightwalletd(endpoint, allow_onion_services).await })?;
 
         Ok(LwdConn {
             runtime,


### PR DESCRIPTION
Prepares the Rust core for the next librustzcash crates release, replicating
the Android SDK's #2046.

Stacked on the send-max branch (`feature/send-max-migration-2.5.3`).

The frozen crates.io release candidates (zcash_client_backend 0.24.0-rc.1,
zcash_client_sqlite 0.22.0-rc.1) were superseded by breaking API changes to the
send-max and Ironwood paths. This moves the backend onto the released
librustzcash crates and adapts the FFI to those changes. Send-max and Ironwood
keep working; no C-ABI signatures change.

Two commits:

1. Cargo: move onto the released crates.io versions (zcash_client_backend
   0.24.0-rc.2, zcash_client_sqlite 0.22.0-rc.2, pczt 0.8.0, zcash_transparent
   0.10, zcash_primitives/zcash_proofs 0.30, zcash_keys 0.16). No
   [patch.crates-io] git overrides are needed; Cargo.lock is committed.
2. Code: adapt the call sites for the parameters added after the RC
   (Option<LockRequest> input-lock, &LockedInputPolicy, LockFilter, expiry
   height, BundlePadding, allow-onion-services), each a named let binding
   passing the behavior-preserving default.

Gates: cargo build green, swift build green, OfflineTests 326/0.