### PR TITLE
[#1863] Reuse zcash_client_backend redact_pczt_for_signer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,11 +32,13 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   than hardcoding it. The resulting proofs are unchanged.
 
 ## Fixed
-- Redacting a PCZT for an external signer now also redacts the Ironwood
-  bundle (clearing spend witnesses and `output_info` output metadata),
-  matching the Orchard, Sapling, and transparent bundles; previously the
-  Ironwood bundle was left untouched, exposing its Merkle witnesses and
-  wallet output metadata to the signer.
+- Redacting a PCZT for an external signer now delegates to
+  `zcash_client_backend`'s `redact_pczt_for_signer` instead of a
+  hand-rolled reimplementation. This redacts the Ironwood bundle, which the
+  previous implementation left untouched (exposing its Merkle witnesses and
+  output metadata to the signer), and also clears zk-proofs, binding
+  signature keys, dummy spend keys, and v6 anchors that the previous
+  implementation did not.
 
 ## Fixed
 - Send-max proposals now spend from the Ironwood pool in addition to

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -20,7 +20,7 @@ use http_body_util::BodyExt;
 use nonempty::NonEmpty;
 use pczt::{
     Pczt,
-    roles::{combiner::Combiner, prover::Prover, redactor::Redactor},
+    roles::{combiner::Combiner, prover::Prover},
 };
 use prost::Message;
 use rand::rngs::OsRng;
@@ -48,7 +48,7 @@ use zcash_client_backend::{
             self, SpendingKeys, create_pczt_from_proposal, create_proposed_transactions,
             decrypt_and_store_transaction, extract_and_store_transaction_from_pczt,
             input_selection::{GreedyInputSelector, LockFilter, LockedInputPolicy, SpendPolicy},
-            propose_send_max_transfer, propose_shielding, propose_transfer,
+            propose_send_max_transfer, propose_shielding, propose_transfer, redact_pczt_for_signer,
         },
     },
     encoding::AddressCodec,
@@ -2880,32 +2880,7 @@ pub unsafe extern "C" fn zcashlc_redact_pczt_for_signer(
         let pczt_bytes = unsafe { slice::from_raw_parts(pczt_ptr, pczt_len) };
         let pczt = Pczt::parse(pczt_bytes).map_err(|e| anyhow!("Invalid PCZT: {:?}", e))?;
 
-        let redacted_pczt = Redactor::new(pczt)
-            .redact_global_with(|mut r| r.redact_proprietary("zcash_client_backend:proposal_info"))
-            .redact_orchard_with(|mut r| {
-                r.redact_actions(|mut ar| {
-                    ar.clear_spend_witness();
-                    ar.redact_output_proprietary("zcash_client_backend:output_info");
-                })
-            })
-            .redact_ironwood_with(|mut r| {
-                r.redact_actions(|mut ar| {
-                    ar.clear_spend_witness();
-                    ar.redact_output_proprietary("zcash_client_backend:output_info");
-                })
-            })
-            .redact_sapling_with(|mut r| {
-                r.redact_spends(|mut sr| sr.clear_witness());
-                r.redact_outputs(|mut or| {
-                    or.redact_proprietary("zcash_client_backend:output_info")
-                });
-            })
-            .redact_transparent_with(|mut r| {
-                r.redact_outputs(|mut or| {
-                    or.redact_proprietary("zcash_client_backend:output_info")
-                });
-            })
-            .finish();
+        let redacted_pczt = redact_pczt_for_signer(&pczt);
 
         Ok(ffi::BoxedSlice::some(redacted_pczt.serialize().map_err(
             |e| anyhow!("Failed to serialize redacted PCZT: {:?}", e),


### PR DESCRIPTION
Closes #1863. Follow-up to #1860. Resolves MOB-1549

`zcashlc_redact_pczt_for_signer` hand-rolled a `Redactor` chain that duplicated `zcash_client_backend::data_api::wallet::redact_pczt_for_signer`. The reimplementation had drifted from the upstream canonical redaction: it cleared only spend witnesses and `output_info` metadata and, unlike upstream, never cleared zk-proofs, binding signature keys (`bsk`), dummy spend keys (`spend_dummy_sk`/`dummy_ask`), or v6 anchors, nor called `compact_resolvable_fields`.

## Change

- Replace the hand-rolled `Redactor::new(pczt)...finish()` body with `redact_pczt_for_signer(&pczt)`.
- Drop the now-unused `pczt::roles::redactor::Redactor` import.

Keeps the SDK aligned with librustzcash and removes a second copy of the redaction policy. `cargo check` passes; changes are rustfmt-clean; CHANGELOG entry is in its own commit.