### PR TITLE
[#1873] Adopt the v6 wallet-controlled-spend derivation fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,13 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   than hardcoding it. The resulting proofs are unchanged.
 
 ## Fixed
+- Hardware-wallet signing of post-NU6.3 (v6) transactions: the
+  wallet-controlled zero-value Orchard spends that pad such transactions now
+  carry ZIP 32 derivation metadata (via `zcash_client_backend 0.24.0-rc.4`),
+  so signers can identify and sign them. Previously these actions were
+  unsignable and v6 sends failed at finalization with a missing
+  spend-auth-signature error even though the device approved the
+  transaction.
 - Redacting a PCZT for an external signer now requests
   `zcash_client_backend`'s full (non-compacted) signer view, and the PCZT
   encoding sent to the signer is the minimal version capable of representing

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1549,8 +1549,7 @@ dependencies = [
 [[package]]
 name = "equihash"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "306286e8dcc39ab3dfceb74c792ce8baffdab90591321d3ffaae64829734c37f"
+source = "git+https://github.com/zcash/librustzcash.git?rev=536a10fd61af2d554bbe92764b0912a5d78e7d49#536a10fd61af2d554bbe92764b0912a5d78e7d49"
 dependencies = [
  "blake2b_simd",
  "corez",
@@ -1586,8 +1585,7 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d42773cb15447644d170be20231a3268600e0c4cea8987d013b93ac973d3cf7"
+source = "git+https://github.com/zcash/librustzcash.git?rev=536a10fd61af2d554bbe92764b0912a5d78e7d49#536a10fd61af2d554bbe92764b0912a5d78e7d49"
 dependencies = [
  "blake2b_simd",
 ]
@@ -3147,8 +3145,7 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 [[package]]
 name = "pczt"
 version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "508e40a1767b8054533db0fdfe9ddce29e708fa4f8bcfe68056995d46f5ee711"
+source = "git+https://github.com/zcash/librustzcash.git?rev=536a10fd61af2d554bbe92764b0912a5d78e7d49#536a10fd61af2d554bbe92764b0912a5d78e7d49"
 dependencies = [
  "blake2b_simd",
  "bls12_381",
@@ -6724,8 +6721,7 @@ dependencies = [
 [[package]]
 name = "zcash_address"
 version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a854b28c07dba372f4410ea8ad62b4bf7d5c2bf8be32fc4b31bc0db6521a975"
+source = "git+https://github.com/zcash/librustzcash.git?rev=536a10fd61af2d554bbe92764b0912a5d78e7d49#536a10fd61af2d554bbe92764b0912a5d78e7d49"
 dependencies = [
  "bech32",
  "bs58",
@@ -6737,9 +6733,8 @@ dependencies = [
 
 [[package]]
 name = "zcash_client_backend"
-version = "0.24.0-rc.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "103eca02554239be80ffaa6fef0b617d60a527f8e3b288cee0de533b9b00a571"
+version = "0.24.0-rc.4"
+source = "git+https://github.com/zcash/librustzcash.git?rev=536a10fd61af2d554bbe92764b0912a5d78e7d49#536a10fd61af2d554bbe92764b0912a5d78e7d49"
 dependencies = [
  "arti-client",
  "base64",
@@ -6865,8 +6860,7 @@ dependencies = [
 [[package]]
 name = "zcash_keys"
 version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc842e024fe37e52cfd3920826c4a28cc2a023fc9d77351d9c0f310becae3eb7"
+source = "git+https://github.com/zcash/librustzcash.git?rev=536a10fd61af2d554bbe92764b0912a5d78e7d49#536a10fd61af2d554bbe92764b0912a5d78e7d49"
 dependencies = [
  "bech32",
  "bip32",
@@ -6922,8 +6916,7 @@ dependencies = [
 [[package]]
 name = "zcash_primitives"
 version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34ca4de11896f704ffe6319c2cd7bc8fc6ab31a55cec80d26def15c009d83678"
+source = "git+https://github.com/zcash/librustzcash.git?rev=536a10fd61af2d554bbe92764b0912a5d78e7d49#536a10fd61af2d554bbe92764b0912a5d78e7d49"
 dependencies = [
  "blake2b_simd",
  "block-buffer 0.11.0-rc.3",
@@ -6975,8 +6968,7 @@ dependencies = [
 [[package]]
 name = "zcash_protocol"
 version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4034db33a1ce58416430e065b01474b958e4649caa3e06e20654683a95149710"
+source = "git+https://github.com/zcash/librustzcash.git?rev=536a10fd61af2d554bbe92764b0912a5d78e7d49#536a10fd61af2d554bbe92764b0912a5d78e7d49"
 dependencies = [
  "corez",
  "document-features",
@@ -7014,8 +7006,7 @@ dependencies = [
 [[package]]
 name = "zcash_transparent"
 version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "547c012778bae17f58007731af074d638aa146ab0ecfc120adebf23d049aff6c"
+source = "git+https://github.com/zcash/librustzcash.git?rev=536a10fd61af2d554bbe92764b0912a5d78e7d49#536a10fd61af2d554bbe92764b0912a5d78e7d49"
 dependencies = [
  "bip32",
  "bs58",
@@ -7108,8 +7099,7 @@ dependencies = [
 [[package]]
 name = "zip321"
 version = "0.9.0-rc.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb464491970d9b61889e4f2b7b00fb9f471a33692e5c0de3122fdc575d8067ab"
+source = "git+https://github.com/zcash/librustzcash.git?rev=536a10fd61af2d554bbe92764b0912a5d78e7d49#536a10fd61af2d554bbe92764b0912a5d78e7d49"
 dependencies = [
  "base64",
  "nom",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ ff = "0.13"
 sapling = { package = "sapling-crypto", version = "0.7", default-features = false }
 transparent = { package = "zcash_transparent", version = "0.10", default-features = false }
 zcash_address = { version = "0.13" }
-zcash_client_backend = { version = "0.24.0-rc.3", features = [
+zcash_client_backend = { version = "0.24.0-rc.4", features = [
     "lightwalletd-tonic-tls-webpki-roots",
     "orchard",
     "pczt",
@@ -93,6 +93,18 @@ cc = "1.0"
 
 [patch.crates-io]
 # zcash_voting = { git = "https://github.com/valargroup/zcash_voting.git", rev = "7d39d02b297f0ce23751f2638bf403285e34e675" }
+# TODO: [#1873] Remove these patches once zcash_client_backend 0.24.0-rc.4 is
+# published (zcash/librustzcash#2779); they pin the release-prep revision so
+# device verification exercises exactly the bits to be published, with the
+# sibling crates pinned to the same revision to keep the dependency graph on a
+# single source.
+pczt = { git = "https://github.com/zcash/librustzcash.git", rev = "536a10fd61af2d554bbe92764b0912a5d78e7d49" }
+zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "536a10fd61af2d554bbe92764b0912a5d78e7d49" }
+zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "536a10fd61af2d554bbe92764b0912a5d78e7d49" }
+zcash_keys = { git = "https://github.com/zcash/librustzcash.git", rev = "536a10fd61af2d554bbe92764b0912a5d78e7d49" }
+zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "536a10fd61af2d554bbe92764b0912a5d78e7d49" }
+zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "536a10fd61af2d554bbe92764b0912a5d78e7d49" }
+zcash_transparent = { git = "https://github.com/zcash/librustzcash.git", rev = "536a10fd61af2d554bbe92764b0912a5d78e7d49" }
 
 [features]
 default = []


### PR DESCRIPTION
Closes #1873.
Resolves MOB-1553

Fixes the residual post-#1870 failure: post-NU6.3 (v6) Keystone sends failed at finalization with `Pczt(Extraction(Orchard(Extract(MissingSpendAuthSig))))` because the wallet-controlled zero-value Orchard spends that pad v6 transactions carried no ZIP 32 derivation metadata — derivation-matching signers correctly skipped them as "not ours", and nothing else could sign them (their `dummy_sk` is absent by design under the post-NU6.3 cross-address rule). Root cause and fix are upstream: zcash/librustzcash#2777, fixed in zcash/librustzcash#2778.

**This PR is the device-verification vehicle:** it bumps `zcash_client_backend` to `0.24.0-rc.4` and pins the release-prep revision (zcash/librustzcash#2779) via `[patch.crates-io]` git pins, so the tester exercises exactly the bits that will be published. On tester confirmation, the crate is published and a follow-up commit drops the pins (`TODO: [#1873]` marks them).

**Testing:** `cargo check` passes against the pinned revision; upstream adds a general signability invariant to the PCZT pool tests (every shielded spend must be pre-signed, dummy-key-carrying, or ZIP 32-derivable) that reproduces this bug class and guards the fix. Device acceptance test: the previously-failing all-Orchard testnet send with Keystone signing, run against this branch (local FFI build required — `./Scripts/init-local-ffi.sh`).

Filed with Claude Code assistance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
