### PR TITLE
Release zcash-swift-wallet-sdk 2.8.0-rc.2

### DIFF
--- a/BuildSupport/Makefile
+++ b/BuildSupport/Makefile
@@ -10,6 +10,18 @@ IOS_DEVICE_ARCHS = aarch64-apple-ios
 IOS_SIM_ARCHS_STABLE = x86_64-apple-ios  aarch64-apple-ios-sim
 MACOS_ARCHS = x86_64-apple-darwin aarch64-apple-darwin
 IOS_SIM_ARCHS = $(IOS_SIM_ARCHS_STABLE)
+ALL_ARCHS = $(IOS_DEVICE_ARCHS) $(IOS_SIM_ARCHS) $(MACOS_ARCHS)
+
+# Cargo serialises concurrent invocations behind a lock on the shared host
+# artifact directory (../target/release), so running one `cargo build --target X`
+# per architecture cannot overlap them — `make -j` does not help. That matters
+# most for the link step: `lto = true` is a single-threaded whole-program pass
+# costing roughly two minutes per architecture, so five of them run back to back.
+#
+# Passing several `--target` flags to one invocation puts every architecture in a
+# single job graph, letting those passes run concurrently.
+CARGO_BUILD = RUSTUP_TOOLCHAIN=stable cargo build --manifest-path ../Cargo.toml --release
+cargo_targets = $(addprefix --target ,$(1))
 
 RUST_SRCS = $(shell find ../rust -name "*.rs") ../Cargo.toml
 STATIC_LIBS = $(shell find ../target -name "libzcashlc.a")
@@ -23,15 +35,26 @@ install:
 release: clean xcframework
 .PHONY: release
 
+# Discard assembled build products. ../target is deliberately preserved so that
+# cargo's fingerprints (and CI's restored Rust cache) still apply; cargo decides
+# what genuinely needs rebuilding. Every framework under products/ is rebuilt
+# from scratch, so no stale slice can survive this.
 clean:
 	rm -rf products
-	rm -rf ../target
 .PHONY: clean
+
+# Additionally discard the cargo target directory, forcing a from-scratch build.
+distclean: clean
+	rm -rf ../target
+.PHONY: distclean
 
 xcframework: products/libzcashlc.xcframework
 .PHONY: xcframework
 
-products/libzcashlc.xcframework: $(PLATFORMS)
+# cargo-all is listed first so a full build compiles every architecture in one
+# invocation. The per-platform cargo rules below then find their work already
+# done and reduce to a fingerprint check.
+products/libzcashlc.xcframework: cargo-all $(PLATFORMS)
 	rm -rf $@
 	mkdir -p $@
 	cp -R products/ios-device/frameworks $@/ios-arm64
@@ -68,20 +91,35 @@ products/ios-device/universal/libzcashlc.a: $(IOS_DEVICE_ARCHS)
 	mkdir -p $(@D)
 	lipo -create $(shell find products/ios-device/static-libraries -name "libzcashlc.a") -output $@
 
-$(MACOS_ARCHS): %: stable-%
+$(MACOS_ARCHS): %: cargo-macos
 	mkdir -p products/macos/static-libraries/$*
 	cp ../target/$*/release/libzcashlc.a products/macos/static-libraries/$*
 .PHONY: $(MACOS_ARCHS)
 
-$(IOS_DEVICE_ARCHS): %: stable-%
+$(IOS_DEVICE_ARCHS): %: cargo-ios-device
 	mkdir -p products/ios-device/static-libraries/$*
 	cp ../target/$*/release/libzcashlc.a products/ios-device/static-libraries/$*
 .PHONY: $(IOS_DEVICE_ARCHS)
 
-$(IOS_SIM_ARCHS_STABLE): %: stable-%
+$(IOS_SIM_ARCHS_STABLE): %: cargo-ios-simulator
 	mkdir -p products/ios-simulator/static-libraries/$*
 	cp ../target/$*/release/libzcashlc.a products/ios-simulator/static-libraries/$*
 .PHONY: $(IOS_SIM_ARCHS_STABLE)
 
