### PR TITLE
Validate the seed against existing accounts in prepare

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
+## Added
+- `ZcashError.initializerSeedMismatch` (`ZINIT0006`): `prepare(with:walletBirthday:for:name:keySource:)`
+  now validates the provided seed against the wallet's existing seed-derived accounts and throws
+  instead of silently opening a wallet the seed cannot spend from. Restoring a different wallet
+  requires `wipe()` first. Wallets whose only accounts are imported (hardware-wallet UFVKs) are
+  exempt — the relevance check is delegated to the Rust core, which treats "there is no seed-derived
+  account to validate against" as relevant, so a hardware-wallet-only wallet is never bricked. See
+  `MIGRATING.md`.
+
 ## Changed
 - `Initializer.initialize` / `Synchronizer.prepare` now return `InitializationResult.seedNotRelevant` instead of silently proceeding when the rust layer reports the provided seed is not relevant to the wallet database (breaking change: `InitializationResult` gained a new case, so exhaustive switches over it must add a case; see MIGRATING.md). Previously this case was indistinguishable from `.success`: account creation was skipped (accounts already existed) and callers proceeded as if they had prepared the wallet they expected, even when the database on disk belonged to a different wallet than the provided seed (e.g. a device-backup restore that brings back `data.db` without the matching keychain seed). Callers must now handle `.seedNotRelevant` the same way they already handle `.seedRequired`. (MOB-1512)
 

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -1,4 +1,13 @@
 # Migrating from previous versions to _Unreleased_
