### PR TITLE
[#1858] Redact Ironwood PCZT bundle for external signers and cache the Orchard proving key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,18 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   serve lightwallet-protocol v0.3.6 (lightwalletd v0.4.18, 2025-05) or newer.
   The public `ZcashError.serviceGetTaddressTxidsFailed` case is unchanged
   aside from its message text.
+- Adding proofs to a PCZT now reuses a cached Orchard-family proving key
+  across the Orchard and Ironwood proofs (both use the same PostNu6_3
+  circuit after NU6.3) instead of rebuilding the key for each, and derives
+  the Ironwood circuit version from the PCZT's consensus branch id rather
+  than hardcoding it. The resulting proofs are unchanged.
+
+## Fixed
+- Redacting a PCZT for an external signer now also redacts the Ironwood
+  bundle (clearing spend witnesses and `output_info` output metadata),
+  matching the Orchard, Sapling, and transparent bundles; previously the
+  Ironwood bundle was left untouched, exposing its Merkle witnesses and
+  wallet output metadata to the signer.
 
 # 2.7.0-rc.1 - 2026-07-25
 

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -2878,6 +2878,12 @@ pub unsafe extern "C" fn zcashlc_redact_pczt_for_signer(
                     ar.redact_output_proprietary("zcash_client_backend:output_info");
                 })
             })
+            .redact_ironwood_with(|mut r| {
+                r.redact_actions(|mut ar| {
+                    ar.clear_spend_witness();
+                    ar.redact_output_proprietary("zcash_client_backend:output_info");
+                })
+            })
             .redact_sapling_with(|mut r| {
                 r.redact_spends(|mut sr| sr.clear_witness());
                 r.redact_outputs(|mut or| {
@@ -2993,37 +2999,45 @@ pub unsafe extern "C" fn zcashlc_add_proofs_to_pczt(
 
         let mut prover = Prover::new(pczt);
 
+        // Orchard and Ironwood share the Orchard-family proving system. The circuit
+        // governing each pool under this PCZT's consensus branch selects the proving
+        // key; derive it from the branch id per pool. `cached_orchard_proving_key`
+        // returns a shared key per circuit version, so the Orchard and Ironwood
+        // proofs reuse one key once NU6.3 collapses both onto the PostNu6_3 circuit.
+        let circuit_version_for = |pool| {
+            zcash_primitives::transaction::components::orchard::bundle_version_for_branch(
+                pczt_branch_id,
+                pool,
+            )
+            .map(|v| v.circuit_version())
+        };
+
         if prover.requires_orchard_proof() {
-            let orchard_circuit_version =
-                zcash_primitives::transaction::components::orchard::bundle_version_for_branch(
-                    pczt_branch_id,
-                    orchard::ValuePool::Orchard,
-                )
-                .ok_or_else(|| {
+            let circuit_version =
+                circuit_version_for(orchard::ValuePool::Orchard).ok_or_else(|| {
                     anyhow!("PCZT's consensus branch does not support the Orchard pool")
-                })?
-                .circuit_version();
+                })?;
             prover = prover
-                .create_orchard_proof(&orchard::circuit::ProvingKey::build(
-                    orchard_circuit_version,
-                ))
+                .create_orchard_proof(
+                    zcash_primitives::transaction::builder::cached_orchard_proving_key(
+                        circuit_version,
+                    ),
+                )
                 .map_err(|e| anyhow!("Failed to create Orchard proof for PCZT: {:?}", e))?;
         }
         assert!(!prover.requires_orchard_proof());
 
         if prover.requires_ironwood_proof() {
-            // Post-NU6.3 proposals route orchard-receiver outputs and change
-            // into Ironwood bundles (the Orchard turnstile forbids adding value
-            // to Orchard once NU6.3 is active), so any PCZT built after
-            // activation can carry an Ironwood bundle that must be proven before
-            // extraction — otherwise a hardware-signed transaction fails at
-            // extract with MissingProof. The Ironwood bundle uses the PostNu6_3
-            // circuit (the fixed circuit plus the `disableCrossAddress`
-            // constraint), a distinct proving key from the Orchard pool's.
+            let circuit_version =
+                circuit_version_for(orchard::ValuePool::Ironwood).ok_or_else(|| {
+                    anyhow!("PCZT's consensus branch does not support the Ironwood pool")
+                })?;
             prover = prover
-                .create_ironwood_proof(&orchard::circuit::ProvingKey::build(
-                    orchard::circuit::OrchardCircuitVersion::PostNu6_3,
-                ))
+                .create_ironwood_proof(
+                    zcash_primitives::transaction::builder::cached_orchard_proving_key(
+                        circuit_version,
+                    ),
+                )
                 .map_err(|e| anyhow!("Failed to create Ironwood proof for PCZT: {:?}", e))?;
         }
         assert!(!prover.requires_ironwood_proof());


### PR DESCRIPTION
Closes #1858. Resolves MOB-1547

Ports the two items from the Android SDK's PCZT Ironwood work (zcash/zcash-android-wallet-sdk#2066) that were still missing in the Swift Rust core. The Ironwood proof-creation item from that PR was already present here.

## Changes (`rust/src/lib.rs`)

- **Redact the Ironwood bundle** in `zcashlc_redact_pczt_for_signer`. It previously cleared spend witnesses and `output_info` metadata for the Orchard, Sapling, and transparent bundles but left the Ironwood bundle untouched, exposing its Merkle witnesses and wallet output metadata to an external/hardware signer. Now mirrored via `redact_ironwood_with`.
- **Cache the Orchard-family proving key** in `zcashlc_add_proofs_to_pczt`. The Orchard and Ironwood proofs each built a fresh `orchard::circuit::ProvingKey`; both collapse onto the `PostNu6_3` circuit after NU6.3, so they now use `cached_orchard_proving_key` (built once per circuit version), and the Ironwood circuit version is derived from the PCZT's consensus branch id via `bundle_version_for_branch` instead of being hardcoded.

## Notes

- Available on this branch's deps: `pczt 0.8.0` (`redact_ironwood_with`), `zcash_primitives 0.30.0` (`cached_orchard_proving_key`).
- `cargo check` passes; additions are rustfmt-clean.
- CHANGELOG entry is in its own commit.