### PR TITLE
[MOB-1568] Submit sequentially instead of fanning out when Tor is off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
+## Changed
+- Multi-endpoint transaction submission no longer fans the same transaction
+  out to every endpoint in parallel when Tor is disabled. With Tor off, each
+  submission is a clearnet connection from the device's real IP, so the
+  parallel race handed every contacted server operator the IP↔txid link at
+  once. Endpoints are now tried one at a time in list order, stopping at the
+  first acceptance, so at most one operator (plus any that already failed to
+  accept) observes the transaction paired with the caller's IP; rejections and
+  transport failures still fail over to the next endpoint, and the overall
+  response timeout is unchanged. The Tor-enabled path keeps the parallel race,
+  where every attempt already rides its own isolated circuit.
+
 # v2.8.0-rc.1 - 2026-07-26
 
 ## Added

--- a/Sources/ZcashLightClientKit/Synchronizer/Dependencies.swift
+++ b/Sources/ZcashLightClientKit/Synchronizer/Dependencies.swift
@@ -107,6 +107,7 @@ enum Dependencies {
         container.register(type: MultiEndpointSubmitter.self, isSingleton: true) { di in
             MultiEndpointSubmitter(
                 endpointSubmitter: di.resolve(EndpointSubmitter.self),
+                sdkFlags: di.resolve(SDKFlags.self),
                 logger: di.resolve(Logger.self)
             )
         }

--- a/Sources/ZcashLightClientKit/Transaction/MultiEndpointSubmitter.swift
+++ b/Sources/ZcashLightClientKit/Transaction/MultiEndpointSubmitter.swift
@@ -5,17 +5,27 @@
 
 import Foundation
 
-/// Races one transaction against multiple endpoints in parallel.
+/// Submits one transaction to multiple endpoints.
+///
+/// With Tor enabled the endpoints are raced in parallel — every attempt rides
+/// its own isolated circuit, so the parallel fan-out reveals nothing about the
+/// sender. With Tor disabled every attempt is a clearnet connection from the
+/// device's real IP, so the endpoints are instead tried strictly one at a time,
+/// stopping at the first acceptance: fanning the same transaction out to every
+/// operator at once would hand each of them the IP↔txid link.
 ///
 /// Resumes the caller as soon as the outcome is decided (first acceptance, all
-/// endpoints failed, timeout, or caller cancellation); in-flight submissions
-/// continue through the grace window in the background before being cancelled.
+/// endpoints failed, timeout, or caller cancellation); in the parallel race,
+/// in-flight submissions continue through the grace window in the background
+/// before being cancelled.
 final class MultiEndpointSubmitter {
     private let endpointSubmitter: EndpointSubmitter
+    private let sdkFlags: SDKFlags
     private let logger: Logger
 
-    init(endpointSubmitter: EndpointSubmitter, logger: Logger) {
+    init(endpointSubmitter: EndpointSubmitter, sdkFlags: SDKFlags, logger: Logger) {
         self.endpointSubmitter = endpointSubmitter
+        self.sdkFlags = sdkFlags
         self.logger = logger
     }
 
@@ -29,10 +39,14 @@ final class MultiEndpointSubmitter {
             return .unreachable
         }
 
+        let torEnabled = await sdkFlags.torEnabled
+        let dispatch: SubmissionRace.Dispatch = torEnabled ? .parallelRace : .sequentialFailover
+
         let race = SubmissionRace(
             transaction: transaction,
             endpoints: endpoints,
             timing: timing,
+            dispatch: dispatch,
             endpointSubmitter: endpointSubmitter,
             logger: logger
         )
@@ -62,9 +76,23 @@ final class MultiEndpointSubmitter {
 /// Holds the race state and the two promises: the caller-facing outcome and the
 /// internal "race finished" signal that releases the task group.
 actor SubmissionRace {
+    /// How the endpoints are contacted.
+    enum Dispatch {
+        /// All endpoints at once; first acceptance wins and stragglers get the
+        /// post-acceptance grace window. Safe only when each attempt is
+        /// network-isolated (Tor circuit per attempt).
+        case parallelRace
+        /// One endpoint at a time in list order, stopping at the first
+        /// acceptance. Used with Tor off, where simultaneous clearnet
+        /// submissions of the same transaction would link the caller's IP to
+        /// the txid at every contacted operator.
+        case sequentialFailover
+    }
+
     private let transaction: CreatedTransaction
     private let endpoints: [LightWalletEndpoint]
     private let timing: SubmissionTiming
+    private let dispatch: Dispatch
     private let endpointSubmitter: EndpointSubmitter
     private let logger: Logger
 
@@ -81,12 +109,14 @@ actor SubmissionRace {
         transaction: CreatedTransaction,
         endpoints: [LightWalletEndpoint],
         timing: SubmissionTiming,
+        dispatch: Dispatch,
         endpointSubmitter: EndpointSubmitter,
         logger: Logger
     ) {
         self.transaction = transaction
         self.endpoints = endpoints
         self.timing = timing
+        self.dispatch = dispatch
         self.endpointSubmitter = endpointSubmitter
         self.logger = logger
     }
@@ -100,9 +130,17 @@ actor SubmissionRace {
             """
         )
         await withTaskGroup(of: Void.self) { group in
-            for endpoint in endpoints {
+            switch dispatch {
+            case .parallelRace:
+                for endpoint in endpoints {
+                    group.addTask {
+                        await self.submit(to: endpoint)
+                    }
+                }
+
+            case .sequentialFailover:
                 group.addTask {
-                    await self.submit(to: endpoint)
+                    await self.submitSequentially()
                 }
             }
             group.addTask {
@@ -142,6 +180,19 @@ actor SubmissionRace {
 
     // MARK: - Child tasks
 
+    /// Tor-off path: endpoints are contacted strictly one at a time, in list
+    /// order, stopping at the first acceptance so no further operator observes
+    /// the transaction paired with the caller's IP. Rejections and transport
+    /// failures advance to the next endpoint; the response timeout and caller
+    /// cancellation end the chain through the regular race events.
+    private func submitSequentially() async {
+        for endpoint in endpoints {
+            guard resolvedOutcome == nil, !Task.isCancelled else { return }
+            await submit(to: endpoint)
+            if winner != nil { return }
+        }
+    }
+
     private func submit(to endpoint: LightWalletEndpoint) async {
         do {
             try await endpointSubmitter.submit(transaction: transaction, to: endpoint)
@@ -176,7 +227,14 @@ actor SubmissionRace {
             winner = endpoint
             logger.info("Transaction \(transaction.txId.toHexStringTxId()) accepted by \(endpoint.host):\(endpoint.port).")
             resolve(.accepted(by: endpoint))
-            startGraceCountdown()
+            switch dispatch {
+            case .parallelRace:
+                startGraceCountdown()
+            case .sequentialFailover:
+                // Nothing runs behind a sequential acceptance — there is no
+                // straggler to grant a grace window to.
+                finishRace()
+            }
         } else {
             logger.info("Transaction \(transaction.txId.toHexStringTxId()) also accepted by \(endpoint.host):\(endpoint.port) in the grace window.")
         }

--- a/Tests/OfflineTests/MultiEndpointSubmitterTests.swift
+++ b/Tests/OfflineTests/MultiEndpointSubmitterTests.swift
@@ -14,7 +14,11 @@ final class MultiEndpointSubmitterTests: ZcashTestCase {
     override func setUp() async throws {
         try await super.setUp()
         mock = EndpointSubmitterMock()
-        submitter = MultiEndpointSubmitter(endpointSubmitter: mock, logger: submissionLifecycleLogger())
+        submitter = MultiEndpointSubmitter(
+            endpointSubmitter: mock,
+            sdkFlags: SDKFlags(torEnabled: true, exchangeRateEnabled: false),
+            logger: submissionLifecycleLogger()
+        )
     }
 
     private let fastTiming = SubmissionTiming(responseTimeout: 1.0, postAcceptanceGraceDelay: 0.3)
@@ -239,5 +243,91 @@ final class MultiEndpointSubmitterTests: ZcashTestCase {
         let outcome = await submitter.submit(transaction: makeTransaction(), to: [endpoint(1)], timing: fastTiming)
 
         XCTAssertEqual(outcome, TransactionSubmissionOutcome.rejected(code: -25, message: "bad tx"))
+    }
+
+    // MARK: - Tor-off sequential failover
+
+    private func makeTorOffSubmitter() -> MultiEndpointSubmitter {
+        MultiEndpointSubmitter(
+            endpointSubmitter: mock,
+            sdkFlags: SDKFlags(torEnabled: false, exchangeRateEnabled: false),
+            logger: submissionLifecycleLogger()
+        )
+    }
+
+    func testTorOffStopsAtFirstAcceptance() async {
+        let torOffSubmitter = makeTorOffSubmitter()
+        let endpoints = [endpoint(1), endpoint(2), endpoint(3)]
+        mock.set(behavior: .succeed, for: endpoint(1))
+        mock.set(behavior: .succeed, for: endpoint(2))
+        mock.set(behavior: .succeed, for: endpoint(3))
+
+        let outcome = await torOffSubmitter.submit(transaction: makeTransaction(), to: endpoints, timing: fastTiming)
+
+        XCTAssertEqual(outcome, TransactionSubmissionOutcome.accepted(by: endpoint(1)))
+        // The privacy property: once one endpoint accepted, the remaining
+        // endpoints are never contacted over clearnet.
+        XCTAssertEqual(mock.recordedSubmissions().map(\.host), [endpoint(1).host])
+    }
+
+    func testTorOffNeverOverlapsSubmissionsAndKeepsFailoverOrder() async {
+        let torOffSubmitter = makeTorOffSubmitter()
+        let endpoints = [endpoint(1), endpoint(2), endpoint(3)]
+        mock.set(behavior: .rejectAfter(0.15, code: -25, message: "first"), for: endpoint(1))
+        mock.set(behavior: .rejectAfter(0.15, code: -26, message: "second"), for: endpoint(2))
+        mock.set(behavior: .succeed, for: endpoint(3))
+
+        let outcome = await torOffSubmitter.submit(transaction: makeTransaction(), to: endpoints, timing: fastTiming)
+
+        XCTAssertEqual(outcome, TransactionSubmissionOutcome.accepted(by: endpoint(3)))
+        XCTAssertEqual(mock.recordedSubmissions().map(\.host), endpoints.map(\.host))
+        XCTAssertEqual(mock.maxConcurrentSubmissions(), 1, "Tor-off submissions must never overlap")
+    }
+
+    func testTorOffAllRejectedReturnsFirstEndpointsRejection() async {
+        let torOffSubmitter = makeTorOffSubmitter()
+        let endpoints = [endpoint(1), endpoint(2)]
+        mock.set(behavior: .reject(code: -25, message: "first"), for: endpoint(1))
+        mock.set(behavior: .reject(code: -26, message: "second"), for: endpoint(2))
+
+        let outcome = await torOffSubmitter.submit(transaction: makeTransaction(), to: endpoints, timing: fastTiming)
+
+        // Sequential order makes "first rejection" deterministic.
+        XCTAssertEqual(outcome, TransactionSubmissionOutcome.rejected(code: -25, message: "first"))
+    }
+
+    func testTorOffTimeoutStillBoundsTheWholeAttempt() async {
+        let torOffSubmitter = makeTorOffSubmitter()
+        let endpoints = [endpoint(1), endpoint(2)]
+        mock.set(behavior: .hang, for: endpoint(1))
+        mock.set(behavior: .succeed, for: endpoint(2))
+        let timing = SubmissionTiming(responseTimeout: 0.2, postAcceptanceGraceDelay: 0.1)
+
+        let outcome = await torOffSubmitter.submit(transaction: makeTransaction(), to: endpoints, timing: timing)
+
+        XCTAssertEqual(outcome, TransactionSubmissionOutcome.timedOut)
+        // The hanging endpoint consumed the whole attempt; the next endpoint was
+        // never contacted before the deadline.
+        XCTAssertEqual(mock.recordedSubmissions().map(\.host), [endpoint(1).host])
+    }
+
+    func testTorOffCallerCancellationStopsTheChain() async {
+        let torOffSubmitter = makeTorOffSubmitter()
+        let endpoints = [endpoint(1), endpoint(2)]
+        mock.set(behavior: .hang, for: endpoint(1))
+        mock.set(behavior: .succeed, for: endpoint(2))
+        let transaction = makeTransaction()
+        let timing = SubmissionTiming(responseTimeout: 5.0, postAcceptanceGraceDelay: 0.1)
+
+        let task = Task { () -> TransactionSubmissionOutcome in
+            await torOffSubmitter.submit(transaction: transaction, to: endpoints, timing: timing)
+        }
+        try? await Task.sleep(nanoseconds: 100_000_000)
+        task.cancel()
+        let outcome = await task.value
+
+        XCTAssertEqual(outcome, TransactionSubmissionOutcome.cancelled)
+        try? await Task.sleep(nanoseconds: 200_000_000)
+        XCTAssertEqual(mock.recordedSubmissions().map(\.host), [endpoint(1).host])
     }
 }

--- a/Tests/TestUtils/SubmissionTestDoubles.swift
+++ b/Tests/TestUtils/SubmissionTestDoubles.swift
@@ -162,6 +162,8 @@ final class EndpointSubmitterMock: EndpointSubmitter {
     private var behaviors: [String: Behavior] = [:]
     private var submitted: [LightWalletEndpoint] = []
     private var cancelled: [LightWalletEndpoint] = []
+    private var inFlightCount = 0
+    private var maxInFlightCount = 0
 
     func set(behavior: Behavior, for endpoint: LightWalletEndpoint) {
         queue.sync { behaviors[Self.key(endpoint)] = behavior }
@@ -175,8 +177,20 @@ final class EndpointSubmitterMock: EndpointSubmitter {
         queue.sync { cancelled }
     }
 
+    /// The highest number of submissions that were ever in flight at once.
+    func maxConcurrentSubmissions() -> Int {
+        queue.sync { maxInFlightCount }
+    }
+
     func submit(transaction: CreatedTransaction, to endpoint: LightWalletEndpoint) async throws {
-        queue.sync { submitted.append(endpoint) }
+        queue.sync {
+            submitted.append(endpoint)
+            inFlightCount += 1
+            maxInFlightCount = max(maxInFlightCount, inFlightCount)
+        }
+        defer {
+            queue.sync { inFlightCount -= 1 }
+        }
         let behavior = queue.sync { behaviors[Self.key(endpoint)] } ?? Behavior.succeed
 
         switch behavior {


### PR DESCRIPTION
## Problem

`MultiEndpointSubmitter` raced the same raw transaction to every endpoint in a task group regardless of the Tor state. With Tor enabled that is safe — each attempt rides its own isolated circuit — but with Tor disabled every attempt is a clearnet gRPC connection from the device's real IP, so a single send handed the IP↔txid link to every configured server operator simultaneously, including the wallet's own sync server.

## Fix

Give `SubmissionRace` a dispatch mode chosen from `SDKFlags.torEnabled` at submission time:

- **Tor on** keeps the parallel race, first-acceptance resolution, and the post-acceptance grace window unchanged.
- **Tor off** now tries endpoints strictly one at a time in list order and stops at the first acceptance, so operators beyond the accepting one are never contacted. Rejections and transport failures still fail over to the next endpoint, the shared response timeout bounds the whole attempt, caller cancellation ends the chain, and there is no grace window because nothing runs behind a sequential acceptance.

The background resubmission path (`SubmitPlanExecutor`) already retried sequentially with stop-on-first-accept and is unchanged.

## Tests

Five new tests for the Tor-off mode (stop-at-first-acceptance with no further endpoints contacted, no overlapping submissions via a new max-concurrency probe on the mock, deterministic first-rejection outcome, timeout bounding, caller cancellation stopping the chain). All 12 pre-existing parallel-race tests pass unmodified, pinning the Tor-on behavior. Full OfflineTests suite: 401 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)