### PR TITLE
[#MOB-1598] Fix stale sync-failure state reporting (frozen latestState, nil expired_unmined misclassification)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   a rewind); the state is now derived from the mined-height evidence instead.
   Previously this misclassification made pending (or even mined) transactions
   flash or stick as failed/expired in clients.
+- `SDKSynchronizer` no longer coalesces consecutive `.error` status updates.
+  Because any two `.error` values compare equal, a repeated sync failure
+  previously left `latestState` (including `latestBlockHeight`) and the state
+  stream frozen at the snapshot taken for the first failure while the compact
+  block processor kept retrying — clients rendered a stale chain tip and a
+  stale error indefinitely. Every failure now re-snapshots and republishes the
+  synchronizer state.
 
 # 2.7.0-rc.2 - 2026-07-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
+## Fixed
+- `ZcashTransaction.Overview.State` no longer misreports a transaction as
+  `.expired` when the `expired_unmined` flag is unavailable (`nil`). The flag is
+  `nil` exactly when the transaction is unmined and its expiry cannot be
+  evaluated yet (unknown expiry height, or no scanned blocks — e.g. right after
+  a rewind); the state is now derived from the mined-height evidence instead.
+  Previously this misclassification made pending (or even mined) transactions
+  flash or stick as failed/expired in clients.
+
 # 2.7.0-rc.2 - 2026-07-26
 
 ## Changed

--- a/Sources/ZcashLightClientKit/Entity/TransactionEntity.swift
+++ b/Sources/ZcashLightClientKit/Entity/TransactionEntity.swift
@@ -26,19 +26,20 @@ public enum ZcashTransaction {
                 minedHeight: BlockHeight?,
                 expiredUnmined: Bool?
             ) {
-                guard let expiredUnmined, !expiredUnmined else {
+                // `expired_unmined` is NULL whenever the transaction is unmined and its expiry
+                // cannot be evaluated (unknown expiry height, or no scanned blocks yet — e.g.
+                // right after a rewind). NULL means "unknown", never "expired": only a positive
+                // confirmation short-circuits here, everything else is derived from the
+                // mined-height evidence below.
+                if expiredUnmined == true {
                     self = .expired
                     return
                 }
 
                 if let minedHeight, (currentHeight - minedHeight) >= ZcashSDK.defaultStaleTolerance {
                     self = .confirmed
-                } else if let minedHeight, (currentHeight - minedHeight) < ZcashSDK.defaultStaleTolerance {
-                    self = .pending
-                } else if minedHeight == nil {
-                    self = .pending
                 } else {
-                    self = .expired
+                    self = .pending
                 }
             }
         }

--- a/Sources/ZcashLightClientKit/Synchronizer/SDKSynchronizer.swift
+++ b/Sources/ZcashLightClientKit/Synchronizer/SDKSynchronizer.swift
@@ -1255,8 +1255,21 @@ public class SDKSynchronizer: Synchronizer {
         )
     }
 
+    /// Whether a status transition must be published. `InternalSyncStatus.==` deliberately treats
+    /// any two `.error` values as equal; coalescing repeated failures on that equality would
+    /// freeze `latestState` (chain tip, balances) and the state stream at the snapshot taken for
+    /// the FIRST failure while the compact block processor keeps retrying — so failures are
+    /// always (re)published.
+    static func shouldNotify(oldStatus: InternalSyncStatus, newStatus: InternalSyncStatus) -> Bool {
+        if case .error = newStatus {
+            return true
+        }
+
+        return oldStatus != newStatus
+    }
+
     private func notify(oldStatus: InternalSyncStatus, newStatus: InternalSyncStatus, updateExternalStatus: Bool = true) async {
-        guard oldStatus != newStatus else { return }
+        guard Self.shouldNotify(oldStatus: oldStatus, newStatus: newStatus) else { return }
 
         let newState: SynchronizerState
 

--- a/Tests/OfflineTests/SDKSynchronizerNotifyTests.swift
+++ b/Tests/OfflineTests/SDKSynchronizerNotifyTests.swift
@@ -1,0 +1,75 @@
+//
+//  SDKSynchronizerNotifyTests.swift
+//
+//
+//  Created by Michal Fousek on 28.07.2026.
+//
+
+import XCTest
+@testable import ZcashLightClientKit
+
+/// `InternalSyncStatus.==` deliberately treats any two `.error` values as equal. If the
+/// synchronizer coalesced status notifications on that equality, `latestState` (chain tip,
+/// balances) and the state stream would freeze at the snapshot taken for the FIRST failure
+/// while the compact block processor keeps retrying — the app would keep rendering a stale
+/// chain tip and a stale error indefinitely. Failures must therefore always be (re)published.
+final class SDKSynchronizerNotifyTests: XCTestCase {
+    func testRepeatedIdenticalErrorIsPublished() {
+        XCTAssertTrue(
+            SDKSynchronizer.shouldNotify(
+                oldStatus: .error(ZcashError.synchronizerNotPrepared),
+                newStatus: .error(ZcashError.synchronizerNotPrepared)
+            )
+        )
+    }
+
+    func testRepeatedDifferentErrorIsPublished() {
+        XCTAssertTrue(
+            SDKSynchronizer.shouldNotify(
+                oldStatus: .error(ZcashError.synchronizerNotPrepared),
+                newStatus: .error(ZcashError.synchronizerDisconnected)
+            )
+        )
+    }
+
+    func testFirstErrorIsPublished() {
+        XCTAssertTrue(
+            SDKSynchronizer.shouldNotify(
+                oldStatus: .synced,
+                newStatus: .error(ZcashError.synchronizerNotPrepared)
+            )
+        )
+    }
+
+    func testUnchangedNonErrorStatusIsCoalesced() {
+        XCTAssertFalse(
+            SDKSynchronizer.shouldNotify(
+                oldStatus: .synced,
+                newStatus: .synced
+            )
+        )
+
+        XCTAssertFalse(
+            SDKSynchronizer.shouldNotify(
+                oldStatus: .syncing(0.5, false),
+                newStatus: .syncing(0.5, false)
+            )
+        )
+    }
+
+    func testChangedStatusIsPublished() {
+        XCTAssertTrue(
+            SDKSynchronizer.shouldNotify(
+                oldStatus: .syncing(0.5, false),
+                newStatus: .syncing(0.75, false)
+            )
+        )
+
+        XCTAssertTrue(
+            SDKSynchronizer.shouldNotify(
+                oldStatus: .error(ZcashError.synchronizerNotPrepared),
+                newStatus: .syncing(0.1, false)
+            )
+        )
+    }
+}

--- a/Tests/OfflineTests/ZcashTransactionStateTests.swift
+++ b/Tests/OfflineTests/ZcashTransactionStateTests.swift
@@ -54,6 +54,44 @@ final class ZcashTransactionStateTests: XCTestCase {
         )
     }
 
