### PR TITLE
[#1859] Include the Ironwood pool in the general send-max spend set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,12 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   The public `ZcashError.serviceGetTaddressTxidsFailed` case is unchanged
   aside from its message text.
 
+## Fixed
+- Send-max proposals now spend from the Ironwood pool in addition to
+  Sapling and Orchard, so a post-NU6.3 wallet's Ironwood funds are no
+  longer silently excluded from a send-max. This affects only the general
+  send-max proposal; the Orchard-to-Ironwood migration is unchanged.
+
 # 2.7.0-rc.1 - 2026-07-25
 
 ## Added

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -2360,11 +2360,21 @@ pub unsafe extern "C" fn zcashlc_propose_send_max_transfer(
         let locked_input_policy = LockedInputPolicy::Exclude;
         let lock_inputs = None;
 
+        // Send-max draws the entire spendable balance across every shielded pool,
+        // so Ironwood is included alongside Sapling and Orchard; omitting it would
+        // silently leave a post-NU6.3 wallet's Ironwood funds behind. Including it
+        // is a no-op when the account holds no Ironwood notes.
+        let spend_pools = [
+            ShieldedPool::Sapling,
+            ShieldedPool::Orchard,
+            ShieldedPool::Ironwood,
+        ];
+
         let proposal = propose_send_max_transfer::<_, _, _, Infallible>(
             &mut db_data,
             &network,
             account_uuid,
-            &[ShieldedPool::Sapling, ShieldedPool::Orchard],
+            &spend_pools,
             &StandardFeeRule::Zip317,
             to,
             memo,


### PR DESCRIPTION
Closes #1859. Resolves MOB-1548

`zcashlc_propose_send_max_transfer` passed only `ShieldedPool::Sapling` and `ShieldedPool::Orchard` as the spend pools for `propose_send_max_transfer`, omitting `ShieldedPool::Ironwood`.

Since send-max draws the entire spendable balance across the listed pools, a post-NU6.3 wallet holding Ironwood notes would have those funds silently excluded, so a 'send max' / 'send everything' would not actually send the maximum. This PR adds `ShieldedPool::Ironwood` to the spend set; it is a no-op when the account holds no Ironwood notes (safe pre-activation, correct after).

## Scope

This is the **general** send-max FFI, not the migration path. The Orchard-to-Ironwood migration (`migration.rs` `propose_orchard_to_ironwood`) intentionally spends from the Orchard pool only and is unaffected.

## Notes

- `cargo check` passes; the addition uses a named `spend_pools` binding and is rustfmt-clean.
- CHANGELOG entry is in its own commit.
- Kept separate from #1860 per review.