+
+## `prepare` now validates the seed against the existing wallet
+
+If the wallet database already contains seed-derived account(s) and the seed passed to `prepare`
+does not match them, `prepare` throws `ZcashError.initializerSeedMismatch` (`ZINIT0006`) instead of
+silently opening the old wallet (which desynced the app's stored seed from the on-disk account).
+Restoring a different wallet requires `wipe()` first. Wallets whose only accounts are imported
+(hardware-wallet UFVKs) are exempt — there is no seed-derived account to compare.
+
 PendingDb is no longer used. Wallet developers should take care about deleting
 the database file since the SDK will no longer require it or any of the
 information stored. 

--- a/Sources/ZcashLightClientKit/Error/ZcashError.swift
+++ b/Sources/ZcashLightClientKit/Error/ZcashError.swift
@@ -31,6 +31,10 @@ public enum ZcashError: Equatable, Error {
     /// Can't set `isExcludedFromBackup` flag to `generalStorageURL`.
     /// ZINIT0005
     case initializerCantSetNoBackupFlagToGeneralStorageURL(_ generalStorageURL: URL, _ error: Error)
+    /// The seed passed to `prepare` does not match the seed-derived account(s) already stored in `data.db`; restoring a different wallet requires wiping first.
+    /// Proceeding would desync the keychain seed from the on-disk account (funds shown/received for an address the seed cannot spend).
+    /// ZINIT0006
+    case initializerSeedMismatch
     /// Unknown GRPC Service error
     /// ZSRVC0001
     case serviceUnknownError(_ error: Error)
@@ -790,6 +794,7 @@ public enum ZcashError: Equatable, Error {
         case .initializerGeneralStorageExistsButIsFile: return "Object on disk at `generalStorageURL` path exists. But it file not directory."
         case .initializerGeneralStorageCantCreate: return "Can't create directory at `generalStorageURL` path."
         case .initializerCantSetNoBackupFlagToGeneralStorageURL: return "Can't set `isExcludedFromBackup` flag to `generalStorageURL`."
+        case .initializerSeedMismatch: return "The seed passed to `prepare` does not match the seed-derived account(s) already stored in `data.db`; restoring a different wallet requires wiping first."
         case .serviceUnknownError: return "Unknown GRPC Service error"
         case .serviceGetInfoFailed: return "LightWalletService.getInfo failed."
         case .serviceLatestBlockFailed: return "LightWalletService.latestBlock failed."
@@ -1014,6 +1019,7 @@ public enum ZcashError: Equatable, Error {
         case .initializerGeneralStorageExistsButIsFile: return .initializerGeneralStorageExistsButIsFile
         case .initializerGeneralStorageCantCreate: return .initializerGeneralStorageCantCreate
         case .initializerCantSetNoBackupFlagToGeneralStorageURL: return .initializerCantSetNoBackupFlagToGeneralStorageURL
+        case .initializerSeedMismatch: return .initializerSeedMismatch
         case .serviceUnknownError: return .serviceUnknownError
         case .serviceGetInfoFailed: return .serviceGetInfoFailed
         case .serviceLatestBlockFailed: return .serviceLatestBlockFailed

--- a/Sources/ZcashLightClientKit/Error/ZcashErrorCode.swift
+++ b/Sources/ZcashLightClientKit/Error/ZcashErrorCode.swift
@@ -21,6 +21,8 @@ public enum ZcashErrorCode: String {
     case initializerGeneralStorageCantCreate = "ZINIT0004"
     /// Can't set `isExcludedFromBackup` flag to `generalStorageURL`.
     case initializerCantSetNoBackupFlagToGeneralStorageURL = "ZINIT0005"
+    /// The seed passed to `prepare` does not match the seed-derived account(s) already stored in `data.db`; restoring a different wallet requires wiping first.
+    case initializerSeedMismatch = "ZINIT0006"
     /// Unknown GRPC Service error
     case serviceUnknownError = "ZSRVC0001"
     /// LightWalletService.getInfo failed.

--- a/Sources/ZcashLightClientKit/Error/ZcashErrorCodeDefinition.swift
+++ b/Sources/ZcashLightClientKit/Error/ZcashErrorCodeDefinition.swift
@@ -47,6 +47,10 @@ enum ZcashErrorDefinition {
     /// Can't set `isExcludedFromBackup` flag to `generalStorageURL`.
     // sourcery: code="ZINIT0005"
     case initializerCantSetNoBackupFlagToGeneralStorageURL(_ generalStorageURL: URL, _ error: Error)
+    /// The seed passed to `prepare` does not match the seed-derived account(s) already stored in `data.db`; restoring a different wallet requires wiping first.
+    /// Proceeding would desync the keychain seed from the on-disk account (funds shown/received for an address the seed cannot spend).
+    // sourcery: code="ZINIT0006"
+    case initializerSeedMismatch
 
     // MARK: - LightWalletService
 

--- a/Sources/ZcashLightClientKit/Initializer.swift
+++ b/Sources/ZcashLightClientKit/Initializer.swift
@@ -461,7 +461,9 @@ public class Initializer {
         self.walletBirthday = checkpoint.height
 
         // If there are no accounts it must be created, the default amount of accounts is 1
-        if let seed, try await rustBackend.listAccounts().isEmpty {
+        let existingAccounts = try await rustBackend.listAccounts()
+        try await validateSeedAgainstExistingAccounts(seed, existingAccounts: existingAccounts)
+        if let seed, existingAccounts.isEmpty {
             var chainTip: UInt32?
             var accountTreeState = checkpoint.treeState()
 
@@ -503,6 +505,24 @@ public class Initializer {
         }
 
         return .success
+    }
+
+    /// Seed↔account integrity guard: `initialize` is idempotent for an existing wallet, so
+    /// restoring a DIFFERENT seed over existing accounts previously no-op'd silently — the
+    /// keychain held seed B while data.db kept seed A's account, the app showed A's balance AND
+    /// receive address (funds receivable but unspendable), and sends failed ZRUST0002. Validate
+    /// the caller's seed against the stored derived account(s) before opening.
+    ///
+    /// The relevance check is delegated to the Rust core, which reports the seed relevant when it
+    /// derives an existing account, when there are no accounts, or when there is no seed-derived
+    /// account to validate against — so imported-only wallets (hardware-wallet UFVKs) are exempt.
+    /// Only a genuine mismatch against existing seed-derived accounts throws. This must not use a
+    /// Swift-side heuristic on `seedFingerprint`/`hdAccountIndex`, since those are also populated
+    /// for imported-spending accounts and would falsely brick hardware-wallet-only wallets.
+    private func validateSeedAgainstExistingAccounts(_ seed: [UInt8]?, existingAccounts: [Account]) async throws {
+        guard let seed, !existingAccounts.isEmpty else { return }
+        let seedIsRelevant = try await rustBackend.isSeedRelevantToAnyDerivedAccount(seed: seed)
+        guard seedIsRelevant else { throw ZcashError.initializerSeedMismatch }
     }
 
     /**

--- a/Tests/OfflineTests/WalletTests.swift
+++ b/Tests/OfflineTests/WalletTests.swift
@@ -161,4 +161,218 @@ class WalletTests: ZcashTestCase {
             return
         }
     }
+
+    /// Pins the `initialize` seed/account integrity guard: `initialize` is idempotent for an existing wallet, so if the
+    /// rust layer reports that the caller's seed doesn't derive any account already stored in `data.db` (for example,
+    /// `data.db` was restored from a device backup belonging to a different wallet than the seed currently held in the
+    /// keychain), `initialize` must throw `ZcashError.initializerSeedMismatch` instead of silently returning `.success`.
+    /// Without this guard the wallet opens against the wrong account: the UI would show that account's balance and
+    /// receive address (funds receivable but unspendable with the caller's seed) while sends fail downstream. Account
+    /// creation must also be skipped entirely in this case, since accounts already exist for this database.
+    func testInitializeThrowsSeedMismatchWhenSeedIsNotRelevantToDerivedAccounts() async throws {
+        let existingAccount = Account(
+            id: TestsData.mockedAccountUUID,
+            name: nil,
+            keySource: nil,
+            seedFingerprint: nil,
+            hdAccountIndex: nil,
+            ufvk: nil,
+            uivk: nil
+        )
+
+        let rustBackendMock = ZcashRustBackendWeldingMock()
+        rustBackendMock.initBlockMetadataDbClosure = { }
+        rustBackendMock.initDataDbSeedClosure = { _ in DbInitResult.success }
+        rustBackendMock.listAccountsClosure = { [existingAccount] }
+        rustBackendMock.isSeedRelevantToAnyDerivedAccountSeedReturnValue = false
+
+        mockContainer.mock(type: ZcashRustBackendWelding.self, isSingleton: true) { _ in rustBackendMock }
+
+        let initializer = Initializer(
+            container: mockContainer,
+            cacheDbURL: nil,
+            fsBlockDbRoot: testTempDirectory,
+            generalStorageURL: testGeneralStorageDirectory,
+            dataDbURL: try __dataDbURL(),
+            torDirURL: try __torDirURL(),
+            endpoint: LightWalletEndpointBuilder.default,
+            network: network,
+            spendParamsURL: try __spendParamsURL(),
+            outputParamsURL: try __outputParamsURL(),
+            saplingParamsSourceURL: SaplingParamsSourceURL.tests,
+            isTorEnabled: false,
+            isExchangeRateEnabled: false
+        )
+
+        do {
+            _ = try await initializer.initialize(
+                with: seedData.bytes,
+                walletBirthday: 663194,
+                for: .existingWallet,
+                name: ""
+            )
+            XCTFail("Expected `initialize` to throw `ZcashError.initializerSeedMismatch` when the seed isn't relevant to any existing account.")
+        } catch {
+            guard let zcashError = error as? ZcashError, case .initializerSeedMismatch = zcashError else {
+                XCTFail("Expected `ZcashError.initializerSeedMismatch`, got \(error) instead.")
+                return
+            }
+        }
+
+        XCTAssertEqual(rustBackendMock.createAccountSeedTreeStateRecoverUntilNameKeySourceCallsCount, 0)
+    }
+
+    /// Companion regression test for `testInitializeThrowsSeedMismatchWhenSeedIsNotRelevantToDerivedAccounts`: the seed/
+    /// account guard must not false-positive on the ordinary "reopen the same wallet" path. When the rust layer reports
+    /// the seed IS relevant to an already-stored account, `initialize` must still return `.success` — otherwise every
+    /// normal app relaunch against an existing wallet would be bricked by the new check.
+    func testInitializeSucceedsWhenSeedIsRelevantToExistingAccounts() async throws {
+        let existingAccount = Account(
+            id: TestsData.mockedAccountUUID,
+            name: nil,
+            keySource: nil,
+            seedFingerprint: nil,
+            hdAccountIndex: nil,
+            ufvk: nil,
+            uivk: nil
+        )
+
+        let rustBackendMock = ZcashRustBackendWeldingMock()
+        rustBackendMock.initBlockMetadataDbClosure = { }
+        rustBackendMock.initDataDbSeedClosure = { _ in DbInitResult.success }
+        rustBackendMock.listAccountsClosure = { [existingAccount] }
+        rustBackendMock.isSeedRelevantToAnyDerivedAccountSeedReturnValue = true
+
+        mockContainer.mock(type: ZcashRustBackendWelding.self, isSingleton: true) { _ in rustBackendMock }
+
+        let initializer = Initializer(
+            container: mockContainer,
+            cacheDbURL: nil,
+            fsBlockDbRoot: testTempDirectory,
+            generalStorageURL: testGeneralStorageDirectory,
+            dataDbURL: try __dataDbURL(),
+            torDirURL: try __torDirURL(),
+            endpoint: LightWalletEndpointBuilder.default,
+            network: network,
+            spendParamsURL: try __spendParamsURL(),
+            outputParamsURL: try __outputParamsURL(),
+            saplingParamsSourceURL: SaplingParamsSourceURL.tests,
+            isTorEnabled: false,
+            isExchangeRateEnabled: false
+        )
+
+        let result = try await initializer.initialize(
+            with: seedData.bytes,
+            walletBirthday: 663194,
+            for: .existingWallet,
+            name: ""
+        )
+
+        guard case .success = result else {
+            XCTFail("Expected `.success` when the seed is relevant to an existing account, got \(result) instead.")
+            return
+        }
+
+        XCTAssertEqual(rustBackendMock.createAccountSeedTreeStateRecoverUntilNameKeySourceCallsCount, 0)
+    }
+
+    /// Companion regression test: the seed/account guard must be skipped entirely for a brand-new wallet. When
+    /// `listAccounts` returns no accounts there is nothing yet to validate the seed against, so `initialize` must go
+    /// straight to account creation instead of consulting `isSeedRelevantToAnyDerivedAccount` — a relevance check with
+    /// nothing to compare against must never gate first-time wallet creation or restore.
+    func testInitializeSkipsSeedRelevanceCheckForEmptyWallet() async throws {
+        let rustBackendMock = ZcashRustBackendWeldingMock()
+        rustBackendMock.initBlockMetadataDbClosure = { }
+        rustBackendMock.initDataDbSeedClosure = { _ in DbInitResult.success }
+        rustBackendMock.listAccountsClosure = { [] }
+        rustBackendMock.createAccountSeedTreeStateRecoverUntilNameKeySourceReturnValue = UnifiedSpendingKey(
+            network: network.networkType,
+            bytes: []
+        )
+
+        mockContainer.mock(type: ZcashRustBackendWelding.self, isSingleton: true) { _ in rustBackendMock }
+
+        let initializer = Initializer(
+            container: mockContainer,
+            cacheDbURL: nil,
+            fsBlockDbRoot: testTempDirectory,
+            generalStorageURL: testGeneralStorageDirectory,
+            dataDbURL: try __dataDbURL(),
+            torDirURL: try __torDirURL(),
+            endpoint: LightWalletEndpointBuilder.default,
+            network: network,
+            spendParamsURL: try __spendParamsURL(),
+            outputParamsURL: try __outputParamsURL(),
+            saplingParamsSourceURL: SaplingParamsSourceURL.tests,
+            isTorEnabled: false,
+            isExchangeRateEnabled: false
+        )
+
+        let result = try await initializer.initialize(
+            with: seedData.bytes,
+            walletBirthday: 663194,
+            for: .existingWallet,
+            name: ""
+        )
+
+        guard case .success = result else {
+            XCTFail("Expected `.success` for a fresh wallet with no existing accounts, got \(result) instead.")
+            return
+        }
+
+        XCTAssertFalse(rustBackendMock.isSeedRelevantToAnyDerivedAccountSeedCalled)
+    }
+
+    /// Companion regression test: the seed/account guard requires a seed to validate against, so it must be skipped
+    /// when no seed is supplied at all. View-only wallets and callers that can't fetch the seed from secure storage
+    /// (e.g. background tasks) pass `nil` here; they must keep working unaffected by the new check instead of being
+    /// gated on a relevance test that has no seed to test.
+    func testInitializeSkipsSeedRelevanceCheckWithoutSeed() async throws {
+        let existingAccount = Account(
+            id: TestsData.mockedAccountUUID,
+            name: nil,
+            keySource: nil,
+            seedFingerprint: nil,
+            hdAccountIndex: nil,
+            ufvk: nil,
+            uivk: nil
+        )
+
+        let rustBackendMock = ZcashRustBackendWeldingMock()
+        rustBackendMock.initBlockMetadataDbClosure = { }
+        rustBackendMock.initDataDbSeedClosure = { _ in DbInitResult.success }
+        rustBackendMock.listAccountsClosure = { [existingAccount] }
+
+        mockContainer.mock(type: ZcashRustBackendWelding.self, isSingleton: true) { _ in rustBackendMock }
+
+        let initializer = Initializer(
+            container: mockContainer,
+            cacheDbURL: nil,
+            fsBlockDbRoot: testTempDirectory,
+            generalStorageURL: testGeneralStorageDirectory,
+            dataDbURL: try __dataDbURL(),
+            torDirURL: try __torDirURL(),
+            endpoint: LightWalletEndpointBuilder.default,
+            network: network,
+            spendParamsURL: try __spendParamsURL(),
+            outputParamsURL: try __outputParamsURL(),
+            saplingParamsSourceURL: SaplingParamsSourceURL.tests,
+            isTorEnabled: false,
+            isExchangeRateEnabled: false
+        )
+
+        let result = try await initializer.initialize(
+            with: nil,
+            walletBirthday: 663194,
+            for: .existingWallet,
+            name: ""
+        )
+
+        guard case .success = result else {
+            XCTFail("Expected `.success` when no seed is provided, got \(result) instead.")
+            return
+        }
+
+        XCTAssertFalse(rustBackendMock.isSeedRelevantToAnyDerivedAccountSeedCalled)
+    }
 }


### PR DESCRIPTION
Ports the prepare-time seed/account integrity guard and `ZcashError.initializerSeedMismatch` (`ZINIT0006`) from `release/2.6.0` onto the 2.8 line. The 2.6.0 side shipped it inside the Ironwood work; this carries over **only** the seed-validation change.

## Why

`Initializer.initialize` is idempotent for an existing wallet, so restoring a *different* seed over existing accounts previously no-op'd silently. The keychain held seed B while `data.db` kept seed A's account — the app showed A's balance and receive address (funds receivable but unspendable) and sends failed `ZRUST0002`. The wallet stayed in that state until `wipe()`.

`initialize` now validates the caller's seed against the stored seed-derived account(s) before opening, and throws `ZcashError.initializerSeedMismatch` on a genuine mismatch.

## What's in it

- `Error/ZcashErrorCodeDefinition.swift` — new `initializerSeedMismatch` case (`ZINIT0006`). `ZcashError.swift` / `ZcashErrorCode.swift` regenerated with `Error/Sourcery/generateErrorCode.sh` (Sourcery 2.3.0), not hand-edited.
- `Initializer.swift` — `validateSeedAgainstExistingAccounts(_:existingAccounts:)`, called before the account-creation branch; `listAccounts()` is hoisted into a local so it isn't fetched twice.
- `CHANGELOG.md` / `MIGRATING.md` — user-visible behavior change documented.
- `Tests/OfflineTests/WalletTests.swift` — four new tests (see below).

The relevance check is delegated to the Rust core, which reports the seed relevant when it derives an existing account, when there are no accounts, or when there is **no seed-derived account to validate against** — so imported-only (hardware-wallet UFVK) wallets are exempt. This is deliberately *not* a Swift-side heuristic on `seedFingerprint`/`hdAccountIndex`: those are populated for imported-spending accounts too, and reading them was what bricked hardware-wallet-only wallets in the first version on 2.6.0. That fix is folded in here, so this line never carries the intermediate broken version.

No Rust or FFI work: `isSeedRelevantToAnyDerivedAccount` and its whole Swift surface already exist on this branch.

## Deliberately not ported

The rest of the `release/2.6.0` delta is unrelated and stays out: custom-network / `NetworkType.regtest` registration, `network.saplingActivationHeight`, the Ironwood balance and subtree-root surface, and the voting changes. 2.8's existing `ZcashError+LocalizedError.swift` and its `getTaddressTransactions` doc text are left as they are.

## Tests

New in `WalletTests`, following the existing MOB-1512 pattern (`ZcashRustBackendWeldingMock` + `mockContainer`):

| Test | Pins |
|---|---|
| `testInitializeThrowsSeedMismatchWhenSeedIsNotRelevantToDerivedAccounts` | accounts exist + seed not relevant ⇒ throws, and `createAccount` is never called |
| `testInitializeSucceedsWhenSeedIsRelevantToExistingAccounts` | the guard doesn't false-positive on an ordinary relaunch |
| `testInitializeSkipsSeedRelevanceCheckForEmptyWallet` | fresh-wallet creation/restore is never gated by a check with nothing to compare |
| `testInitializeSkipsSeedRelevanceCheckWithoutSeed` | view-only / no-seed callers are unaffected |

The imported-only exemption lives in the Rust core, so it isn't unit-testable from Swift — the guard only honors what Rust reports.

Verified locally against the branch's pinned `2.7.0-rc.1` XCFramework (no local FFI):

- `swift build` — clean
- `swift test --filter OfflineTests` — **396 tests, 0 failures**
- `swiftlint` on the changed sources — no new violations
- Red-green checked: commenting out the `validateSeedAgainstExistingAccounts` call fails the mismatch test and only that test

## Consumer

`zodl-ios` already consumes `ZcashError.initializerSeedMismatch` in its `RootInitialization` heal path; the symbol exists only on `release/2.6.0` today, which is what motivated the port.

🤖 Generated with [Claude Code](https://claude.com/claude-code)