+    /// `expired_unmined` is NULL in `v_transactions` whenever the transaction is unmined and its
+    /// expiry cannot be evaluated (unknown expiry height, or no scanned blocks yet — e.g. right
+    /// after a rewind). NULL means "unknown", never "expired": the state must be derived from the
+    /// mined-height evidence instead of short-circuiting to `.expired`.
+    func testNilExpiredUnminedDerivesStateFromMinedHeight() {
+        let currentHeight = 1_500_000
+
+        // Mined with enough confirmations -> confirmed.
+        XCTAssertEqual(
+            ZcashTransaction.Overview.State(
+                currentHeight: currentHeight,
+                minedHeight: currentHeight - ZcashSDK.defaultStaleTolerance,
+                expiredUnmined: nil
+            ),
+            .confirmed
+        )
+
+        // Freshly mined -> pending.
+        XCTAssertEqual(
+            ZcashTransaction.Overview.State(
+                currentHeight: currentHeight,
+                minedHeight: currentHeight,
+                expiredUnmined: nil
+            ),
+            .pending
+        )
+
+        // Unmined -> pending.
+        XCTAssertEqual(
+            ZcashTransaction.Overview.State(
+                currentHeight: currentHeight,
+                minedHeight: nil,
+                expiredUnmined: nil
+            ),
+            .pending
+        )
+    }
+
     func testMinedHeightAboveOrEqualToStaleConstantIsConfirmed() {
         let currentHeight = 1010
 


### PR DESCRIPTION
## What

Two state-reporting fixes behind the "a sent transaction stays *Sending* although it is mined with 20+ confirmations" report (MOB-1598), investigated on 2026-07-28 after NU6.3 activation:

1. **`ZcashTransaction.Overview.State`**: `expired_unmined` is `NULL` in `v_transactions` exactly when the transaction is unmined and its expiry cannot be evaluated (unknown expiry height, or no scanned blocks yet — e.g. right after a rewind). The initializer treated `nil` as a positive expiry confirmation and short-circuited to `.expired`, which makes pending (or even mined) transactions flash or stick as failed/expired in clients. Now only `expiredUnmined == true` short-circuits; `nil` falls through to the mined-height evidence.

2. **`SDKSynchronizer`**: `InternalSyncStatus.==` deliberately treats any two `.error` values as equal, so `notify()`'s equality guard coalesced every repeated failure — `latestState` (including `latestBlockHeight`) and the state stream froze at the snapshot taken for the *first* failure while the compact block processor kept retrying every 10–30 s (retries are unbounded). Clients rendered a stale chain tip and a stale error indefinitely; a stale chain tip also disables client-side expiry fallbacks, which is how a mined transaction can display as *Sending* forever when scanning is persistently failing. Failures are now always republished (decision extracted into `SDKSynchronizer.shouldNotify` and unit-tested); `SessionTicker.isNewSyncSession` guards on `isDifferent` first, so repeated failures do not spawn new sync sessions.

## Branch base

Per CONTRIBUTING ("merge forward, cherry-pick back"), the branch is cut from `maint/v2.7.x` — the oldest currently-supported maintenance line — and the PR targets it. Both defects exist there in the same shape.

**Note for the forward merge to `maint/v2.8.x`/`main`**: the 2.8 line's `State.init` additionally carries the `expiryHeight` parameter and the expiry-vs-tip fallback for unmined transactions. The resolved shape there is: `if expiredUnmined == true { self = .expired; return }`, then `confirmed`/`pending` by mined depth, and for unmined transactions keep the existing fallback (`expiryHeight > 0 && currentHeight >= expiryHeight → .expired`, else `.pending`). The `SDKSynchronizer`/`Synchronizer` changes merge forward cleanly (files are identical across the lines).

## Testing

- TDD on this base: the new `testNilExpiredUnminedDerivesStateFromMinedHeight` cases fail on the previous implementation and pass now; `SDKSynchronizerNotifyTests` covers the coalescing decision.
- Full `swift test --filter OfflineTests` on `maint/v2.7.x` base: green (counts in the PR checks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
