### PR TITLE
Build every Apple architecture in one cargo invocation

### DIFF
--- a/BuildSupport/Makefile
+++ b/BuildSupport/Makefile
@@ -10,6 +10,18 @@ IOS_DEVICE_ARCHS = aarch64-apple-ios
 IOS_SIM_ARCHS_STABLE = x86_64-apple-ios  aarch64-apple-ios-sim
 MACOS_ARCHS = x86_64-apple-darwin aarch64-apple-darwin
 IOS_SIM_ARCHS = $(IOS_SIM_ARCHS_STABLE)
+ALL_ARCHS = $(IOS_DEVICE_ARCHS) $(IOS_SIM_ARCHS) $(MACOS_ARCHS)
+
+# Cargo serialises concurrent invocations behind a lock on the shared host
+# artifact directory (../target/release), so running one `cargo build --target X`
+# per architecture cannot overlap them — `make -j` does not help. That matters
+# most for the link step: `lto = true` is a single-threaded whole-program pass
+# costing roughly two minutes per architecture, so five of them run back to back.
+#
+# Passing several `--target` flags to one invocation puts every architecture in a
+# single job graph, letting those passes run concurrently.
+CARGO_BUILD = RUSTUP_TOOLCHAIN=stable cargo build --manifest-path ../Cargo.toml --release
+cargo_targets = $(addprefix --target ,$(1))
 
 RUST_SRCS = $(shell find ../rust -name "*.rs") ../Cargo.toml
 STATIC_LIBS = $(shell find ../target -name "libzcashlc.a")
@@ -23,15 +35,26 @@ install:
 release: clean xcframework
 .PHONY: release
 
+# Discard assembled build products. ../target is deliberately preserved so that
+# cargo's fingerprints (and CI's restored Rust cache) still apply; cargo decides
+# what genuinely needs rebuilding. Every framework under products/ is rebuilt
+# from scratch, so no stale slice can survive this.
 clean:
 	rm -rf products
-	rm -rf ../target
 .PHONY: clean
+
+# Additionally discard the cargo target directory, forcing a from-scratch build.
+distclean: clean
+	rm -rf ../target
+.PHONY: distclean
 
 xcframework: products/libzcashlc.xcframework
 .PHONY: xcframework
 
-products/libzcashlc.xcframework: $(PLATFORMS)
+# cargo-all is listed first so a full build compiles every architecture in one
+# invocation. The per-platform cargo rules below then find their work already
+# done and reduce to a fingerprint check.
+products/libzcashlc.xcframework: cargo-all $(PLATFORMS)
 	rm -rf $@
 	mkdir -p $@
 	cp -R products/ios-device/frameworks $@/ios-arm64
@@ -68,20 +91,35 @@ products/ios-device/universal/libzcashlc.a: $(IOS_DEVICE_ARCHS)
 	mkdir -p $(@D)
 	lipo -create $(shell find products/ios-device/static-libraries -name "libzcashlc.a") -output $@
 
-$(MACOS_ARCHS): %: stable-%
+$(MACOS_ARCHS): %: cargo-macos
 	mkdir -p products/macos/static-libraries/$*
 	cp ../target/$*/release/libzcashlc.a products/macos/static-libraries/$*
 .PHONY: $(MACOS_ARCHS)
 
-$(IOS_DEVICE_ARCHS): %: stable-%
+$(IOS_DEVICE_ARCHS): %: cargo-ios-device
 	mkdir -p products/ios-device/static-libraries/$*
 	cp ../target/$*/release/libzcashlc.a products/ios-device/static-libraries/$*
 .PHONY: $(IOS_DEVICE_ARCHS)
 
-$(IOS_SIM_ARCHS_STABLE): %: stable-%
+$(IOS_SIM_ARCHS_STABLE): %: cargo-ios-simulator
 	mkdir -p products/ios-simulator/static-libraries/$*
 	cp ../target/$*/release/libzcashlc.a products/ios-simulator/static-libraries/$*
 .PHONY: $(IOS_SIM_ARCHS_STABLE)
 
-stable-%: # target/%/release/libzcashlc.a:
-	sh -c "RUSTUP_TOOLCHAIN=stable cargo build --manifest-path ../Cargo.toml --target $* --release"
+# Each platform builds only its own architectures, so `make macos` still needs
+# just the macOS rustup targets installed.
+cargo-all:
+	$(CARGO_BUILD) $(call cargo_targets,$(ALL_ARCHS))
+.PHONY: cargo-all
+
+cargo-macos:
+	$(CARGO_BUILD) $(call cargo_targets,$(MACOS_ARCHS))
+.PHONY: cargo-macos
+
+cargo-ios-device:
+	$(CARGO_BUILD) $(call cargo_targets,$(IOS_DEVICE_ARCHS))
+.PHONY: cargo-ios-device
+
+cargo-ios-simulator:
+	$(CARGO_BUILD) $(call cargo_targets,$(IOS_SIM_ARCHS))
+.PHONY: cargo-ios-simulator

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
+## Changed
+- The FFI xcframework build now compiles every Apple architecture in a single
+  multi-target `cargo build` invocation rather than one invocation per
+  architecture. Concurrent cargo invocations serialize on a lock over the
+  shared host artifact directory, so the single-threaded fat-LTO pass for each
+  architecture previously ran one after another; they now overlap. The
+  per-platform goals (`make macos`, `make ios-device`, `make ios-simulator`)
+  still build only their own architectures.
+- `make clean` in `BuildSupport/` no longer removes the cargo `target`
+  directory; the new `make distclean` goal does. This lets a restored Rust
+  dependency cache survive a release build, which previously deleted it before
+  compiling.
+
 # 2.7.0-rc.2 - 2026-07-26
 
 ## Changed

