### PR TITLE
[#MOB-1455] Report crossing values, and carry migration ids as u32

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,10 @@ implementation detail of the SDK and are documented in `rust/CHANGELOG.md`.
   `MigrationTransferProposal`, `MigrationTransferResult`, `MigrationRunEstimate` (and its
   `MigrationRunEstimate.Run`), `NoteSplitProposal`, `PreparedMigrationTransfer`,
   `MigrationUnsignedTransferPczt`, and `MigrationSignedTransferPczt`.
+- Migration transaction ids are `UInt32` (the engine's own id type) rather than decimal strings,
+  across `MigrationTransferProposal`, `PreparedMigrationTransfer`, `MigrationUnsignedTransferPczt`,
+  `MigrationSignedTransferPczt`, `MigrationAttentionReason.invalidTransfer`, and
+  `migrationRecordTransferResult(transferId:result:for:)`.
 - These are the value types of the staged migration API; the `Synchronizer` methods that produce
   and consume them land in a follow-up release, so no migration can be driven from the public API
   yet.

--- a/Sources/ZcashLightClientKit/Model/MigrationModels.swift
+++ b/Sources/ZcashLightClientKit/Model/MigrationModels.swift
@@ -77,8 +77,8 @@ public struct NoteSplitProposal: Equatable, Sendable {
 
 /// A single scheduled Orchard -> Ironwood transfer, as one element of a `MigrationSchedule`.
 public struct MigrationTransferProposal: Identifiable, Equatable, Sendable, Codable {
-    /// The transfer's opaque, engine-issued id.
-    public let id: String
+    /// The transfer's engine-issued id.
+    public let id: UInt32
     /// The value that crosses the turnstile: what this transfer adds to the destination pool, and
     /// one of the round `{1,2,5}×10ⁿ` denominations the run was planned in. The note the transfer
     /// spends is larger — it also carries the buffer that pays the transfer's own fee — but that
@@ -96,7 +96,7 @@ public struct MigrationTransferProposal: Identifiable, Equatable, Sendable, Coda
 
     /// Creates a `MigrationTransferProposal`.
     public init(
-        id: String,
+        id: UInt32,
         amount: Zatoshi,
         anchorHeight: BlockHeight,
         nextExecutableAfterHeight: BlockHeight,
@@ -264,8 +264,8 @@ public struct MigrationRunEstimate: Equatable, Sendable {
 /// A fully proven, signed migration transaction persisted by the engine, ready for the platform
 /// to broadcast (see `ZcashRustBackendWelding.migrationExtractBroadcastTx(pczt:for:)`).
 public struct PreparedMigrationTransfer: Equatable, Sendable {
-    /// The transfer's opaque, engine-issued id.
-    public let id: String
+    /// The transfer's engine-issued id.
+    public let id: UInt32
     /// The finalized transaction's id, in the SDK's raw/internal byte order (matching `TxId.id`,
     /// not the reversed display-hex order produced by `Data.toHexStringTxId()`). Zeroed when the
     /// value is a STORAGE RECEIPT (`migrationStoreSignedNoteSplitPczts`) whose transaction has not
@@ -275,7 +275,7 @@ public struct PreparedMigrationTransfer: Equatable, Sendable {
     public let pczt: Data
 
     /// Creates a `PreparedMigrationTransfer`.
-    public init(id: String, txid: Data, pczt: Data) {
+    public init(id: UInt32, txid: Data, pczt: Data) {
         self.id = id
         self.txid = txid
         self.pczt = pczt
@@ -304,7 +304,7 @@ public enum MigrationTransferResult: Equatable, Sendable {
 /// Why a migration requires user attention, as carried by `MigrationState.requiresAttention`.
 public enum MigrationAttentionReason: Equatable, Sendable {
     /// The input note funding `transferId` was spent externally before its transfer broadcast.
-    case invalidTransfer(transferId: String)
+    case invalidTransfer(transferId: UInt32)
     /// A transaction's anchor/expiry elapsed before it could be broadcast.
     case transferExpired
 }
@@ -312,13 +312,13 @@ public enum MigrationAttentionReason: Equatable, Sendable {
 /// An unsigned-but-proven PCZT for one scheduled transfer, awaiting an external signer (see
 /// `ZcashRustBackendWelding.migrationCreateUnsignedTransferPczts(for:for:)`).
 public struct MigrationUnsignedTransferPczt: Equatable, Sendable {
-    /// The transfer's opaque, engine-issued id.
-    public let id: String
+    /// The transfer's engine-issued id.
+    public let id: UInt32
     /// The serialized, proven-but-unsigned PCZT.
     public let pczt: Data
 
     /// Creates a `MigrationUnsignedTransferPczt`.
-    public init(id: String, pczt: Data) {
+    public init(id: UInt32, pczt: Data) {
         self.id = id
         self.pczt = pczt
     }
@@ -327,15 +327,15 @@ public struct MigrationUnsignedTransferPczt: Equatable, Sendable {
 /// An externally signed PCZT for one scheduled transfer, to be handed back to the engine via
 /// `ZcashRustBackendWelding.migrationStoreSignedSchedulePczts(_:for:)`.
 public struct MigrationSignedTransferPczt: Equatable, Sendable {
-    /// The transfer's opaque, engine-issued id (must match the corresponding
+    /// The transfer's engine-issued id (must match the corresponding
     /// `MigrationUnsignedTransferPczt.id`).
-    public let id: String
+    public let id: UInt32
     /// The serialized, signed PCZT.
     public let pczt: Data
 
     /// Creates a `MigrationSignedTransferPczt`. Apps construct this directly after routing the
     /// corresponding `MigrationUnsignedTransferPczt` through an external signer.
-    public init(id: String, pczt: Data) {
+    public init(id: UInt32, pczt: Data) {
         self.id = id
         self.pczt = pczt
     }

--- a/Sources/ZcashLightClientKit/Model/MigrationModels.swift
+++ b/Sources/ZcashLightClientKit/Model/MigrationModels.swift
@@ -79,7 +79,10 @@ public struct NoteSplitProposal: Equatable, Sendable {
 public struct MigrationTransferProposal: Identifiable, Equatable, Sendable, Codable {
     /// The transfer's opaque, engine-issued id.
     public let id: String
-    /// The value that crosses the turnstile.
+    /// The value that crosses the turnstile: what this transfer adds to the destination pool, and
+    /// one of the round `{1,2,5}×10ⁿ` denominations the run was planned in. The note the transfer
+    /// spends is larger — it also carries the buffer that pays the transfer's own fee — but that
+    /// is a spend-side detail the user is not asked to approve.
     public let amount: Zatoshi
     /// The "now" reference height at proposal time (the chain tip). With ZIP 374 the real anchor
     /// is drawn per transfer and installed at proving time, so this field is NOT a commitment-tree

--- a/Sources/ZcashLightClientKit/Rust/ZcashRustBackend.swift
+++ b/Sources/ZcashLightClientKit/Rust/ZcashRustBackend.swift
@@ -1833,7 +1833,7 @@ struct ZcashRustBackend: ZcashRustBackendWelding {
 
     @DBActor
     func migrationRecordTransferResult(
-        transferId: String,
+        transferId: UInt32,
         result: MigrationTransferResult,
         for account: AccountUUID
     ) async throws {
@@ -1866,7 +1866,7 @@ struct ZcashRustBackend: ZcashRustBackendWelding {
             dbData.1,
             account.id,
             networkType.networkId,
-            [CChar](transferId.utf8CString),
+            transferId,
             resultTag,
             txidBytes
         )
@@ -1991,9 +1991,7 @@ struct ZcashRustBackend: ZcashRustBackendWelding {
         _ signed: [MigrationSignedTransferPczt],
         for account: AccountUUID
     ) async throws -> PreparedMigrationTransfer {
-        let idsCStrings = makeCStrings(signed.map { $0.id })
-        defer { freeCStrings(idsCStrings) }
-        let idsConstPointers = constPointers(idsCStrings)
+        let ids: [UInt32] = signed.map { $0.id }
 
         // One owned buffer per pczt (see `migrationStoreSignedSchedulePczts` for the rationale).
         let pcztBuffers: [UnsafeMutablePointer<UInt8>] = signed.map { transfer in
@@ -2006,7 +2004,7 @@ struct ZcashRustBackend: ZcashRustBackendWelding {
         let pcztPointers: [UnsafePointer<UInt8>?] = pcztBuffers.map { UnsafePointer($0) }
         let pcztLens: [UInt] = signed.map { UInt($0.pczt.count) }
 
-        let preparedPtr = idsConstPointers.withUnsafeBufferPointer { idsPtr in
+        let preparedPtr = ids.withUnsafeBufferPointer { idsPtr in
             pcztPointers.withUnsafeBufferPointer { pcztsPtr in
                 pcztLens.withUnsafeBufferPointer { lensPtr in
                     zcashlc_migration_store_signed_note_split_pczts(
@@ -2080,9 +2078,7 @@ struct ZcashRustBackend: ZcashRustBackendWelding {
 
     @DBActor
     func migrationStoreSignedSchedulePczts(_ signed: [MigrationSignedTransferPczt], for account: AccountUUID) async throws {
-        let idsCStrings = makeCStrings(signed.map { $0.id })
-        defer { freeCStrings(idsCStrings) }
-        let idsConstPointers = constPointers(idsCStrings)
+        let ids: [UInt32] = signed.map { $0.id }
 
         // One owned buffer per pczt, each populated with a single `copyBytes` call. The FFI call
         // needs every pczt's bytes alive as an independent buffer simultaneously (parallel
@@ -2099,7 +2095,7 @@ struct ZcashRustBackend: ZcashRustBackendWelding {
         let pcztPointers: [UnsafePointer<UInt8>?] = pcztBuffers.map { UnsafePointer($0) }
         let pcztLens: [UInt] = signed.map { UInt($0.pczt.count) }
 
-        let success = idsConstPointers.withUnsafeBufferPointer { idsPtr in
+        let success = ids.withUnsafeBufferPointer { idsPtr in
             pcztPointers.withUnsafeBufferPointer { pcztsPtr in
                 pcztLens.withUnsafeBufferPointer { lensPtr in
                     zcashlc_migration_store_signed_schedule_pczts(
@@ -2393,14 +2389,7 @@ extension FfiAttentionReason {
     func unsafeToMigrationAttentionReason() -> MigrationAttentionReason? {
         switch tag {
         case 0:
-            guard
-                let transferIdPtr = invalid_transfer.transfer_id,
-                let transferId = String(validatingUTF8: transferIdPtr)
-            else {
-                return nil
-            }
-
-            return .invalidTransfer(transferId: transferId)
+            return .invalidTransfer(transferId: invalid_transfer.transfer_id)
         case 1:
             return .transferExpired
         default:
@@ -2448,18 +2437,14 @@ extension FfiNoteSplitProposal {
 
 extension FfiPreparedTransfer {
     /// Converts an [`FfiPreparedTransfer`] into a [`PreparedMigrationTransfer`], or `nil` for the
-    /// "nothing due" sentinel (`id` and `pczt` both null).
+    /// "nothing due" sentinel (a null `pczt`, whose `id` is meaningless).
     func unsafeToPreparedMigrationTransfer() -> PreparedMigrationTransfer? {
-        guard
-            let idPtr = id,
-            let pcztPtr = pczt,
-            let transferId = String(validatingUTF8: idPtr)
-        else {
+        guard let pcztPtr = pczt else {
             return nil
         }
 
         return PreparedMigrationTransfer(
-            id: transferId,
+            id: id,
             txid: Data(FfiTxId(tuple: txid).array),
             pczt: Data(bytes: pcztPtr, count: Int(pczt_len))
         )
@@ -2470,10 +2455,8 @@ extension FfiTransferProposal {
     /// Converts an [`FfiTransferProposal`] into a [`MigrationTransferProposal`], or `nil` for a
     /// missing `id` (should not happen; defensive only).
     func unsafeToMigrationTransferProposal() -> MigrationTransferProposal? {
-        guard let idPtr = id, let transferId = String(validatingUTF8: idPtr) else { return nil }
-
         return MigrationTransferProposal(
-            id: transferId,
+            id: id,
             amount: Zatoshi(amount),
             anchorHeight: BlockHeight(anchor_height),
             nextExecutableAfterHeight: BlockHeight(next_executable_after_height),
@@ -2531,18 +2514,14 @@ extension FfiMigrationRunEstimate {
 
 extension FfiUnsignedTransferPczt {
     /// Converts an [`FfiUnsignedTransferPczt`] into a [`MigrationUnsignedTransferPczt`], or `nil`
-    /// for a missing `id`/`pczt` (should not happen; defensive only).
+    /// for a missing `pczt` (should not happen; defensive only).
     func unsafeToMigrationUnsignedTransferPczt() -> MigrationUnsignedTransferPczt? {
-        guard
-            let idPtr = id,
-            let pcztPtr = pczt,
-            let transferId = String(validatingUTF8: idPtr)
-        else {
+        guard let pcztPtr = pczt else {
             return nil
         }
 
         return MigrationUnsignedTransferPczt(
-            id: transferId,
+            id: id,
             pczt: Data(bytes: pcztPtr, count: Int(pczt_len))
         )
     }

--- a/Sources/ZcashLightClientKit/Rust/ZcashRustBackendWelding.swift
+++ b/Sources/ZcashLightClientKit/Rust/ZcashRustBackendWelding.swift
@@ -533,7 +533,7 @@ protocol ZcashRustBackendWelding {
     ///           `migrationInvalidTxId` if `result` is `.success` and its `txId` does not decode
     ///           to a 32-byte transaction id.
     func migrationRecordTransferResult(
-        transferId: String,
+        transferId: UInt32,
         result: MigrationTransferResult,
         for account: AccountUUID
     ) async throws

--- a/Tests/OfflineTests/MigrationFFITests.swift
+++ b/Tests/OfflineTests/MigrationFFITests.swift
@@ -212,29 +212,38 @@ final class MigrationFFITests: XCTestCase {
         }
     }
 
-    /// Ported from the prototype's `testRecordTransferResultWithNoActiveRunThrows`: recording a
-    /// result against a transfer id with no active migration run throws
-    /// `MigrationError::InvalidState(NoActiveRun)` -- a deterministic, sync-independent throw (this
-    /// path never touches the wallet schema at all). Uses `.networkError` rather than `.success` to
-    /// keep the test focused on the "no active run" contract, sidestepping the unrelated txid-hex
-    /// validation `.success` carries (see `TxIdTests.testTxIdStringRoundTripsThroughRawBytesForAnAsymmetricFixture`
-    /// / `testTxIdRawBytesRoundTripThroughDisplayHexStringForAnAsymmetricFixture` for the conversion
-    /// helpers themselves, and
-    /// `OrchardMigrationCompositionTests.testExecuteNextPendingTransferRecordsTheDocumentedByteOrderForAnAsymmetricTxId`
-    /// for that validation exercised through this same welding record path).
+    /// Recording a SUCCESS against a transfer id with no active migration run throws: that path
+    /// must load the stored run to mark the transfer broadcast, and there is none. A deterministic,
+    /// sync-independent throw — it never touches the wallet schema.
+    ///
+    /// (Before transfer ids became `UInt32` this test passed `.networkError` with an unparseable
+    /// string id, so what threw was the id decode, not the missing run. `.networkError` records
+    /// nothing by design — see `testRecordTransferResultForANetworkErrorSucceedsWithNoActiveRun`
+    /// — so it can never exercise this contract.)
     func testRecordTransferResultWithNoActiveRunThrows() async throws {
         do {
             try await rustBackend.migrationRecordTransferResult(
-                transferId: "does-not-exist",
-                result: MigrationTransferResult.networkError(retryable: true),
+                transferId: 4_294_967_295,
+                result: MigrationTransferResult.success(txId: String(repeating: "ab", count: 32)),
                 for: account
             )
-            XCTFail("Expected recording a result with no active migration run to throw")
+            XCTFail("Expected recording a success with no active migration run to throw")
         } catch ZcashError.rustMigrationRecordTransferResult {
             // expected
         } catch {
             XCTFail("Expected rustMigrationRecordTransferResult but got \(error)")
         }
+    }
+
+    /// A network error is a Swift-level signal for the caller's own retry policy: the native side
+    /// records nothing and reports success, even with no active run. Documents the asymmetry the
+    /// test above depends on.
+    func testRecordTransferResultForANetworkErrorSucceedsWithNoActiveRun() async throws {
+        try await rustBackend.migrationRecordTransferResult(
+            transferId: 4_294_967_295,
+            result: MigrationTransferResult.networkError(retryable: true),
+            for: account
+        )
     }
 
     /// Ported from the prototype's `testExtractBroadcastTxWithInvalidPcztThrows`: garbage PCZT bytes
@@ -315,8 +324,8 @@ final class MigrationFFITests: XCTestCase {
 
         do {
             try await rustBackend.migrationRecordTransferResult(
-                transferId: "does-not-exist",
-                result: MigrationTransferResult.networkError(retryable: true),
+                transferId: 4_294_967_295,
+                result: MigrationTransferResult.success(txId: String(repeating: "ab", count: 32)),
                 for: account
             )
             XCTFail("Expected recording a result with no active migration run to throw")

--- a/Tests/TestUtils/Sourcery/GeneratedMocks/AutoMockable.generated.swift
+++ b/Tests/TestUtils/Sourcery/GeneratedMocks/AutoMockable.generated.swift
@@ -4529,10 +4529,10 @@ class ZcashRustBackendWeldingMock: ZcashRustBackendWelding {
     var migrationRecordTransferResultTransferIdResultForCalled: Bool {
         return migrationRecordTransferResultTransferIdResultForCallsCount > 0
     }
-    var migrationRecordTransferResultTransferIdResultForReceivedArguments: (transferId: String, result: MigrationTransferResult, account: AccountUUID)?
-    var migrationRecordTransferResultTransferIdResultForClosure: ((String, MigrationTransferResult, AccountUUID) async throws -> Void)?
+    var migrationRecordTransferResultTransferIdResultForReceivedArguments: (transferId: UInt32, result: MigrationTransferResult, account: AccountUUID)?
+    var migrationRecordTransferResultTransferIdResultForClosure: ((UInt32, MigrationTransferResult, AccountUUID) async throws -> Void)?
 
-    func migrationRecordTransferResult(transferId: String, result: MigrationTransferResult, for account: AccountUUID) async throws {
+    func migrationRecordTransferResult(transferId: UInt32, result: MigrationTransferResult, for account: AccountUUID) async throws {
         if let error = migrationRecordTransferResultTransferIdResultForThrowableError {
             throw error
         }

--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -46,7 +46,12 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   echoes, checked against the previewed plan (or, once committed, the stored
   state), with a mismatch surfacing `MIGRATION_PLAN_STALE`, so a stale or
   tampered display can never sign different values than the ones the user
-  approved. Ids, amounts, expiry heights, and the estimated duration are
+  approved. Every transfer amount the FFI reports (schedule rows, the pending
+  transfer proposal) is the value that CROSSES into Ironwood — the funding note
+  the transfer spends, less the buffer that pays that transfer's own fee — so it
+  is one of the round `{1,2,5}×10ⁿ` denominations the run was planned in and the
+  amount the destination balance grows by, not the larger spend-side note value.
+  Ids, amounts, expiry heights, and the estimated duration are
   always compared; next-executable heights are compared only against the
   previewed plan, never post-commit (the immediate lane's commit-time
   reschedule legitimately moves them away from an honest echo, with no way

--- a/rust/src/migration.rs
+++ b/rust/src/migration.rs
@@ -368,18 +368,38 @@ fn compute_plan(ctx: &mut CallCtx) -> anyhow::Result<Option<(MigrationPlan, Bloc
     }
 }
 
-/// The row set the platform sees for a plan's transfer schedule: `(engine tx id, amount, broadcast
-/// height, expiry height)`, sorted chronologically by broadcast height.
+/// What a transfer spending `funding_note` CROSSES into Ironwood: the note less the fee buffer
+/// that funds the transfer's own fee (the transfer has no change output, so the buffer is consumed
+/// exactly). This is the round `{1,2,5}×10ⁿ` denomination the user consented to and the amount
+/// their Ironwood balance will grow by — the funding note itself is a spend-side value that
+/// overstates it by one transfer fee.
 ///
-/// - Amounts pair with `funding_notes()` (the post-reconciliation values), NOT the note split's
-///   raw `crossing_values()` — the two differ whenever preparation fees drop the smallest
-///   denominations, and mispairing silently attaches wrong amounts to schedule heights.
+/// The engine builds every funding note as `crossing + buffer`, so the subtraction cannot
+/// underflow; a stored plan that violated that invariant saturates to zero rather than panicking
+/// across the FFI, and the zero is self-evidently wrong in the platform's display.
+// TODO: [#1806] Replace with the engine's own `transfer_crossing_value` /
+// `crossing_values` accessors (librustzcash #2767) when the pin moves to the next rc.
+fn crossing_amount(funding_note: Zatoshis, note_fee_buffer: Zatoshis) -> Zatoshis {
+    (funding_note - note_fee_buffer).unwrap_or(Zatoshis::ZERO)
+}
+
+/// The row set the platform sees for a plan's transfer schedule: `(engine tx id, crossing amount,
+/// broadcast height, expiry height)`, sorted chronologically by broadcast height.
+///
+/// - Amounts are what each transfer CROSSES (see [`crossing_amount`]), not the funding note it
+///   spends: serving the note overstates every row by one transfer fee and shows a value that is
+///   not a round denomination the user was asked to approve.
+/// - Rows still pair with `funding_notes()` (the post-reconciliation values), NOT the denomination
+///   plan's raw `crossing_values()` — the two differ whenever preparation fees drop the smallest
+///   denominations, and mispairing silently attaches wrong amounts to schedule heights. Taking the
+///   buffer off each paired row preserves that pairing.
 /// - The engine numbers every preparation transaction first, then transfers in `schedule()`
 ///   order, so transfer `i`'s real committed id is `prep_tx_count + i`.
 /// - The sort makes the platform's row order chronological: ZIP 318 SHUFFLE deliberately makes
 ///   funding-note order differ from broadcast order.
 fn schedule_rows(
     funding_notes: &[Zatoshis],
+    note_fee_buffer: Zatoshis,
     schedule: &[zcash_pool_migration::scheduling::Schedule],
     prep_tx_count: u32,
 ) -> anyhow::Result<Vec<(MigrationTxId, Zatoshis, BlockHeight, BlockHeight)>> {
@@ -394,10 +414,10 @@ fn schedule_rows(
         .iter()
         .zip(schedule.iter())
         .enumerate()
-        .map(|(i, (amount, entry))| {
+        .map(|(i, (funding_note, entry))| {
             (
                 MigrationTxId::new(prep_tx_count + i as u32),
-                *amount,
+                crossing_amount(*funding_note, note_fee_buffer),
                 entry.broadcast_height(),
                 entry.expiry_height(),
             )
@@ -442,7 +462,12 @@ fn encode_schedule_from_plan(
     now_reference: BlockHeight,
     plan_handle: migration_plan_cache::PlanHandle,
 ) -> anyhow::Result<*mut FfiMigrationSchedule> {
-    let rows = schedule_rows(&plan.funding_notes(), plan.schedule(), prep_tx_count(plan))?;
+    let rows = schedule_rows(
+        &plan.funding_notes(),
+        plan.note_split().note_fee_buffer(),
+        plan.schedule(),
+        prep_tx_count(plan),
+    )?;
     let transfers = rows
         .into_iter()
         .map(|(id, amount, broadcast, expiry)| {
@@ -906,11 +931,18 @@ fn derive_state(
     }
 }
 
-/// The amount a stored transfer crosses, from the run's funding notes (`Transfer { crossing }`
-/// indexes into them).
+/// The amount a stored transfer CROSSES: its funding note (`Transfer { crossing }` indexes into
+/// the run's funding notes) less the fee buffer that pays the transfer's own fee — see
+/// [`crossing_amount`]. `None` for a preparation transaction, which crosses nothing.
 fn transfer_amount(state: &MigrationState, tx: &MigrationTransaction) -> Option<Zatoshis> {
     match tx.kind() {
-        MigrationTxKind::Transfer { crossing } => state.funding_notes().get(crossing).copied(),
+        MigrationTxKind::Transfer { crossing } => {
+            let buffer = state.note_split().note_fee_buffer();
+            state
+                .funding_notes()
+                .get(crossing)
+                .map(|funding_note| crossing_amount(*funding_note, buffer))
+        }
         _ => None,
     }
 }
@@ -1961,8 +1993,12 @@ pub unsafe extern "C" fn zcashlc_migration_propose_immediate_transfers(
         match plan_and_cache(&mut ctx, true)? {
             Some((plan, reference_height, handle)) => {
                 // Preview mirrors the commit-time rewrite: every transfer due at the tip.
-                let rows =
-                    schedule_rows(&plan.funding_notes(), plan.schedule(), prep_tx_count(&plan))?;
+                let rows = schedule_rows(
+                    &plan.funding_notes(),
+                    plan.note_split().note_fee_buffer(),
+                    plan.schedule(),
+                    prep_tx_count(&plan),
+                )?;
                 let transfers = rows
                     .into_iter()
                     .map(|(id, amount, _, expiry)| {
@@ -3030,12 +3066,19 @@ mod tests {
         ));
     }
 
+    /// The fee buffer the row fixtures build their funding notes with; any nonzero value exercises
+    /// the crossing subtraction.
+    const TEST_BUFFER: u64 = 15_000;
+
     #[test]
     fn schedule_rows_sort_chronologically_with_prep_offset() {
         let mut rng = StdRng::seed_from_u64(7);
         let schedule = scheduling::schedule(&SchedulingParams::ZIP_318, h(1_000), 5, &mut rng);
-        let amounts: Vec<Zatoshis> = (1..=5).map(|i| zat(i * 100_000_000)).collect();
-        let rows = schedule_rows(&amounts, &schedule, 3).unwrap();
+        // Funding notes, i.e. each crossing value PLUS the fee buffer, as the engine mints them.
+        let funding_notes: Vec<Zatoshis> = (1..=5)
+            .map(|i| zat(i * 100_000_000 + TEST_BUFFER))
+            .collect();
+        let rows = schedule_rows(&funding_notes, zat(TEST_BUFFER), &schedule, 3).unwrap();
         assert_eq!(rows.len(), 5);
         // Chronological by broadcast height.
         for pair in rows.windows(2) {
@@ -3045,19 +3088,41 @@ mod tests {
         let mut ids: Vec<u32> = rows.iter().map(|(id, _, _, _)| u32::from(*id)).collect();
         ids.sort_unstable();
         assert_eq!(ids, vec![3, 4, 5, 6, 7]);
-        // Amount pairing survives the sort: each id maps back to its crossing's amount.
+        // Amount pairing survives the sort, and each row carries the CROSSING value (the round
+        // denomination the user consented to), not the funding note that funds its fee.
         for (id, amount, _, _) in &rows {
             let crossing = u32::from(*id) - 3;
             assert_eq!(*amount, zat((u64::from(crossing) + 1) * 100_000_000));
         }
     }
 
+    /// A row reports what the transfer moves, never the note it spends: serving the funding note
+    /// would overstate every amount by one transfer fee and stop it being a round denomination.
+    #[test]
+    fn schedule_rows_report_the_crossing_value_not_the_funding_note() {
+        let mut rng = StdRng::seed_from_u64(11);
+        let schedule = scheduling::schedule(&SchedulingParams::ZIP_318, h(1_000), 1, &mut rng);
+        let crossing = 500_000_000;
+        let rows = schedule_rows(
+            &[zat(crossing + TEST_BUFFER)],
+            zat(TEST_BUFFER),
+            &schedule,
+            0,
+        )
+        .unwrap();
+        assert_eq!(
+            rows[0].1,
+            zat(crossing),
+            "the row must carry the crossing value, not the funding note"
+        );
+    }
+
     #[test]
     fn schedule_rows_reject_length_mismatch() {
         let mut rng = StdRng::seed_from_u64(7);
         let schedule = scheduling::schedule(&SchedulingParams::ZIP_318, h(1_000), 3, &mut rng);
-        let amounts = vec![zat(100)];
-        assert!(schedule_rows(&amounts, &schedule, 0).is_err());
+        let funding_notes = vec![zat(100)];
+        assert!(schedule_rows(&funding_notes, zat(0), &schedule, 0).is_err());
     }
 
     // ----- schedule-duration semantics (#1806): from `now` to the LAST scheduled broadcast -----
@@ -3648,9 +3713,11 @@ mod tests {
             .to_str()
             .expect("the row id is UTF-8");
         assert_eq!(row_id, "0", "the stored transfer's engine id");
-        // The state-side amount is the FUNDING NOTE (crossing + fee buffer), exactly what the
-        // consent echo compares (`expected_rows_from_state` uses the same `transfer_amount`).
-        assert_eq!(row.amount, 100_010_000);
+        // The state-side amount is what the transfer CROSSES: the fixture's funding note is
+        // 100_010_000 (crossing 100_000_000 plus the 10_000 fee buffer), and the row serves the
+        // crossing. The consent echo compares the same value (`expected_rows_from_state` uses the
+        // same `transfer_amount`), so platform and native still agree.
+        assert_eq!(row.amount, 100_000_000);
         assert_eq!(
             row.next_executable_after_height, 3_499_000,
             "the stored scheduled height is served unchanged"

--- a/rust/src/migration.rs
+++ b/rust/src/migration.rs
@@ -137,20 +137,6 @@ unsafe fn slice_or_empty<'a, T>(ptr: *const T, len: usize) -> &'a [T] {
     }
 }
 
-/// Decode a decimal transaction-id string (`MigrationTxId` raw value) from a C string.
-fn transfer_id_from_c(id: *const c_char) -> anyhow::Result<MigrationTxId> {
-    if id.is_null() {
-        return Err(anyhow!("transfer_id is null"));
-    }
-    let raw = unsafe { CStr::from_ptr(id) }
-        .to_str()
-        .map_err(|e| anyhow!("transfer id is not valid UTF-8: {e}"))?;
-    let idx: u32 = raw
-        .parse()
-        .map_err(|e| anyhow!("invalid transfer id {raw}: {e}"))?;
-    Ok(MigrationTxId::new(idx))
-}
-
 /// The common per-call context: the network parameters, the wallet handle, the migration-store
 /// connection (a second, independent connection to the same wallet database file — the
 /// account-keyed migration tables live inside it), and the raw path/account for the plan cache.
@@ -472,7 +458,7 @@ fn encode_schedule_from_plan(
         .into_iter()
         .map(|(id, amount, broadcast, expiry)| {
             Ok(FfiTransferProposal {
-                id: cstring_raw(&u32::from(id).to_string(), "transfer proposal id")?,
+                id: u32::from(id),
                 amount: zat_to_i64(amount),
                 anchor_height: i64::from(u32::from(now_reference)),
                 next_executable_after_height: i64::from(u32::from(broadcast)),
@@ -558,7 +544,7 @@ fn encode_schedule_from_state(
             let amount = transfer_amount(state, t)
                 .ok_or_else(|| anyhow!("stored transfer has no funding-note amount"))?;
             Ok(FfiTransferProposal {
-                id: cstring_raw(&u32::from(t.id()).to_string(), "transfer proposal id")?,
+                id: u32::from(t.id()),
                 amount: zat_to_i64(amount),
                 anchor_height: i64::from(u32::from(now_reference)),
                 next_executable_after_height: i64::from(u32::from(t.scheduled_height())),
@@ -988,10 +974,9 @@ impl FfiMigrationProgress {
 /// Why a migration requires user attention (payload of [`FfiMigrationState::RequiresAttention`]).
 #[repr(C, u8)]
 pub enum FfiAttentionReason {
-    /// The transfer identified by `transfer_id` was terminally rejected at broadcast (its input
-    /// note was spent externally, or the network refused it as invalid). `transfer_id` is an owned
-    /// C string, freed by [`zcashlc_free_migration_state`].
-    InvalidTransfer { transfer_id: *mut c_char },
+    /// The transfer identified by `transfer_id` (the engine's raw id) was terminally rejected at
+    /// broadcast: its input note was spent externally, or the network refused it as invalid.
+    InvalidTransfer { transfer_id: u32 },
     /// A transaction's expiry elapsed before it could be broadcast (or mined).
     TransferExpired,
 }
@@ -1036,9 +1021,9 @@ pub struct FfiNoteSplitProposal {
 /// `pczt` null) means "nothing is due" (as opposed to a NULL return, which signals an error).
 #[repr(C)]
 pub struct FfiPreparedTransfer {
-    /// The transaction's id (the engine's decimal id), as an owned C string (null only in the
-    /// "nothing due" sentinel).
-    pub id: *mut c_char,
+    /// The transaction's id (the engine's raw id). Meaningful only when `pczt` is non-null; the
+    /// "nothing due" sentinel leaves it `0`.
+    pub id: u32,
     /// The finalized transaction's id, as raw (internal-order) 32-byte value (zeroed when the
     /// value is a storage receipt whose transaction has not been proven yet).
     pub txid: [u8; 32],
@@ -1053,7 +1038,7 @@ impl FfiPreparedTransfer {
         txid: [u8; 32],
         pczt_bytes: Vec<u8>,
     ) -> anyhow::Result<*mut Self> {
-        let id = cstring_raw(&u32::from(id).to_string(), "prepared transfer id")?;
+        let id = u32::from(id);
         let (pczt, pczt_len) = ptr_from_vec(pczt_bytes);
         Ok(Box::into_raw(Box::new(FfiPreparedTransfer {
             id,
@@ -1065,7 +1050,7 @@ impl FfiPreparedTransfer {
 
     fn none() -> *mut Self {
         Box::into_raw(Box::new(FfiPreparedTransfer {
-            id: ptr::null_mut(),
+            id: 0,
             txid: [0u8; 32],
             pczt: ptr::null_mut(),
             pczt_len: 0,
@@ -1076,8 +1061,8 @@ impl FfiPreparedTransfer {
 /// A single scheduled Orchard→Ironwood transfer (element of [`FfiMigrationSchedule`]).
 #[repr(C)]
 pub struct FfiTransferProposal {
-    /// The transfer's id (the engine's decimal id), as an owned C string.
-    pub id: *mut c_char,
+    /// The transfer's id (the engine's raw id).
+    pub id: u32,
     /// The value (zatoshi) that crosses the turnstile.
     pub amount: i64,
     /// The "now" reference height at encode time (the chain tip). With ZIP 374 the real anchor is
@@ -1099,7 +1084,7 @@ impl FfiTransferProposal {
         expiry: BlockHeight,
     ) -> anyhow::Result<*mut Self> {
         Ok(Box::into_raw(Box::new(FfiTransferProposal {
-            id: cstring_raw(&u32::from(id).to_string(), "transfer proposal id")?,
+            id: u32::from(id),
             amount: zat_to_i64(amount),
             anchor_height: i64::from(u32::from(now_reference)),
             next_executable_after_height: i64::from(u32::from(next_executable_after)),
@@ -1159,8 +1144,8 @@ pub struct FfiMigrationRunEstimate {
 /// An unsigned PCZT awaiting an external signer (element of [`FfiUnsignedTransferPczts`]).
 #[repr(C)]
 pub struct FfiUnsignedTransferPczt {
-    /// The transaction's id (the engine's decimal id), as an owned C string.
-    pub id: *mut c_char,
+    /// The transaction's id (the engine's raw id).
+    pub id: u32,
     /// Heap `pczt_len`-byte serialized unsigned PCZT.
     pub pczt: *mut u8,
     pub pczt_len: usize,
@@ -1181,7 +1166,7 @@ impl FfiUnsignedTransferPczts {
         let items = pairs
             .into_iter()
             .map(|(id, bytes)| {
-                let id = cstring_raw(&u32::from(id).to_string(), "unsigned transfer pczt id")?;
+                let id = u32::from(id);
                 let (pczt, pczt_len) = ptr_from_vec(bytes);
                 Ok(FfiUnsignedTransferPczt { id, pczt, pczt_len })
             })
@@ -1283,15 +1268,9 @@ fn cstring_raw(s: &str, what: &str) -> anyhow::Result<*mut c_char> {
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn zcashlc_free_migration_state(ptr: *mut FfiMigrationState) {
     if !ptr.is_null() {
-        let boxed = unsafe { Box::from_raw(ptr) };
-        if let FfiMigrationState::RequiresAttention(FfiAttentionReason::InvalidTransfer {
-            transfer_id,
-        }) = &*boxed
-            && !transfer_id.is_null()
-        {
-            unsafe { zcashlc_string_free(*transfer_id) }
-        }
-        drop(boxed);
+        // Every payload is plain data (`InvalidTransfer` carries a `u32` id), so dropping the
+        // box is the whole of the cleanup.
+        drop(unsafe { Box::from_raw(ptr) });
     }
 }
 
@@ -1329,15 +1308,12 @@ pub unsafe extern "C" fn zcashlc_free_migration_note_split_proposal(
 pub unsafe extern "C" fn zcashlc_free_migration_prepared_transfer(ptr: *mut FfiPreparedTransfer) {
     if !ptr.is_null() {
         let boxed = unsafe { Box::from_raw(ptr) };
-        if !boxed.id.is_null() {
-            unsafe { zcashlc_string_free(boxed.id) }
-        }
         free_ptr_from_vec(boxed.pczt, boxed.pczt_len);
         drop(boxed);
     }
 }
 
-/// Frees a [`FfiMigrationSchedule`], including every transfer's id string.
+/// Frees a [`FfiMigrationSchedule`] and its transfer rows.
 ///
 /// # Safety
 /// `ptr` must be null or point to a [`FfiMigrationSchedule`] handed out by this module.
@@ -1345,28 +1321,22 @@ pub unsafe extern "C" fn zcashlc_free_migration_prepared_transfer(ptr: *mut FfiP
 pub unsafe extern "C" fn zcashlc_free_migration_schedule(ptr: *mut FfiMigrationSchedule) {
     if !ptr.is_null() {
         let boxed = unsafe { Box::from_raw(ptr) };
-        free_ptr_from_vec_with(boxed.transfers, boxed.transfers_len, |t| {
-            if !t.id.is_null() {
-                unsafe { zcashlc_string_free(t.id) }
-            }
-        });
+        // Every row is plain data (ids are `u32`), so freeing the row vector is enough.
+        free_ptr_from_vec(boxed.transfers, boxed.transfers_len);
         drop(boxed);
     }
 }
 
 /// Frees a standalone [`FfiTransferProposal`] (as returned by
-/// `zcashlc_migration_pending_transfer_proposal`), including its id string.
+/// `zcashlc_migration_pending_transfer_proposal`).
 ///
 /// # Safety
 /// `ptr` must be null or point to a [`FfiTransferProposal`] handed out by this module.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn zcashlc_free_migration_transfer_proposal(ptr: *mut FfiTransferProposal) {
     if !ptr.is_null() {
-        let boxed = unsafe { Box::from_raw(ptr) };
-        if !boxed.id.is_null() {
-            unsafe { zcashlc_string_free(boxed.id) }
-        }
-        drop(boxed);
+        // The id is a plain `u32`; dropping the box is the whole of the cleanup.
+        drop(unsafe { Box::from_raw(ptr) });
     }
 }
 
@@ -1394,9 +1364,6 @@ pub unsafe extern "C" fn zcashlc_free_migration_unsigned_transfer_pczts(
     if !ptr.is_null() {
         let boxed = unsafe { Box::from_raw(ptr) };
         free_ptr_from_vec_with(boxed.ptr, boxed.len, |u| {
-            if !u.id.is_null() {
-                unsafe { zcashlc_string_free(u.id) }
-            }
             free_ptr_from_vec(u.pczt, u.pczt_len);
         });
         drop(boxed);
@@ -1460,7 +1427,7 @@ fn marshal_state(
         }),
         DerivedState::InvalidTransfer(id) => {
             FfiMigrationState::RequiresAttention(FfiAttentionReason::InvalidTransfer {
-                transfer_id: cstring_raw(&id.to_string(), "attention transfer id")?,
+                transfer_id: id,
             })
         }
         DerivedState::TransferExpired => {
@@ -2003,7 +1970,7 @@ pub unsafe extern "C" fn zcashlc_migration_propose_immediate_transfers(
                     .into_iter()
                     .map(|(id, amount, _, expiry)| {
                         Ok(FfiTransferProposal {
-                            id: cstring_raw(&u32::from(id).to_string(), "transfer proposal id")?,
+                            id: u32::from(id),
                             amount: zat_to_i64(amount),
                             anchor_height: i64::from(u32::from(reference_height)),
                             next_executable_after_height: i64::from(u32::from(reference_height)),
@@ -2178,21 +2145,20 @@ pub unsafe extern "C" fn zcashlc_migration_extract_broadcast_tx(
 /// surfaces `RequiresAttention`.
 ///
 /// # Safety
-/// See [`open`]; `transfer_id` must be a valid C string; for tag 0, `txid_bytes` must be valid
-/// for reads of 32 bytes.
+/// See [`open`]; for tag 0, `txid_bytes` must be valid for reads of 32 bytes.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn zcashlc_migration_record_transfer_result(
     db_data: *const u8,
     db_data_len: usize,
     account_uuid_bytes: *const u8,
     network_id: u32,
-    transfer_id: *const c_char,
+    transfer_id: u32,
     result_tag: i32,
     txid_bytes: *const u8,
 ) -> bool {
     let res = catch_panic(|| {
         let mut ctx = unsafe { open(db_data, db_data_len, account_uuid_bytes, network_id)? };
-        let id = transfer_id_from_c(transfer_id)?;
+        let id = MigrationTxId::new(transfer_id);
         match result_tag {
             0 => {
                 if txid_bytes.is_null() {
@@ -2476,7 +2442,7 @@ pub unsafe extern "C" fn zcashlc_migration_store_signed_note_split_pczts(
     db_data_len: usize,
     account_uuid_bytes: *const u8,
     network_id: u32,
-    ids: *const *const c_char,
+    ids: *const u32,
     ids_len: usize,
     pczts: *const *const u8,
     pczt_lens: *const usize,
@@ -2573,7 +2539,7 @@ pub unsafe extern "C" fn zcashlc_migration_store_signed_schedule_pczts(
     db_data_len: usize,
     account_uuid_bytes: *const u8,
     network_id: u32,
-    ids: *const *const c_char,
+    ids: *const u32,
     ids_len: usize,
     pczts: *const *const u8,
     pczt_lens: *const usize,
@@ -2603,20 +2569,20 @@ pub unsafe extern "C" fn zcashlc_migration_store_signed_schedule_pczts(
 /// Decode the platform's parallel `(id, pczt)` arrays into owned pairs.
 ///
 /// # Safety
-/// `ids`/`pczts`/`pczt_lens` must be valid for reads of `len` elements; every `ids[i]` must be a
-/// valid C string and every `pczts[i]` valid for `pczt_lens[i]` bytes.
+/// `ids`/`pczts`/`pczt_lens` must be valid for reads of `len` elements, and every `pczts[i]` valid
+/// for `pczt_lens[i]` bytes.
 unsafe fn decode_signed_pairs(
-    ids: *const *const c_char,
+    ids: *const u32,
     len: usize,
     pczts: *const *const u8,
     pczt_lens: *const usize,
 ) -> anyhow::Result<Vec<(MigrationTxId, Vec<u8>)>> {
-    let id_ptrs = unsafe { slice_or_empty(ids, len) };
+    let ids = unsafe { slice_or_empty(ids, len) };
     let pczt_ptrs = unsafe { slice_or_empty(pczts, len) };
     let lens = unsafe { slice_or_empty(pczt_lens, len) };
     let mut out = Vec::with_capacity(len);
     for i in 0..len {
-        let id = transfer_id_from_c(id_ptrs[i])?;
+        let id = MigrationTxId::new(ids[i]);
         if pczt_ptrs[i].is_null() {
             return Err(anyhow!("signed pczt at index {i} is null"));
         }
@@ -2738,7 +2704,7 @@ pub unsafe extern "C" fn zcashlc_migration_keystone_decode_sign_batch_part(
 /// the returned pointer with [`zcashlc_free_migration_unsigned_transfer_pczts`].
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn zcashlc_migration_keystone_apply_batch_signatures(
-    ids: *const *const c_char,
+    ids: *const u32,
     ids_len: usize,
     pczts: *const *const u8,
     pczt_lens: *const usize,
@@ -3709,10 +3675,7 @@ mod tests {
         );
         assert_eq!(schedule.estimated_duration_hours, 0);
         let row = unsafe { &*schedule.transfers };
-        let row_id = unsafe { CStr::from_ptr(row.id) }
-            .to_str()
-            .expect("the row id is UTF-8");
-        assert_eq!(row_id, "0", "the stored transfer's engine id");
+        assert_eq!(row.id, 0, "the stored transfer's engine id");
         // The state-side amount is what the transfer CROSSES: the fixture's funding note is
         // 100_010_000 (crossing 100_000_000 plus the 10_000 fee buffer), and the row serves the
         // crossing. The consent echo compares the same value (`expected_rows_from_state` uses the


### PR DESCRIPTION
Two defects in the migration FFI, from the #1813 review. Targets that branch. Part of #1806.

## 1. Transfer amounts were the note spent, not the value crossed

The engine mints each self-funding note as `crossing + fee buffer`; the transfer spends the whole note, the buffer pays its own fee, and only the remainder crosses (no change output, so the buffer is consumed exactly). Every amount the FFI served came from `funding_notes()`, so schedule rows and the pending-transfer proposal each **overstated the transfer by one transfer fee** — and showed a value that is not the round `{1,2,5}×10ⁿ` denomination the user is asked to approve, nor the amount their Ironwood balance will grow by.

Both paths now subtract the note fee buffer. Rows still pair against `funding_notes()` (so the post-reconciliation pairing with schedule entries is untouched — see the Android SDK's comment about what mispairing did live); the buffer comes off each paired row. The consent echo compares the same values on both sides, so platform and native still agree.

The Android SDK already reports crossing values; this brings Swift into line. Once the pin moves to the next engine rc, both can drop the arithmetic for the engine's own accessors — added in zcash/librustzcash#2767, with a `TODO` here pointing at it.

## 2. Transaction ids were decimal strings

`MigrationTxId` is a `u32`. The FFI rendered it as an owned C string outbound and parsed it back inbound, buying nothing — every id is engine-issued, round-tripped verbatim, never displayed — and costing an allocation and free per schedule row, a parse-failure lane on every inbound call, and a Swift API where an opaque-looking `String` invites platform code to construct one.

Now `u32` on both directions (`FfiTransferProposal`, `FfiPreparedTransfer`, `FfiUnsignedTransferPczt`, `FfiAttentionReason::InvalidTransfer`, `zcashlc_migration_record_transfer_result`, the signed-PCZT store calls' `ids` arrays), with the per-id string frees gone from the destructors. `FfiPreparedTransfer`'s "nothing due" sentinel is a null `pczt` alone, which it always also was. Swift models and `migrationRecordTransferResult` take `UInt32`.

### A test that was passing for the wrong reason

Two `MigrationFFITests` cases asserted "recording a result with no active run throws" while passing the id `"does-not-exist"` — so what threw was the id decode, and the assertion never reached the contract it named. With real ids they fail, because `.networkError` deliberately records nothing (`1 => Ok(true)`). Both now use `.success`, which does have to load the run, and a new case documents the `.networkError` no-op.

## Testing

`cargo test --lib` 73/73 (new coverage that a schedule row carries the crossing value, not the funding note); `swift test --filter OfflineTests` 530/530 against a locally built FFI; `cargo fmt` clean, no new clippy warnings.

## Note for merge order

This touches `FfiPreparedTransfer` alongside #1853 (opportunistic proving), which adds a `status` field to the same struct. Whichever lands second needs a trivial conflict resolution — the two changes are independent, and the `status` field makes the "nothing due" sentinel explicit rather than implicit in the null `pczt`.

### Which identifier this is

The engine id names the **transfer**, not one broadcast attempt, and that is why it stays the key here rather than being replaced by the real `txid`: `rebuild_expired_transfer` keeps the transfer id while producing a new transaction with a new `txid`, so an app that keyed its records on the `txid` loses the thread exactly when a transfer expires and is rebuilt. `PreparedMigrationTransfer` carries both — use `txid` to talk to the network about a transaction, `id` to talk about the transfer. zcash/librustzcash#2767 renames the engine type `MigrationTxId` → `MigrationTransferId` to make that explicit; when the pin moves to that rc, the references here rename with it.

## Notes for #1812's rebase

#1812 rebases onto `michal/MOB-1455/MOB-1495-sdk-pool-migration-ffi` after this lands. Textual conflicts are expected in `MigrationModels.swift`, `ZcashRustBackend.swift`, `ZcashRustBackendWelding.swift` and `rust/src/migration.rs`. Three semantic points to respect:

1. **Ids are `UInt32`.** `MigrationTransferProposal`, `PreparedMigrationTransfer`, `MigrationUnsignedTransferPczt`, `MigrationSignedTransferPczt`, `MigrationAttentionReason.invalidTransfer`, and `migrationRecordTransferResult(transferId:)` all move off `String`. #1812's `welding.migrationRecordTransferResult(transferId: prepared.id, ...)` keeps compiling unchanged, since both sides move together.

2. **The id join gets simpler.** #1812's transaction-status model already declares `public let id: UInt32`, and its doc says status rows join to schedule rows via `String(status.id) == MigrationTransferProposal.id`. With ids now `UInt32` on both sides that becomes plain `status.id == proposal.id`; the `String(...)` conversion and the "opaque string id" wording should go.

3. **`MigrationTransferProposal.amount` is now net.** It is the value that crosses into Ironwood, not the funding note spent. #1812's `ImmediateMigrationProposal.amount` is already documented as "the net swept amount -- what arrives in the Ironwood pool once mined" and computed as `sweptPaymentValue(of:) - fee`. Before this PR those two surfaces disagreed (schedule gross, immediate net); after it they agree, so any comment or logic compensating for the difference can be dropped.

---

This PR was prepared with Claude Code assistance.


