### PR TITLE
Advance maint/v3.0.x to the 2.8.x branch point

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -5,7 +5,6 @@ on:
     paths-ignore:
       - '.github/ISSUE_TEMPLATE/*'
       - '.github/PULL_REQUEST_TEMPLATE.md'
-      - 'LICENSE'
       - 'README.md'
       - 'CHANGELOG.md'
       - 'CONTRIBUTING.md'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
+## Fixed
+- Tor-layer errors (`rustTorConnectToLightwalletd`, `rustTorLwdGetInfo`, `rustTorLwdSubmit`, `rustTorLwdFetchTransaction`, `rustTorLwdLatestBlockHeight`, `rustTorLwdGetTreeState`) are now classified as retryable service errors in `CompactBlockProcessor`. Previously these errors bypassed the service-error retry path and went straight to a fatal sync failure, so a transient Tor circuit/stream issue (e.g. "remote hostname lookup failure", "Failed to obtain exit circuit for ports", "Tor network protocol violation") required a full app restart to recover. They now trigger the same reset-and-retry behavior (including tearing down cached Tor connections via `service.closeConnections()`) as other transport errors, up to `ZcashSDK.serviceFailureRetries` times.
+
 # 2.6.0-alpha.6
 
 ## Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Fixed
 - Tor-layer errors (`rustTorConnectToLightwalletd`, `rustTorLwdGetInfo`, `rustTorLwdSubmit`, `rustTorLwdFetchTransaction`, `rustTorLwdLatestBlockHeight`, `rustTorLwdGetTreeState`) are now classified as retryable service errors in `CompactBlockProcessor`. Previously these errors bypassed the service-error retry path and went straight to a fatal sync failure, so a transient Tor circuit/stream issue (e.g. "remote hostname lookup failure", "Failed to obtain exit circuit for ports", "Tor network protocol violation") required a full app restart to recover. They now trigger the same reset-and-retry behavior (including tearing down cached Tor connections via `service.closeConnections()`) as other transport errors, up to `ZcashSDK.serviceFailureRetries` times.
+- `Initializer.initialize` / `Synchronizer.prepare` now return `InitializationResult.seedNotRelevant` instead of silently proceeding when the rust layer reports the provided seed is not relevant to the wallet database. Previously this case was indistinguishable from `.success`: account creation was skipped (accounts already existed) and callers proceeded as if they had prepared the wallet they expected, even when the database on disk belonged to a different wallet than the provided seed (e.g. a device-backup restore that brings back `data.db` without the matching keychain seed). Callers must now handle `.seedNotRelevant` the same way they already handle `.seedRequired`. (MOB-1512)
 
 # 2.6.0-alpha.6
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,11 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
+## Changed
+- `Initializer.initialize` / `Synchronizer.prepare` now return `InitializationResult.seedNotRelevant` instead of silently proceeding when the rust layer reports the provided seed is not relevant to the wallet database (breaking change: `InitializationResult` gained a new case, so exhaustive switches over it must add a case; see MIGRATING.md). Previously this case was indistinguishable from `.success`: account creation was skipped (accounts already existed) and callers proceeded as if they had prepared the wallet they expected, even when the database on disk belonged to a different wallet than the provided seed (e.g. a device-backup restore that brings back `data.db` without the matching keychain seed). Callers must now handle `.seedNotRelevant` the same way they already handle `.seedRequired`. (MOB-1512)
+
 ## Fixed
 - Tor-layer errors (`rustTorConnectToLightwalletd`, `rustTorLwdGetInfo`, `rustTorLwdSubmit`, `rustTorLwdFetchTransaction`, `rustTorLwdLatestBlockHeight`, `rustTorLwdGetTreeState`) are now classified as retryable service errors in `CompactBlockProcessor`. Previously these errors bypassed the service-error retry path and went straight to a fatal sync failure, so a transient Tor circuit/stream issue (e.g. "remote hostname lookup failure", "Failed to obtain exit circuit for ports", "Tor network protocol violation") required a full app restart to recover. They now trigger the same reset-and-retry behavior (including tearing down cached Tor connections via `service.closeConnections()`) as other transport errors, up to `ZcashSDK.serviceFailureRetries` times.