--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -6,6 +6,15 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+- `build.rs` now watches the whole `rust/src` directory. It previously named
+  only `lib.rs`, `voting.rs` and `voting/`, and emitting any `rerun-if-changed`
+  disables cargo's default whole-package watching, so edits to any other module
+  (`ffi.rs` in particular) recompiled the crate without rerunning the build
+  script. The cbindgen-generated `target/Headers/zcashlc.h` could therefore go
+  stale, leaving a newly added FFI function absent from the header or a changed
+  signature unreflected.
+
 ## 2.5.0 - 2026-05-11
 
 ### Added

--- a/rust/build.rs
+++ b/rust/build.rs
@@ -3,9 +3,11 @@ extern crate cbindgen;
 use std::{env, path::PathBuf};
 
 fn main() {
-    println!("cargo:rerun-if-changed=rust/src/lib.rs");
-    println!("cargo:rerun-if-changed=rust/src/voting.rs");
-    println!("cargo:rerun-if-changed=rust/src/voting");
+    // cbindgen parses the whole crate to produce target/Headers/zcashlc.h, so
+    // every module is an input to the generated header. Watch the source
+    // directory as a whole: naming individual files here silently left the
+    // header stale after edits to any module that was not listed.
+    println!("cargo:rerun-if-changed=rust/src");
     println!("cargo:rerun-if-changed=rust/wrapper.c");
     println!("cargo:rerun-if-changed=rust/wrapper.h");
 


### PR DESCRIPTION
Closes #1901
Closes #1902
Resolves MOB-1601
Resolves MOB-1600

The FFI release build recompiled each of the five Apple architectures with its
own `cargo build --target <triple>`. Those invocations cannot be overlapped
with `make -j`, because concurrent cargo processes sharing `../target` block on
an exclusive lock over the host artifact directory:

```
[ios]    Blocking waiting for file lock on package cache
[darwin] Blocking waiting for file lock on artifact directory
```

The cost concentrates in the link step. `[profile.release] lto = true` is a
single-threaded whole-program pass over a ~674-crate graph, so the five passes
ran back to back.

## Changes

**Single multi-target cargo invocation** (`BuildSupport/Makefile`). Passing
several `--target` flags to one `cargo build` puts every architecture into a
single job graph with one lock, so those LTO passes overlap. Measured on 16
cores with dependencies warm:

| Build | Wall | User CPU | Utilization |
|---|---|---|---|
| One architecture, LTO/link tail only | 2m02s | 156s | ~1.0x (serial) |
| All five, one invocation | 3m52s | 1924s | ~5.1x |

The per-platform goals keep their own narrow architecture lists, so
`make macos` still needs only the two macOS rustup targets installed — which
`swift.yml` and `codeql.yml` rely on. `make macos` also drops from two cargo
invocations to one. A full build takes `cargo-all` as its first prerequisite,
after which the per-platform rules reduce to a fingerprint check.

**`clean` / `distclean` split.** `clean` now removes `products/` only;
`distclean` additionally wipes `../target`. `Scripts/prepare-release.sh` runs
`make clean` immediately after `build-ffi.yml` restores `Swatinem/rust-cache`,
so that cache had never affected a release build. Products are still rebuilt
from scratch, so no stale slice can survive `clean`.

**`rust/build.rs` header-staleness fix.** Removing the `target/` wipe from
`clean` exposed a pre-existing bug that wipe had been masking. `build.rs`
generates `zcashlc.h` via cbindgen, which parses the whole crate, but declared
`rerun-if-changed` for only `lib.rs`, `voting.rs`, `voting/` and the wrappers.
Emitting any `rerun-if-changed` disables cargo's default whole-package
watching, leaving `ffi.rs`, `derivation.rs`, `eip681.rs`, `tor.rs`,
`migration.rs` and `os_log.rs` unwatched. Verified by appending a new exported
function to `rust/src/ffi.rs` and rebuilding without wiping `target/`:

| `build.rs` | New `extern "C"` fn present in `zcashlc.h`? |
|---|---|
| before | no (stale header) |
| after | yes |

`Scripts/rebuild-local-ffi.sh` calls `cargo build` directly and was exposed to
this already.

## Verification

- `make macos` builds only the macOS architectures and emits a single cargo
  invocation naming just those two triples.
- A full `make xcframework` produces all three slices with the expected
  architectures (`ios-arm64` → `arm64`, `ios-arm64_x86_64-simulator` →
  `x86_64 arm64`, `macos-arm64_x86_64` → `x86_64 arm64`), with `Headers`,
  `Modules/module.modulemap` and both `Info.plist` files in place.
- Header regeneration confirmed in both directions (function added → appears;
  reverted → disappears).

## Notes for review

- Releases now build incrementally rather than from scratch. Switching
  `Scripts/prepare-release.sh` to `make distclean` would restore the previous
  from-scratch behaviour at the cost of the cache benefit — happy to change it
  if that hermeticity is wanted for tagged releases. Note that
  `Swatinem/rust-cache` strips workspace-local artifacts before saving, so
  `libzcashlc` itself and its LTO link always rerun regardless; the saving is
  on the dependency crates.
- Both workflows hash `BuildSupport/Makefile` into their FFI cache key, so this
  invalidates that cache once.
- Not addressed here: `lto = "thin"` would cut the per-architecture cost
  itself, but it changes codegen for scanning and proving, so it wants a
  runtime benchmark rather than a build-time one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