-stable-%: # target/%/release/libzcashlc.a:
-	sh -c "RUSTUP_TOOLCHAIN=stable cargo build --manifest-path ../Cargo.toml --target $* --release"
+# Each platform builds only its own architectures, so `make macos` still needs
+# just the macOS rustup targets installed.
+cargo-all:
+	$(CARGO_BUILD) $(call cargo_targets,$(ALL_ARCHS))
+.PHONY: cargo-all
+
+cargo-macos:
+	$(CARGO_BUILD) $(call cargo_targets,$(MACOS_ARCHS))
+.PHONY: cargo-macos
+
+cargo-ios-device:
+	$(CARGO_BUILD) $(call cargo_targets,$(IOS_DEVICE_ARCHS))
+.PHONY: cargo-ios-device
+
+cargo-ios-simulator:
+	$(CARGO_BUILD) $(call cargo_targets,$(IOS_SIM_ARCHS))
+.PHONY: cargo-ios-simulator

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
+# 2.8.0-rc.2 - 2026-07-28
+
 ## Changed
 - The FFI xcframework build now compiles every Apple architecture in a single
   multi-target `cargo build` invocation rather than one invocation per

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
+## Changed
+- The FFI xcframework build now compiles every Apple architecture in a single
+  multi-target `cargo build` invocation rather than one invocation per
+  architecture. Concurrent cargo invocations serialize on a lock over the
+  shared host artifact directory, so the single-threaded fat-LTO pass for each
+  architecture previously ran one after another; they now overlap. The
+  per-platform goals (`make macos`, `make ios-device`, `make ios-simulator`)
+  still build only their own architectures.
+- `make clean` in `BuildSupport/` no longer removes the cargo `target`
+  directory; the new `make distclean` goal does. This lets a restored Rust
+  dependency cache survive a release build, which previously deleted it before
+  compiling.
+
 # 2.7.0-rc.2 - 2026-07-26
 
 ## Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6737,9 +6737,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_client_backend"
