### PR TITLE
CONTRIBUTING: document the maintenance branch and release process

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,6 +113,14 @@ main          ───●───────────────●──
 
 ### Cutting a release
 
+`./Scripts/start-release.sh <remote> <version>` performs steps 1 through 4:
+it works out which release this one follows, creates and pushes the release
+branch, creates the review branch, and promotes the CHANGELOG. Pass
+`--dry-run` first to see what it will do. It does not touch `Package.swift` --
+the binary target's URL and checksum are written later by
+`Scripts/release.sh`, once the xcframework exists. The steps below are what it
+automates, and what to do by hand if a release needs to deviate.
+
 1. Create `release/X.Y.Z` **from the previous release tag** and push it to
    upstream. It starts out identical to the last release.
 2. Create `review/X.Y.Z` from the maintenance branch that contains all of the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,7 @@ Please read it before you start participating.
 * [Asking Questions](#asking-questions)
 * [Reporting Security Issues](#reporting-security-issues)
 * [Reporting Non Security Issues](#reporting-other-issues)
+* [Release and Maintenance Branches](#release-and-maintenance-branches)
 * [Commit Messages](#commit-messages)
 * [Developers Certificate of Origin](#developers-certificate-of-origin)
 
@@ -67,6 +68,116 @@ prioritized.
   the reader doesn't have to make guesses. Make sure that the purpose and inner
   logic are either obvious to a reasonably skilled professional, or add a
   comment that explains it.
+
+## Release and Maintenance Branches
+
+`main` is the development trunk. Released versions are maintained on long-lived
+`maint/` branches, one per minor release line, so that a fix can reach users
+already running an older version without shipping them unrelated trunk work.
+
+| Branch | Lifetime | Purpose |
+| --- | --- | --- |
+| `main` | permanent | Development trunk. New feature work lands here. |
+| `maint/vX.Y.x` | permanent | One per supported release line. Fixes to released versions land here. |
+| `release/X.Y.Z` | one release | Cut from the previous release tag. The base of the release PR, and what gets tagged. |
+| `review/X.Y.Z` | one release | Release preparation: version bumps, CHANGELOG promotion, final review. |
+
+### Basing a bug fix
+
+**The rule is: merge forward, cherry-pick back.**
+
+Branch bug fixes from the oldest currently-supported maintenance branch — at the
+time of writing that is `maint/v2.7.x`. From there the fix travels to every newer
+line by merging forward, keeping one commit identity and leaving later merges
+between those branches clean. This is the normal path and the one the diagram
+below shows; expect nearly every fix to take it.
+
+Cherry-picking back is the exception, for a fix that has already landed on a
+newer line and turns out to be needed on an older one too. Never merge backward:
+that would drag everything else on the newer line into the older release.
+
+```
+                    fix/1234
+                   ●────●
+                  /       \
+maint/v2.7.x  ───●─────────●─────────────────────────────▶   base bug fixes here
+                            \
+                             \  merge forward
+                              ▼
+maint/v2.8.x  ───●────────────●──────────────────────────▶
+                               \
+                                \  merge forward
+                                 ▼
+main          ───●───────────────●───────────────────────▶
+```
+
+### Cutting a release
+
+1. Create `release/X.Y.Z` **from the previous release tag** and push it to
+   upstream. It starts out identical to the last release.
+2. Create `review/X.Y.Z` from the maintenance branch that contains all of the
+   changes to be released.
+3. Open a pull request **on the public repository** from `review/X.Y.Z` into
+   `release/X.Y.Z`.
+4. Make the release preparation commits on `review/X.Y.Z` — version bumps,
+   CHANGELOG promotion, and anything else the release needs. The review branch,
+   not the release branch, is where this work happens.
+5. Merge the pull request, then tag the result `X.Y.Z`.
+
+Basing the release branch on the previous release tag is what makes the pull
+request worth reviewing: its diff is exactly what users receive relative to the
+last release, rather than the intervening development history.
+
+```
+tag X.Y.W  (previous release)
+      │
+      └──▶  release/X.Y.Z  ●──────────────────────────────●  tag X.Y.Z
+                                                          ▲
+                                                          │  PR: review ──▶ release
+                                                          │
+        review/X.Y.Z   ●────●────●────────────────────────┘
+                       ▲     version bumps, CHANGELOG promotion
+                       │
+                       │  branch from maint
+maint/vX.Y.x ──●────●──┴────────────────────────▶
+               └─ changes to be released ─┘
+```
+
+### After the release
+
+Three merges, in order:
+
+1. Merge `release/X.Y.Z` back into `maint/vX.Y.x`, so the maintenance branch
+   carries the tagged release and its preparation commits.
+2. Merge each maintenance branch forward into the next newer one. With
+   `maint/v2.7.x` and `maint/v2.8.x` both active, a release on the 2.7 line goes
+   `maint/v2.7.x` → `maint/v2.8.x`. Repeat along the chain for every newer line.
+3. Merge the newest maintenance branch into `main`.
+
+```
+release/X.Y.Z   ●  tag X.Y.Z
+                 \
+                  \  1. merge back
+                   ▼
+maint/vX.Y.x  ──────●────────────────────────────────────▶
+                     \
+                      \  2. merge forward
+                       ▼
+maint/vX.Y+1.x  ────────●────────────────────────────────▶
+                         \
+                          \  3. merge back to trunk
+                           ▼
+main          ──────────────●────────────────────────────▶
+```
+
+Do not treat step 3 as release-time-only work: merge `maint/` branches back to
+`main` regularly. Trunk then never drifts far from what is shipping, and each
+merge stays small enough to resolve confidently.
+
+Skipping a forward merge is how a fix silently regresses — a user upgrading from
+2.7.1 to 2.8.0 would lose it. If a forward merge conflicts, resolve it in favour
+of keeping both changes rather than dropping either, and verify the result builds
+before pushing.
 
 ## Commit Messages
 

--- a/Scripts/start-release.sh
+++ b/Scripts/start-release.sh
@@ -1,0 +1,215 @@
+#!/usr/bin/env bash
+#
+# start-release.sh: open a release for review.
+#
+# This is the FIRST step of a release, before Scripts/prepare-release.sh and
+# Scripts/release.sh. It creates the two branches described in CONTRIBUTING.md
+# and makes the CHANGELOG commit:
+#
+#   release/X.Y.Z   cut from the PREVIOUS release tag. It is the base of the
+#                   release PR and what eventually gets tagged.
+#   review/X.Y.Z    cut from the revision being released. It carries the
+#                   release preparation commits.
+#
+# The PR from review/X.Y.Z into release/X.Y.Z then shows exactly what this
+# release adds over the previous one, with none of the intervening history.
+#
+# It does not touch Package.swift. The binary target's URL and checksum cannot
+# be known until the xcframework has been built and uploaded, so those are
+# written by Scripts/release.sh, which runs after this PR has merged.
+#
+# Usage:
+#   ./Scripts/start-release.sh [options] <remote> <version> [<revision>]
+#
+#   <remote>    git remote for zcash/zcash-swift-wallet-sdk, e.g. upstream
+#   <version>   version being released, e.g. 2.7.1
+#   <revision>  commit or branch holding the changes to release
+#               (default: current HEAD, which should be a maint/ branch)
+#
+# Options:
+#   --previous <tag>  base the release branch on this tag rather than the
+#                     detected one. Use when the newest tag reachable from
+#                     <revision> is not the release you are following.
+#   --push-review     also push review/X.Y.Z, so the PR can be opened at once.
+#   --dry-run         print what would happen and change nothing.
+#
+# It deliberately does not tag, publish, or open the PR: those are the steps
+# worth a human looking at the diff first.
+
+set -euo pipefail
+
+# Tags and release branches carry no `v` prefix in this repository (2.7.0-rc.1,
+# release/3.0.0), unlike the sibling Android SDK. Maintenance branches do.
+readonly TAG_PREFIX=""
+
+usage() { sed -n '2,38p' "$0" | sed 's|^# \{0,1\}||'; exit "${1:-1}"; }
+
+PREVIOUS=""
+PUSH_REVIEW=false
+DRY_RUN=false
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --previous)     PREVIOUS="${2:?--previous needs a tag}"; shift 2 ;;
+        --push-review)  PUSH_REVIEW=true; shift ;;
+        --dry-run)      DRY_RUN=true; shift ;;
+        -h|--help)      usage 0 ;;
+        --*)            echo "error: unknown option '$1'" >&2; usage ;;
+        *)              break ;;
+    esac
+done
+
+[ $# -ge 2 ] || usage
+readonly REMOTE="$1"
+readonly VERSION="${2#v}"
+readonly REVISION="${3:-HEAD}"
+
+cd "$(git rev-parse --show-toplevel)"
+
+run() {
+    if $DRY_RUN; then echo "  would run: $*"; else "$@"; fi
+}
+
+step() { echo; echo "==> $*"; }
+
+# Semver ordering. GNU `sort -V` ranks 2.7.0-rc.1 *above* 2.7.0, which is
+# backwards: a pre-release precedes its release. Mapping '-' to '~' fixes it,
+# because sort -V treats '~' as lower than the empty string.
+version_sort() { sed 's/-/~/' | sort -V | sed 's/~/-/'; }
+
+version_le() {
+    [ "$(printf '%s\n%s\n' "$1" "$2" | version_sort | head -1)" = "$1" ]
+}
+
+# ---------------------------------------------------------------- preflight
+
+step "Checking preconditions"
+
+if [ -n "$(git status --porcelain --untracked-files=no)" ]; then
+    echo "error: working tree has uncommitted changes." >&2
+    exit 1
+fi
+
+git remote get-url "$REMOTE" >/dev/null 2>&1 || {
+    echo "error: no such remote '$REMOTE'." >&2; exit 1; }
+
+echo "  fetching $REMOTE ..."
+git fetch --tags "$REMOTE" >/dev/null 2>&1
+
+REV_SHA="$(git rev-parse --verify "${REVISION}^{commit}")"
+echo "  releasing the content of $REVISION ($(git rev-parse --short "$REV_SHA"))"
+
+readonly NEW_TAG="${TAG_PREFIX}${VERSION}"
+if git rev-parse -q --verify "refs/tags/${NEW_TAG}" >/dev/null; then
+    echo "error: ${NEW_TAG} is already tagged; pick a new version." >&2
+    exit 1
+fi
+
+# ------------------------------------------------------- previous release
+
+step "Determining the release base"
+
+if [ -n "$PREVIOUS" ]; then
+    PREV_TAG="${PREVIOUS}"
+    git rev-parse -q --verify "refs/tags/${PREV_TAG}" >/dev/null || {
+        echo "error: no such tag '${PREV_TAG}'." >&2; exit 1; }
+    echo "  using --previous ${PREV_TAG}"
+else
+    # Only tags reachable from the revision are candidates: a tag on a newer
+    # line is not something this release can be a successor to. The glob keeps
+    # non-version tags (e.g. rustwelding-*) out of the running.
+    PREV_TAG="$(git tag --list --merged "$REV_SHA" '[0-9]*' | version_sort | tail -1)"
+    [ -n "$PREV_TAG" ] || {
+        echo "error: no release tags are reachable from ${REVISION}." >&2
+        echo "       pass --previous <tag> to say which release this follows." >&2
+        exit 1; }
+    echo "  newest release reachable from ${REVISION}: ${PREV_TAG}"
+fi
+
+PREV_VERSION="${PREV_TAG#"$TAG_PREFIX"}"
+if version_le "$VERSION" "$PREV_VERSION"; then
+    echo "error: ${VERSION} does not come after ${PREV_VERSION}." >&2
+    exit 1
+fi
+
+readonly RELEASE_BRANCH="release/${VERSION}"
+readonly REVIEW_BRANCH="review/${VERSION}"
+
+for b in "$RELEASE_BRANCH" "$REVIEW_BRANCH"; do
+    git rev-parse -q --verify "refs/heads/${b}" >/dev/null && {
+        echo "error: branch ${b} already exists locally." >&2; exit 1; }
+done
+
+echo
+echo "  ${RELEASE_BRANCH}  <- ${PREV_TAG}        (PR base, pushed to ${REMOTE})"
+echo "  ${REVIEW_BRANCH}   <- ${REVISION}   (release prep goes here)"
+
+# --------------------------------------------------------------- branches
+
+step "Creating ${RELEASE_BRANCH} from ${PREV_TAG}"
+run git branch "$RELEASE_BRANCH" "refs/tags/${PREV_TAG}"
+run git push "$REMOTE" "${RELEASE_BRANCH}:${RELEASE_BRANCH}"
+
+step "Creating ${REVIEW_BRANCH} from ${REVISION}"
+run git switch -c "$REVIEW_BRANCH" "$REV_SHA"
+
+# ------------------------------------------------------------- CHANGELOG
+
+step "Promoting the CHANGELOG"
+
+# Entries are written as part of the commit that makes each change, so this
+# only ever promotes what is already there -- it never generates text. An
+# empty Unreleased section means the entries were not written, which is much
+# more likely to be an oversight than a genuinely invisible release.
+if ! awk '/^# Unreleased/{f=1;next} f && /^# /{exit} f && NF{found=1} END{exit !found}' CHANGELOG.md; then
+    echo "error: the Unreleased section is empty." >&2
+    echo "       Every user-visible change needs an entry before release." >&2
+    exit 1
+fi
+
+if $DRY_RUN; then
+    echo "  would insert '# ${VERSION} - $(date +%Y-%m-%d)' below '# Unreleased'"
+else
+    awk -v ver="$VERSION" -v date="$(date +%Y-%m-%d)" '
+        !done && /^# Unreleased/ { print; print ""; print "# " ver " - " date; done=1; next }
+        { print }
+    ' CHANGELOG.md > CHANGELOG.md.tmp && mv CHANGELOG.md.tmp CHANGELOG.md
+    grep -q "^# ${VERSION} - " CHANGELOG.md \
+        || { echo "error: CHANGELOG not promoted." >&2; exit 1; }
+    echo "  # ${VERSION} - $(date +%Y-%m-%d)"
+fi
+
+# ----------------------------------------------------------------- commit
+
+step "Committing"
+run git add CHANGELOG.md
+run git commit -m "Prepare SDK release ${VERSION}"
+
+if $PUSH_REVIEW; then
+    step "Pushing ${REVIEW_BRANCH}"
+    run git push -u "$REMOTE" "$REVIEW_BRANCH"
+fi
+
+# ------------------------------------------------------------- next steps
+
+cat <<EOF
+
+Done. ${RELEASE_BRANCH} is on ${REMOTE}; ${REVIEW_BRANCH} is checked out here.
+
+Next:
+EOF
+$PUSH_REVIEW || echo "  git push -u ${REMOTE} ${REVIEW_BRANCH}"
+cat <<EOF
+  gh pr create --repo zcash/zcash-swift-wallet-sdk \\
+      --base ${RELEASE_BRANCH} --head ${REVIEW_BRANCH} \\
+      --title "Release zcash-swift-wallet-sdk ${VERSION}"
+
+Review the PR diff: it is exactly what users get over ${PREV_TAG}. Then merge
+it and run
+
+  ./Scripts/release.sh ${REMOTE} ${VERSION}
+
+from ${RELEASE_BRANCH}, which builds the xcframework, writes the Package.swift
+URL and checksum, tags ${NEW_TAG} and publishes. Afterwards merge the release
+branch back into its maint/ branch and forward along the chain, as described in
+CONTRIBUTING.md.
+EOF


### PR DESCRIPTION
Documents the maintenance-branch and release process in `CONTRIBUTING.md`, and adds `Scripts/start-release.sh` to automate the branch setup it describes.

Targets `maint/v2.7.x`, the oldest currently-supported line, so it merges forward to `maint/v3.0.x` and `main` — per the rule the document itself states.

Opened without a closing keyword: this is documentation and tooling with no tracking issue.

## `CONTRIBUTING.md`

A new **Release and Maintenance Branches** section covering the three things that are easy to get wrong and fail quietly:

- **Base bug fixes on the oldest supported maintenance branch.** The rule is *merge forward, cherry-pick back*. A fix based on a newer line can't travel to an older one by merging at all.
- **Cut `release/X.Y.Z` from the previous release tag**, not from the maintenance branch. That is what makes the release PR's diff exactly what users receive, rather than the intervening development history.
- **Do the release preparation on `review/X.Y.Z`**, not on the release branch.

Plus the post-release merges — release → `maint/vX.Y.x` → forward along the chain → `main` — with the note that merging maint back to `main` is regular practice, not release-time-only. Skipping a forward merge is how a fix silently regresses.

Three ASCII diagrams: the fix path, the release PR shape, and the post-release merges.

Written in this repository's own naming: tags and release branches carry no `v` prefix here (`2.7.0-rc.1`, `release/3.0.0`), while maintenance branches do (`maint/v2.7.x`). The sibling Android SDK PR uses that repository's v-prefixed form.

## `Scripts/start-release.sh`

Slots in **ahead of** the existing `prepare-release.sh` and `release.sh`, which assume you are already on the right branch at the right version. It works out which release this one follows, cuts and pushes `release/X.Y.Z`, cuts `review/X.Y.Z`, promotes the CHANGELOG, and commits. Tagging, publishing and opening the PR stay manual. `--dry-run` shows the plan.

**It does not touch `Package.swift`.** The binary target's URL and checksum cannot exist until the xcframework has been built and uploaded, so `release.sh` remains the place that writes them, after this PR has merged. The script's closing output hands off to it explicitly.

**Base-tag selection** is the part worth review attention. The previous release is the newest version tag *reachable from the revision being released*, not the newest tag in the repository. `sort -V` can't be used directly — it ranks `2.7.0-rc.1` **above** `2.7.0`, while semver puts a pre-release before its release; mapping `-` → `~` before sorting fixes it, since `sort -V` treats `~` as lower than the empty string. The tag glob also keeps non-version tags such as `rustwelding-*` out of the candidates. Verified against this repo's ~160 tags: it selects `2.7.0-rc.1` correctly.

**CHANGELOG handling** only promotes; it never generates text, because entries are written as part of the commit that makes each change. It refuses to run when the Unreleased section is empty, since that almost always means the entries were never written. This repository's CHANGELOG uses `# Version - date` headings with `##` subsections rather than the bracketed Keep a Changelog form, and the script matches that — verified against the real file.

---

_Opened with the assistance of Claude Code._