-- `Initializer.initialize` / `Synchronizer.prepare` now return `InitializationResult.seedNotRelevant` instead of silently proceeding when the rust layer reports the provided seed is not relevant to the wallet database. Previously this case was indistinguishable from `.success`: account creation was skipped (accounts already existed) and callers proceeded as if they had prepared the wallet they expected, even when the database on disk belonged to a different wallet than the provided seed (e.g. a device-backup restore that brings back `data.db` without the matching keychain seed). Callers must now handle `.seedNotRelevant` the same way they already handle `.seedRequired`. (MOB-1512)
 
 # 2.6.0-alpha.6
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,6 +101,7 @@ Generated files and `Tests/` are excluded from the main `.swiftlint.yml` (tests 
 - **TODOs**: format as `TODO: [#<issue_number>] ...` — bare `TODO:`/`FIXME:` warn.
 - **SwiftLint disables**: only the exceptions listed in `SWIFTLINT.md` are permitted, always scoped with `// swiftlint:disable:next` / `disable:previous` / region blocks.
 - **Commits and PRs**: every PR must reference an issue. Commit title format is `[#<issue_number>] <self-descriptive title>` (see `CONTRIBUTING.md`). PRs are typically squash-merged.
+- **Rust formatting**: always run `cargo fmt` in `rust/` before committing changes to the Rust code. Consistent formatting keeps diffs minimal and avoids spurious conflicts when rebasing.
 - **Breaking API changes**: document them in `MIGRATING.md`, and add a `CHANGELOG.md` entry for every user-visible change.
 - **Main branch policy**: `main` is development-stable (all merges build + tests pass) but clients must depend on published tags, never on `main`.
 - **Sync concurrency**: `CompactBlockProcessor` is a Swift actor. Callers without structured concurrency should hop to `@MainActor` contexts rather than blocking.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ The Rust code in `rust/` is compiled into the `libzcashlc` XCFramework. Two mode
 
 Scripts:
 
-- `./Scripts/init-local-ffi.sh` — one-time setup; default builds all 5 architectures and creates `LocalPackages/`. **`--macos-only`** builds only the macOS slice from your `rust/` (good for `swift build` / `swift test` on the Mac). Use `--cached` only when your branch has no FFI changes relative to the release. Use --macos-only to rebuild for fast local development.
+- `./Scripts/init-local-ffi.sh` — one-time setup; default builds all 5 architectures and creates `LocalPackages/`. Arm-only subsets (faster on Apple Silicon — they skip the x86_64 slices): **`--arm-macos`** (macOS slice only, good for `swift build` / `swift test` on the Mac), **`--arm-ios`** (iOS simulator + device slices), **`--arm-all`** (iOS simulator + device + macOS). Use `--cached` only when your branch has no FFI changes relative to the release.
 - `./Scripts/rebuild-local-ffi.sh [ios-sim|ios-device|macos]` — fast single-arch incremental rebuild after Rust edits. `ios-sim` is default.
 - `./Scripts/reset-local-ffi.sh` — remove `LocalPackages/` and switch back to the release binary.
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020 Zcash
+Copyright © 2026 Znewco, Inc. (d/b/a Zcash Open Development Lab)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -26,6 +26,10 @@ let outcome = await synchronizer.broadcaster.submit(
 - The retry plan is recorded before any network attempt and stays recorded when `submit` returns `.cancelled` or `.timedOut`: background resubmission may still broadcast the transaction later. Treat those outcomes as "outcome unknown", not as "not sent".
 - `LightWalletEndpoint` now conforms to `Equatable`. If your app declared that conformance retroactively, remove your declaration.
 
+## `Initializer.InitializationResult` gained `.seedNotRelevant`
+
+`Initializer.InitializationResult` (returned by `Initializer.initialize` and `Synchronizer.prepare`) gained a new case, `.seedNotRelevant`, returned when the rust layer reports that the provided seed does not match the accounts already present in the wallet database. Any exhaustive `switch` over `InitializationResult` must add a case for it. `prepare`/`initialize` can now return `.seedNotRelevant` in situations where they previously returned `.success` over a mismatched database — handle it the same way you already handle `.seedRequired`.
+
 # Migrating from previous versions to 0.20.0-beta
 The `SDKSynchronizer` no longer uses `NotificationCenter` to send notifications.
 Notifications are replaced with `Combine` publishers.

--- a/Scripts/init-local-ffi.sh
+++ b/Scripts/init-local-ffi.sh
@@ -1,8 +1,18 @@
 #!/bin/bash
 # Initialize local FFI development environment
-# Usage: ./Scripts/init-local-ffi.sh [--cached|--macos-only]
-#   --cached      Download pre-built release instead of building from source
-#   --macos-only  Build only the macOS slice from your rust/ (fast; swift build / swift test on Mac)
+# Usage: ./Scripts/init-local-ffi.sh [option]
+#
+# Options:
+#   (no option)   Build the full XCFramework (all 5 architectures) from your rust/.
+#   --arm-macos   Build only the arm64 macOS slice (aarch64-apple-darwin).
+#   --arm-ios     Build only the arm64 iOS slices: simulator (aarch64-apple-ios-sim)
+#                 and device (aarch64-apple-ios).
+#   --arm-all     Build all arm64 slices: iOS simulator + device + macOS.
+#   --cached      Download the pre-built release XCFramework instead of building.
+#
+# The --arm-* options skip the x86_64 simulator/Mac slices, which you cannot run on
+# Apple Silicon anyway, so local iteration is faster. They always build the aarch64
+# targets regardless of host architecture.
 #
 # This creates LocalPackages/ with a locally-built xcframework.
 # Package.swift automatically detects LocalPackages/ and switches
@@ -18,23 +28,151 @@ if [[ -f "$HOME/.cargo/env" ]]; then
     source "$HOME/.cargo/env"
 fi
 
-USE_CACHED=false
-MACOS_ONLY=false
-if [[ "${1:-}" == "--cached" ]]; then
-    USE_CACHED=true
-elif [[ "${1:-}" == "--macos-only" ]]; then
-    MACOS_ONLY=true
-fi
-
 XCFRAMEWORK_DIR="LocalPackages/libzcashlc.xcframework"
 
-if [[ "$MACOS_ONLY" == "true" ]]; then
-    echo "Initializing local FFI for macOS only (single-arch from your rust/)..."
+usage() {
+    if [[ -n "${1:-}" ]]; then
+        echo "Error: $1" >&2
+        echo "" >&2
+    fi
+    cat >&2 << 'USAGEEOF'
+Usage: ./Scripts/init-local-ffi.sh [option]
+
+Options:
+  (no option)   Build the full XCFramework (all 5 architectures) from your rust/.
+  --arm-macos   Build only the arm64 macOS slice (aarch64-apple-darwin).
+  --arm-ios     Build only the arm64 iOS slices: simulator + device.
+  --arm-all     Build all arm64 slices: iOS simulator + device + macOS.
+  --cached      Download the pre-built release XCFramework instead of building.
+
+Creates LocalPackages/ with a locally-built xcframework. Package.swift detects
+LocalPackages/ and uses it instead of the released binary.
+USAGEEOF
+    exit 1
+}
+
+# Build an arm64-only xcframework containing exactly the requested slices, then
+# atomically swap it into place. Each argument is one of: ios-sim, ios-device, macos.
+#
+# The slices reuse the same LibraryIdentifiers as the full build (e.g.
+# macos-arm64_x86_64) but declare only arm64 in SupportedArchitectures, matching
+# what rebuild-local-ffi.sh produces, so the two tools stay interchangeable.
+build_arm_xcframework() {
+    local targets=("$@")
+
+    local temp_dir temp_xcfw
+    temp_dir=$(mktemp -d)
+    temp_xcfw="$temp_dir/libzcashlc.xcframework"
+    mkdir -p "$temp_xcfw"
+
+    # One JSON object per slice, accumulated for the xcframework Info.plist.
+    local libraries_json=""
+
+    local target
+    for target in "${targets[@]}"; do
+        local rust_target slice platform variant
+        case "$target" in
+            ios-sim)
+                rust_target="aarch64-apple-ios-sim"
+                slice="ios-arm64_x86_64-simulator"
+                platform="ios"
+                variant="simulator"
+                ;;
+            ios-device)
+                rust_target="aarch64-apple-ios"
+                slice="ios-arm64"
+                platform="ios"
+                variant=""
+                ;;
+            macos)
+                rust_target="aarch64-apple-darwin"
+                slice="macos-arm64_x86_64"
+                platform="macos"
+                variant=""
+                ;;
+            *)
+                echo "Internal error: unknown arm target '$target'" >&2
+                exit 1
+                ;;
+        esac
+
+        echo "Building $rust_target -> $slice ..."
+
+        # Ensure the Rust target is available (idempotent), then build it.
+        # cargo is incremental, so repeat builds after small edits are fast.
+        rustup target add "$rust_target"
+        cargo build --target "$rust_target" --release
+
+        # Populate the framework for this slice.
+        local framework="$temp_xcfw/$slice/libzcashlc.framework"
+        mkdir -p "$framework/Modules" "$framework/Headers"
+        cp "target/$rust_target/release/libzcashlc.a" "$framework/libzcashlc"
+        cp BuildSupport/module.modulemap "$framework/Modules/"
+        cp BuildSupport/platform-Info.plist "$framework/Info.plist"
+        if [[ -d "target/Headers" ]]; then
+            cp -R target/Headers/* "$framework/Headers/"
+        fi
+
+        # Assemble this slice's AvailableLibraries entry as JSON (arm64 only).
+        local variant_json=""
+        if [[ -n "$variant" ]]; then
+            variant_json=", \"SupportedPlatformVariant\": \"$variant\""
+        fi
+        local entry="{\"LibraryIdentifier\": \"$slice\", \"LibraryPath\": \"libzcashlc.framework\", \"SupportedArchitectures\": [\"arm64\"], \"SupportedPlatform\": \"$platform\"$variant_json}"
+        if [[ -n "$libraries_json" ]]; then
+            libraries_json="$libraries_json, $entry"
+        else
+            libraries_json="$entry"
+        fi
+    done
+
+    # Generate the xcframework Info.plist from JSON; plutil emits canonical XML
+    # and validates it in one step, so we avoid hand-writing plist whitespace.
+    printf '{"AvailableLibraries": [%s], "CFBundlePackageType": "XFWK", "XCFrameworkFormatVersion": "1.0"}' "$libraries_json" \
+        | plutil -convert xml1 -o "$temp_xcfw/Info.plist" -
+
+    # Atomically swap the freshly built xcframework into place.
     mkdir -p LocalPackages
-    # rebuild-local-ffi.sh requires this directory to exist; it replaces contents entirely.
-    mkdir -p "$XCFRAMEWORK_DIR"
-    ./Scripts/rebuild-local-ffi.sh macos
-elif [[ "$USE_CACHED" == "true" ]]; then
+    rm -rf "$XCFRAMEWORK_DIR"
+    mv "$temp_xcfw" "$XCFRAMEWORK_DIR"
+    rm -rf "$temp_dir"
+}
+
+# Parse the single optional flag.
+if [[ $# -gt 1 ]]; then
+    usage "Too many arguments; pass at most one option."
+fi
+
+BUILD_MODE="full"
+ARM_TARGETS=()
+case "${1:-}" in
+    "")
+        BUILD_MODE="full"
+        ;;
+    --cached)
+        BUILD_MODE="cached"
+        ;;
+    --arm-macos)
+        BUILD_MODE="arm"
+        ARM_TARGETS=(macos)
+        ;;
+    --arm-ios)
+        BUILD_MODE="arm"
+        ARM_TARGETS=(ios-sim ios-device)
+        ;;
+    --arm-all)
+        BUILD_MODE="arm"
+        ARM_TARGETS=(ios-sim ios-device macos)
+        ;;
+    *)
+        usage "Unknown option: $1"
+        ;;
+esac
+
+if [[ "$BUILD_MODE" == "arm" ]]; then
+    echo "Initializing local FFI for arm64 (${ARM_TARGETS[*]})..."
+    build_arm_xcframework "${ARM_TARGETS[@]}"
+elif [[ "$BUILD_MODE" == "cached" ]]; then
     echo "Downloading pre-built xcframework..."
     REPO="zcash/zcash-swift-wallet-sdk"
 
@@ -95,10 +233,12 @@ echo "Next steps:"
 echo "  1. Open ZcashSDK.xcworkspace in Xcode (or run: swift build)"
 echo "  2. The workspace scheme rebuilds FFI automatically on each build."
 echo "     If opening Package.swift directly, run ./Scripts/rebuild-local-ffi.sh after Rust changes."
-if [[ "$MACOS_ONLY" == "true" ]]; then
+if [[ "$BUILD_MODE" == "arm" ]]; then
     echo ""
-    echo "Note: --macos-only produced a single-slice XCFramework. For iOS Simulator or device,"
-    echo "      run ./Scripts/rebuild-local-ffi.sh ios-sim or ios-device, or full ./Scripts/init-local-ffi.sh for every arch."
+    echo "Note: this produced an arm64-only XCFramework (${ARM_TARGETS[*]})."
+    echo "      Building for an x86_64 simulator/Mac or a slice you didn't include will fail"
+    echo "      until you build it. Run ./Scripts/rebuild-local-ffi.sh <target> for a single"
+    echo "      arch, or ./Scripts/init-local-ffi.sh (no flags) for the full 5-architecture build."
 fi
 echo ""
 echo "To switch back to the release binary: rm -rf LocalPackages/"

--- a/Scripts/prepare-release.sh
+++ b/Scripts/prepare-release.sh
@@ -9,6 +9,9 @@
 #   4. Writes release info to BuildSupport/products/release.env
 #   5. Outputs the values needed for Package.swift
 #
+# Versions with a SemVer pre-release suffix (e.g. 2.6.0-alpha.1, 2.7.0-rc.2)
+# are detected automatically and the GitHub release is marked as a pre-release.
+#
 # After running this script:
 #   1. Update Package.swift with the URL and checksum
 #   2. Commit the Package.swift change
@@ -49,7 +52,16 @@ REPO="zcash/zcash-swift-wallet-sdk"
 PRODUCTS_DIR="BuildSupport/products"
 ZIP_FILE="libzcashlc.xcframework.zip"
 
+# SemVer: a hyphen in the version (e.g. 2.6.0-alpha.1) marks a pre-release
+PRERELEASE_FLAG=()
+if [[ "$VERSION" == *-* ]]; then
+    PRERELEASE_FLAG=(--prerelease)
+fi
+
 echo "=== Preparing release ${VERSION} ==="
+if [[ ${#PRERELEASE_FLAG[@]} -gt 0 ]]; then
+    echo "Pre-release suffix detected. The GitHub release will be marked as a pre-release."
+fi
 echo ""
 
 # Check for uncommitted changes (skip in non-interactive mode, e.g. CI)
@@ -110,7 +122,8 @@ else
         --repo "$REPO" \
         --title "$VERSION" \
         --notes "Zcash Light Client SDK ${VERSION}" \
-        --draft
+        --draft \
+        "${PRERELEASE_FLAG[@]}"
 fi
 
 RELEASE_URL="https://github.com/${REPO}/releases/tag/${VERSION}"

--- a/Scripts/prepare-release.sh
+++ b/Scripts/prepare-release.sh
@@ -116,6 +116,13 @@ if gh release view "$VERSION" --repo "$REPO" &>/dev/null; then
         "$PRODUCTS_DIR/$ZIP_FILE" \
         --repo "$REPO" \
         --clobber
+    # gh release upload can only replace assets, not release properties, so an
+    # existing release (e.g. one created before pre-release detection existed)
+    # needs an explicit edit to gain the pre-release bit.
+    if [[ ${#PRERELEASE_FLAG[@]} -gt 0 ]]; then
+        echo "Marking existing release ${VERSION} as a pre-release."
+        gh release edit "$VERSION" --repo "$REPO" "${PRERELEASE_FLAG[@]}"
+    fi
 else
     gh release create "$VERSION" \
         "$PRODUCTS_DIR/$ZIP_FILE" \

--- a/Scripts/release.sh
+++ b/Scripts/release.sh
@@ -17,6 +17,9 @@
 #              (e.g., 'origin' or 'upstream')
 #   <version>  The version to release (e.g., '2.5.0')
 #
+# Versions with a SemVer pre-release suffix (e.g. 2.6.0-alpha.1, 2.7.0-rc.2)
+# are detected automatically and the GitHub release is marked as a pre-release.
+#
 # Prerequisites:
 #   - gh CLI installed and authenticated
 #   - Rust toolchain with all Apple targets
@@ -58,7 +61,16 @@ fi
 REPO="zcash/zcash-swift-wallet-sdk"
 PRODUCTS_DIR="BuildSupport/products"
 
+# SemVer: a hyphen in the version (e.g. 2.6.0-alpha.1) marks a pre-release
+PRERELEASE_FLAG=()
+if [[ "$VERSION" == *-* ]]; then
+    PRERELEASE_FLAG=(--prerelease)
+fi
+
 echo "=== SDK Release ${VERSION} ==="
+if [[ ${#PRERELEASE_FLAG[@]} -gt 0 ]]; then
+    echo "Pre-release suffix detected. The GitHub release will be marked as a pre-release."
+fi
 echo ""
 
 # Verify clean working directory
@@ -148,7 +160,7 @@ if [[ ! $REPLY =~ ^[Yy]$ ]]; then
     echo "Release paused. To resume manually:"
     echo "  git tag -s ${VERSION} -m \"Release ${VERSION}\""
     echo "  git push ${UPSTREAM_REMOTE} ${CURRENT_BRANCH} ${VERSION}"
-    echo "  gh release edit ${VERSION} --repo ${REPO} --draft=false"
+    echo "  gh release edit ${VERSION} --repo ${REPO} --draft=false${PRERELEASE_FLAG:+ ${PRERELEASE_FLAG[*]}}"
     exit 0
 fi
 
@@ -162,11 +174,15 @@ git push "$UPSTREAM_REMOTE" "$CURRENT_BRANCH" "$VERSION"
 
 echo ""
 echo "=== Step 6/6: Publishing release ==="
-gh release edit "$VERSION" --repo "$REPO" --draft=false
+gh release edit "$VERSION" --repo "$REPO" --draft=false "${PRERELEASE_FLAG[@]}"
 
 echo ""
 echo "=========================================="
-echo "  Release ${VERSION} complete!"
+if [[ ${#PRERELEASE_FLAG[@]} -gt 0 ]]; then
+    echo "  Pre-release ${VERSION} complete!"
+else
+    echo "  Release ${VERSION} complete!"
+fi
 echo "=========================================="
 echo ""
 echo "  GitHub Release: https://github.com/${REPO}/releases/tag/${VERSION}"

--- a/Sources/ZcashLightClientKit/Block/CompactBlockProcessor.swift
+++ b/Sources/ZcashLightClientKit/Block/CompactBlockProcessor.swift
@@ -654,7 +654,10 @@ extension CompactBlockProcessor {
                     ZcashError.serviceLatestBlockHeightFailed, ZcashError.serviceBlockRangeFailed,
                     ZcashError.serviceSubmitFailed, ZcashError.serviceFetchTransactionFailed,
                     ZcashError.serviceFetchUTXOsFailed, ZcashError.serviceBlockStreamFailed,
-                    ZcashError.serviceSubtreeRootsStreamFailed: serviceError = true
+                    ZcashError.serviceSubtreeRootsStreamFailed,
+                    ZcashError.rustTorConnectToLightwalletd, ZcashError.rustTorLwdGetInfo,
+                    ZcashError.rustTorLwdSubmit, ZcashError.rustTorLwdFetchTransaction,
+                    ZcashError.rustTorLwdLatestBlockHeight, ZcashError.rustTorLwdGetTreeState: serviceError = true
                 default:
                     // Non-ZcashError exceptions are raw gRPC/transport failures that escaped without
                     // proper wrapping — treat them as service errors so the retry logic kicks in

--- a/Sources/ZcashLightClientKit/Initializer.swift
+++ b/Sources/ZcashLightClientKit/Initializer.swift
@@ -105,6 +105,7 @@ public class Initializer {
     public enum InitializationResult {
         case success
         case seedRequired
+        case seedNotRelevant
     }
 
     public enum LoggingPolicy {
@@ -424,6 +425,11 @@ public class Initializer {
     /// and is view-only, or by a wallet that does have the seed but the process does not have the
     /// consent of the OS to fetch the keys from the secure storage, like on background tasks.
     ///
+    /// `InitializationResult.seedNotRelevant` is returned when the provided seed does not match the accounts
+    /// already present in the wallet database. The rust layer currently reports this during seed-requiring
+    /// migrations; callers must treat it as "this database belongs to a different wallet" rather than proceed
+    /// as if initialization succeeded.
+    ///
     /// 'cache.db' and 'data.db' files are created by this function (if they
     /// do not already exist). These files can be given a prefix for scenarios where multiple wallets
     ///
@@ -439,8 +445,13 @@ public class Initializer {
     ) async throws -> InitializationResult {
         try await storage.create()
 
-        if case .seedRequired = try await rustBackend.initDataDb(seed: seed) {
+        switch try await rustBackend.initDataDb(seed: seed) {
+        case .seedRequired:
             return .seedRequired
+        case .seedNotRelevant:
+            return .seedNotRelevant
+        case .success:
+            break
         }
 
         let checkpointSource = container.resolve(CheckpointSource.self)

--- a/Sources/ZcashLightClientKit/Synchronizer.swift
+++ b/Sources/ZcashLightClientKit/Synchronizer.swift
@@ -121,6 +121,11 @@ public protocol Synchronizer: AnyObject {
     /// and is view-only, or by a wallet that does have the seed but the process does not have the
     /// consent of the OS to fetch the keys from the secure storage, like on background tasks.
     ///
+    /// `InitializationResult.seedNotRelevant` is returned when the provided seed does not match the accounts
+    /// already present in the wallet database. The rust layer currently reports this during seed-requiring
+    /// migrations; callers must treat it as "this database belongs to a different wallet" rather than proceed
+    /// as if initialization succeeded.
+    ///
     /// 'cache.db' and 'data.db' files are created by this function (if they
     /// do not already exist). These files can be given a prefix for scenarios where multiple wallets
     ///

--- a/Sources/ZcashLightClientKit/Synchronizer/SDKSynchronizer.swift
+++ b/Sources/ZcashLightClientKit/Synchronizer/SDKSynchronizer.swift
@@ -168,14 +168,19 @@ public class SDKSynchronizer: Synchronizer {
             throw error
         }
 
-        if case .seedRequired = try await self.initializer.initialize(
+        let initResult = try await self.initializer.initialize(
             with: seed,
             walletBirthday: walletBirthday,
             for: walletMode,
             name: name,
             keySource: keySource
-        ) {
-            return .seedRequired
+        )
+
+        switch initResult {
+        case .seedRequired, .seedNotRelevant:
+            return initResult
+        case .success:
+            break
         }
 
         await latestBlocksDataProvider.updateWalletBirthday(initializer.walletBirthday)

--- a/Tests/OfflineTests/SynchronizerOfflineTests.swift
+++ b/Tests/OfflineTests/SynchronizerOfflineTests.swift
@@ -336,6 +336,48 @@ class SynchronizerOfflineTests: ZcashTestCase {
         await fulfillment(of: [expectation], timeout: 1)
     }
 
+    /// MOB-1512: `SDKSynchronizer.prepare` must propagate `.seedNotRelevant` from `Initializer.initialize` instead of
+    /// treating it the same as `.success`, otherwise a caller can end up "prepared" against a wallet database that
+    /// doesn't belong to the seed it holds (e.g. a restored `data.db` paired with an unrelated keychain seed).
+    func testPreparePropagatesSeedNotRelevantFromRustBackend() async throws {
+        let rustBackendMock = ZcashRustBackendWeldingMock()
+        rustBackendMock.initBlockMetadataDbClosure = { }
+        rustBackendMock.initDataDbSeedClosure = { _ in DbInitResult.seedNotRelevant }
+
+        mockContainer.mock(type: ZcashRustBackendWelding.self, isSingleton: true) { _ in rustBackendMock }
+
+        let initializer = Initializer(
+            container: mockContainer,
+            cacheDbURL: nil,
+            fsBlockDbRoot: testTempDirectory,
+            generalStorageURL: testGeneralStorageDirectory,
+            dataDbURL: try __dataDbURL(),
+            torDirURL: try __torDirURL(),
+            endpoint: LightWalletEndpointBuilder.default,
+            network: network,
+            spendParamsURL: try __spendParamsURL(),
+            outputParamsURL: try __outputParamsURL(),
+            saplingParamsSourceURL: SaplingParamsSourceURL.tests,
+            isTorEnabled: false,
+            isExchangeRateEnabled: false
+        )
+
+        let synchronizer = SDKSynchronizer(initializer: initializer)
+
+        let result = try await synchronizer.prepare(
+            with: nil,
+            walletBirthday: 1900000,
+            for: .existingWallet,
+            name: "",
+            keySource: nil
+        )
+
+        guard case .seedNotRelevant = result else {
+            XCTFail("Expected `.seedNotRelevant` to propagate from `Initializer.initialize`, got \(result) instead.")
+            return
+        }
+    }
+
     func testIsNewSessionOnUnpreparedToValidTransition() {
         XCTAssertTrue(SessionTicker.live.isNewSyncSession(.unprepared, .syncing(0, false)))
     }

--- a/Tests/OfflineTests/SynchronizerOfflineTests.swift
+++ b/Tests/OfflineTests/SynchronizerOfflineTests.swift
@@ -365,7 +365,7 @@ class SynchronizerOfflineTests: ZcashTestCase {
         let synchronizer = SDKSynchronizer(initializer: initializer)
 
         let result = try await synchronizer.prepare(
-            with: nil,
+            with: Environment.seedBytes,
             walletBirthday: 1900000,
             for: .existingWallet,
             name: "",

--- a/Tests/OfflineTests/WalletTests.swift
+++ b/Tests/OfflineTests/WalletTests.swift
@@ -112,7 +112,7 @@ class WalletTests: ZcashTestCase {
         )
 
         let result = try await initializer.initialize(
-            with: nil,
+            with: seedData.bytes,
             walletBirthday: 663194,
             for: .existingWallet,
             name: ""

--- a/Tests/OfflineTests/WalletTests.swift
+++ b/Tests/OfflineTests/WalletTests.swift
@@ -83,4 +83,82 @@ class WalletTests: ZcashTestCase {
         // fileExists actually sucks, so attempting to delete the file and checking what happens is far better :)
         XCTAssertNoThrow( try FileManager.default.removeItem(at: dbData!) )
     }
+
+    /// MOB-1512: when the rust layer reports that the provided seed isn't relevant to the accounts already present in the
+    /// wallet database (for example, a restored `data.db` that belongs to a different wallet than the seed available to the
+    /// caller), `Initializer.initialize` must surface `.seedNotRelevant` to the caller instead of silently proceeding as if
+    /// initialization succeeded.
+    func testInitializePropagatesSeedNotRelevantFromRustBackend() async throws {
+        let rustBackendMock = ZcashRustBackendWeldingMock()
+        rustBackendMock.initBlockMetadataDbClosure = { }
+        rustBackendMock.initDataDbSeedClosure = { _ in DbInitResult.seedNotRelevant }
+
+        mockContainer.mock(type: ZcashRustBackendWelding.self, isSingleton: true) { _ in rustBackendMock }
+
+        let initializer = Initializer(
+            container: mockContainer,
+            cacheDbURL: nil,
+            fsBlockDbRoot: testTempDirectory,
+            generalStorageURL: testGeneralStorageDirectory,
+            dataDbURL: try __dataDbURL(),
+            torDirURL: try __torDirURL(),
+            endpoint: LightWalletEndpointBuilder.default,
+            network: network,
+            spendParamsURL: try __spendParamsURL(),
+            outputParamsURL: try __outputParamsURL(),
+            saplingParamsSourceURL: SaplingParamsSourceURL.tests,
+            isTorEnabled: false,
+            isExchangeRateEnabled: false
+        )
+
+        let result = try await initializer.initialize(
+            with: nil,
+            walletBirthday: 663194,
+            for: .existingWallet,
+            name: ""
+        )
+
+        guard case .seedNotRelevant = result else {
+            XCTFail("Expected `.seedNotRelevant` when rustBackend.initDataDb() reports it, got \(result) instead.")
+            return
+        }
+    }
+
+    /// Companion regression test for `testInitializePropagatesSeedNotRelevantFromRustBackend`: the pre-existing
+    /// `.seedRequired` propagation must keep working once `initialize` switches exhaustively over `DbInitResult`.
+    func testInitializePropagatesSeedRequiredFromRustBackend() async throws {
+        let rustBackendMock = ZcashRustBackendWeldingMock()
+        rustBackendMock.initBlockMetadataDbClosure = { }
+        rustBackendMock.initDataDbSeedClosure = { _ in DbInitResult.seedRequired }
+
+        mockContainer.mock(type: ZcashRustBackendWelding.self, isSingleton: true) { _ in rustBackendMock }
+
+        let initializer = Initializer(
+            container: mockContainer,
+            cacheDbURL: nil,
+            fsBlockDbRoot: testTempDirectory,
+            generalStorageURL: testGeneralStorageDirectory,
+            dataDbURL: try __dataDbURL(),
+            torDirURL: try __torDirURL(),
+            endpoint: LightWalletEndpointBuilder.default,
+            network: network,
+            spendParamsURL: try __spendParamsURL(),
+            outputParamsURL: try __outputParamsURL(),
+            saplingParamsSourceURL: SaplingParamsSourceURL.tests,
+            isTorEnabled: false,
+            isExchangeRateEnabled: false
+        )
+
+        let result = try await initializer.initialize(
+            with: nil,
+            walletBirthday: 663194,
+            for: .existingWallet,
+            name: ""
+        )
+
+        guard case .seedRequired = result else {
+            XCTFail("Expected `.seedRequired` when rustBackend.initDataDb() reports it, got \(result) instead.")
+            return
+        }
+    }
 }

--- a/docs/LOCAL_DEVELOPMENT.md
+++ b/docs/LOCAL_DEVELOPMENT.md
@@ -54,6 +54,16 @@ The `--cached` flag downloads a pre-built release instead of building from sourc
 
 **Warning:** Only use `--cached` if there have been no FFI changes on your branch since the last release. Using a stale pre-built binary with modified Swift bindings could cause silent data corruption and loss of funds. Additionally, `--cached` skips the Rust build entirely, so the first call to `rebuild-local-ffi.sh` will be a full (non-incremental) build.
 
+For faster iteration on Apple Silicon you can build only the arm64 slices you need, skipping the x86_64 simulator/Mac slices you can't run there anyway:
+
+```bash
+./Scripts/init-local-ffi.sh --arm-macos # macOS (swift build / swift test on the Mac)
+./Scripts/init-local-ffi.sh --arm-ios   # iOS simulator + device
+./Scripts/init-local-ffi.sh --arm-all   # iOS simulator + device + macOS
+```
+
+Building for a slice you didn't include will fail until you build it (via `rebuild-local-ffi.sh` or a full `init-local-ffi.sh`).
+
 ### Opening in Xcode
 
 You can open the project two ways:
@@ -99,14 +109,19 @@ If using Xcode, you may also need to reset package caches: File > Packages > Res
 One-time setup that creates the local development environment.
 
 ```bash
-./Scripts/init-local-ffi.sh          # Build from source (recommended)
-./Scripts/init-local-ffi.sh --cached # Download pre-built release
+./Scripts/init-local-ffi.sh             # Build from source, all 5 architectures (recommended)
+./Scripts/init-local-ffi.sh --arm-macos # arm64 macOS slice only
+./Scripts/init-local-ffi.sh --arm-ios   # arm64 iOS simulator + device slices
+./Scripts/init-local-ffi.sh --arm-all   # arm64 iOS simulator + device + macOS slices
+./Scripts/init-local-ffi.sh --cached    # Download pre-built release
 ```
 
 This script:
-- Builds the full XCFramework (all 5 architectures) or downloads a pre-built one
+- Builds the full XCFramework (all 5 architectures), an arm64-only subset (`--arm-*`, faster on Apple Silicon since it skips the x86_64 slices), or downloads a pre-built one
 - Creates `LocalPackages/` with an SPM wrapper package
 - `Package.swift` automatically detects `LocalPackages/` and switches to local mode
+
+The `--arm-*` flags always build the `aarch64-*` targets regardless of host architecture. They produce an XCFramework containing only the requested arm64 slices, so building for an x86_64 simulator/Mac (or a slice you didn't include) will fail until you build it — run `rebuild-local-ffi.sh <target>` or a full `init-local-ffi.sh` to add the missing slices. Any unrecognized flag prints usage and exits without building.
 
 ### `rebuild-local-ffi.sh`
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -25,4 +25,7 @@ Steps:
 - Use `./Scripts/release.sh <remote> <version>` for a fully automated release, or
 - Use `./Scripts/prepare-release.sh <version>` for a semi-automated process with manual steps
 
+Versions with a SemVer pre-release suffix (e.g. `2.6.0-alpha.1`) are detected automatically
+and the GitHub release is marked as a pre-release.
+
 See the scripts themselves for detailed usage instructions.


### PR DESCRIPTION
Moves `maint/v3.0.x` from the `2.6.0-alpha.6` tag (4303068e) to 74cdbbc0 — the same commit `maint/v2.8.x` is branched from, and the commit the ZODL iOS app pins.

This is a base advance only. **Every commit here is already contained in `release/3.0.0`**, the head of #1848, so merging this does not change that PR's content — only what it displays:

| | files | commits |
|---|---|---|
| #1848 today | 78 | 35 |
| #1848 after this | 69 | 20 |

What drops out is the 2.6.0-alpha.6 → 74cdbbc0 range, which is not part of the 3.0.0 work and is only inflating the review. What remains is the Ironwood work itself.

The branch is pinned at 74cdbbc0 rather than tracking `maint/v2.8.x` on purpose. Once #1856 merges, `maint/v2.8.x` carries the full 2.8.0-rc.1 payload, and bringing that into `maint/v3.0.x` before `release/3.0.0` has had it merged forward would make #1848 render as though 3.0.0 deletes the `lightwallet-protocol/` subtree and the rest of the 2.7.x work (10 files shown as deleted, 748 lines). Advancing `maint/v3.0.x` past 74cdbbc0 should wait until `release/3.0.0` gets that forward merge — which is a real reconciliation, ~18 conflicts, mostly between the two independent Ironwood protobuf efforts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