-version = "0.24.0-rc.4"
+version = "0.24.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e019c2adb1eb2c3479603f4556e85c01022723f14ce8837a3bb225cb2af4d3f"
+checksum = "956f2438ea82fbbcf2407fb7c96e14ea6420963fbb0483a522e3e20fab2ae93f"
 dependencies = [
  "arti-client",
  "base64",
@@ -6805,9 +6805,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_client_sqlite"
-version = "0.22.0-rc.4"
+version = "0.22.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a496ad83b77e790bd0ea1013db14961b3ff825550097a2658837dc7e92a23d53"
+checksum = "70415a7cc23b9850d984231b989813684166adab55c22d92185abd0601288c2e"
 dependencies = [
  "bip32",
  "bitflags",
@@ -6864,9 +6864,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_keys"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc842e024fe37e52cfd3920826c4a28cc2a023fc9d77351d9c0f310becae3eb7"
+checksum = "def800f128e459eedebc900f36f408eaf0687634128dcf64ecfeaeebc3e16c14"
 dependencies = [
  "bech32",
  "bip32",
@@ -6907,9 +6907,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_pool_migration"
-version = "0.1.0-rc.3"
+version = "0.1.0-rc.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7e4169a96a25de216d4a7265fe772003aaeea05ed2566b14cfc0b8146b1f99e"
+checksum = "ed5099c9398bc00929cfc6b72842cbd9af60b0acc45f64ce830c4ed42026d2fe"
 dependencies = [
  "corez",
  "getset",
@@ -6923,6 +6923,7 @@ dependencies = [
  "zcash_keys",
  "zcash_primitives",
  "zcash_protocol",
+ "zip32",
 ]
 
 [[package]]
@@ -6980,9 +6981,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_protocol"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4034db33a1ce58416430e065b01474b958e4649caa3e06e20654683a95149710"
+checksum = "5d23144aed9cc370a746896a1b0cb5ebe40d7ce0599aa8522ac6b189c1d61a22"
 dependencies = [
  "corez",
  "document-features",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ ff = "0.13"
 sapling = { package = "sapling-crypto", version = "0.7", default-features = false }
 transparent = { package = "zcash_transparent", version = "0.10", default-features = false }
 zcash_address = { version = "0.13" }
-zcash_client_backend = { version = "0.24.0-rc.4", features = [
+zcash_client_backend = { version = "0.24.0-rc.5", features = [
     "lightwalletd-tonic-tls-webpki-roots",
     "orchard",
     "pczt",
@@ -29,11 +29,11 @@ zcash_client_backend = { version = "0.24.0-rc.4", features = [
     "transparent-inputs",
     "unstable",
 ] }
-zcash_client_sqlite = { version = "0.22.0-rc.4", features = ["orchard", "transparent-inputs", "unstable", "serde"] }
+zcash_client_sqlite = { version = "0.22.0-rc.5", features = ["orchard", "transparent-inputs", "unstable", "serde"] }
 zcash_note_encryption = "0.4.1"
 zcash_primitives = "0.30"
 zcash_proofs = "0.30"
-zcash_protocol = "0.10"
+zcash_protocol = "0.10.2"
 zcash_script = "0.4"
 zip32 = "0.2"
 pczt = { version = "0.9.0", features = ["prover", "orchard", "sapling"] }
@@ -90,6 +90,16 @@ xz2 = { version = "0.1", features = ["static"] }
 bindgen = "0.72"
 cbindgen = "0.29"
 cc = "1.0"
+
+[patch.crates-io]
+# pczt = { git = "https://github.com/zcash/librustzcash.git", rev = "REPLACE_ME" }
+# zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "REPLACE_ME" }
+# zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "REPLACE_ME" }
+# zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "REPLACE_ME" }
+# zcash_keys = { git = "https://github.com/zcash/librustzcash.git", rev = "REPLACE_ME" }
+# zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "REPLACE_ME" }
+# zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "REPLACE_ME" }
+# zcash_transparent = { git = "https://github.com/zcash/librustzcash.git", rev = "REPLACE_ME" }
 
 [features]
 default = []

--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -39,7 +39,6 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   script. The cbindgen-generated `target/Headers/zcashlc.h` could therefore go
   stale, leaving a newly added FFI function absent from the header or a changed
   signature unreflected.
->>>>>>> maint/v2.7.x
 
 ## 2.5.0 - 2026-05-11
 

--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -6,6 +6,10 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+- Migrated to `zcash_protocol 0.10.2`, `zcash_client_backend 0.24.0-rc.5`,
+  `zcash_client_sqlite 0.22.0-rc.5`
+
 ### Fixed
 - `build.rs` now watches the whole `rust/src` directory. It previously named
   only `lib.rs`, `voting.rs` and `voting/`, and emitting any `rerun-if-changed`

--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -6,6 +6,15 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+- `build.rs` now watches the whole `rust/src` directory. It previously named
+  only `lib.rs`, `voting.rs` and `voting/`, and emitting any `rerun-if-changed`
+  disables cargo's default whole-package watching, so edits to any other module
+  (`ffi.rs` in particular) recompiled the crate without rerunning the build
+  script. The cbindgen-generated `target/Headers/zcashlc.h` could therefore go
+  stale, leaving a newly added FFI function absent from the header or a changed
+  signature unreflected.
+
 ## 2.5.0 - 2026-05-11
 
 ### Added

--- a/rust/build.rs
+++ b/rust/build.rs
@@ -3,9 +3,11 @@ extern crate cbindgen;
 use std::{env, path::PathBuf};
 
 fn main() {
-    println!("cargo:rerun-if-changed=rust/src/lib.rs");
-    println!("cargo:rerun-if-changed=rust/src/voting.rs");
-    println!("cargo:rerun-if-changed=rust/src/voting");
+    // cbindgen parses the whole crate to produce target/Headers/zcashlc.h, so
+    // every module is an input to the generated header. Watch the source
+    // directory as a whole: naming individual files here silently left the
+    // header stale after edits to any module that was not listed.
+    println!("cargo:rerun-if-changed=rust/src");
     println!("cargo:rerun-if-changed=rust/wrapper.c");
     println!("cargo:rerun-if-changed=rust/wrapper.h");
 

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -477,6 +477,10 @@ pub unsafe extern "C" fn zcashlc_create_account(
                 BirthdayError::Decode(e) => {
                     anyhow!("Invalid TreeState: Invalid frontier encoding: {}", e)
                 }
+                // `BirthdayError` is `#[non_exhaustive]`; this arm is unreachable
+                // against enum versions that expose only the variants above.
+                #[allow(unreachable_patterns)]
+                _ => anyhow!("Invalid TreeState: unrecognized birthday error"),
             })?;
 
         let account_name = unsafe { CStr::from_ptr(account_name).to_str()? };
@@ -567,6 +571,10 @@ pub unsafe extern "C" fn zcashlc_import_account_ufvk(
                 BirthdayError::Decode(e) => {
                     anyhow!("Invalid TreeState: Invalid frontier encoding: {}", e)
                 }
+                // `BirthdayError` is `#[non_exhaustive]`; this arm is unreachable
+                // against enum versions that expose only the variants above.
+                #[allow(unreachable_patterns)]
+                _ => anyhow!("Invalid TreeState: unrecognized birthday error"),
             })?;
 
         let hd_account_index = zip32::AccountId::try_from(hd_account_index_raw).ok();


### PR DESCRIPTION
Release zcash-swift-wallet-sdk version 2.8.0-rc.2

- **rust: handle non_exhaustive BirthdayError match**
- **[#1902] Watch all of rust/src so the generated header cannot go stale**
- **[#1901] Build every Apple architecture in one cargo invocation**
- **Update to latest librustzcash releases.**
- **Prepare SDK release 2.8.0-rc.2**
