### PR TITLE
Expand the Makefile and route the CI build jobs through it

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -136,29 +136,20 @@ jobs:
     - name: Build FFI for macOS
       if: matrix.language == 'swift' && steps.cache-ffi.outputs.cache-hit != 'true'
       timeout-minutes: 30
-      working-directory: ./BuildSupport
-      run: |
-        echo "Building FFI for macOS..."
-        make macos
-        mkdir -p products/libzcashlc.xcframework
-        cp -R products/macos/frameworks products/libzcashlc.xcframework/macos-arm64_x86_64
-        cp Info.plist products/libzcashlc.xcframework
+      run: make ffi-macos
 
     - name: Configure local FFI
       if: matrix.language == 'swift'
-      run: |
-        mkdir -p LocalPackages
-        cp -R BuildSupport/products/libzcashlc.xcframework LocalPackages/
-        cp BuildSupport/LocalPackages-Package.swift LocalPackages/Package.swift
+      run: make configure-local-ffi
 
     - name: Resolve Swift dependencies
       if: matrix.language == 'swift'
-      run: swift package resolve
+      run: make resolve
 
     - name: Build Swift package
       if: matrix.language == 'swift'
       timeout-minutes: 30
-      run: swift build
+      run: make build
 
     # --- End Swift manual build steps ---
 

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -63,38 +63,22 @@ jobs:
     - name: Build FFI for macOS
       if: steps.cache-ffi.outputs.cache-hit != 'true'
       timeout-minutes: 30
-      working-directory: ./BuildSupport
-      run: |
-        echo "Building FFI for macOS..."
-        make macos
-        mkdir -p products/libzcashlc.xcframework
-        cp -R products/macos/frameworks products/libzcashlc.xcframework/macos-arm64_x86_64
-        cp Info.plist products/libzcashlc.xcframework
+      run: make ffi-macos
 
     # Verify xcframework exists (whether from cache or fresh build)
     - name: Verify XCFramework
-      run: |
-        if [ ! -d "BuildSupport/products/libzcashlc.xcframework" ]; then
-          echo "Error: BuildSupport/products/libzcashlc.xcframework not found"
-          exit 1
-        fi
-        echo "XCFramework contents:"
-        ls -la BuildSupport/products/libzcashlc.xcframework/
+      run: make verify-ffi
 
     # Set up LocalPackages so Package.swift auto-detects the local build
     - name: Configure local FFI for CI
-      run: |
-        mkdir -p LocalPackages
-        cp -R BuildSupport/products/libzcashlc.xcframework LocalPackages/
-        cp BuildSupport/LocalPackages-Package.swift LocalPackages/Package.swift
-        echo "LocalPackages created — Package.swift will use local FFI"
+      run: make configure-local-ffi
 
     # Build the Swift package
     - name: Build ZcashLightClientKit Swift Package
       timeout-minutes: 15
-      run: swift build -v
+      run: make build SWIFT_BUILD_FLAGS=-v
 
     # Run tests
     - name: Run OfflineTests suite
       timeout-minutes: 10
-      run: swift test --filter OfflineTests
+      run: make test-offline

--- a/Makefile
+++ b/Makefile
@@ -1,39 +1,200 @@
-# Convenience development targets for this repository. Run from the repo root.
-# See BuildSupport/Makefile for the full FFI build graph.
+# Makefile for the Zcash Swift wallet SDK. Run from the repo root.
+#
+# Every command the project needs goes through a target here, so that local
+# runs and CI runs are identical: .github/workflows/ invokes these targets
+# rather than repeating the commands.
+#
+# Run `make help` for the target list, and `make info` for the resolved
+# toolchain.
+#
+# Layout
+# ------
+# The Rust FFI build graph lives in BuildSupport/Makefile; the ffi-* targets
+# here delegate to it and then assemble the XCFramework exactly as CI does.
+# The Swift package itself is built with SwiftPM from the repo root.
+#
+# Portability
+# -----------
+# Written for GNU Make 3.81, which is what macOS ships, so it avoids the
+# 4.x-only features (`!=`, `$(file ...)`, `.ONESHELL`). The swift build and
+# test targets work anywhere SwiftPM does; the ffi-* targets produce an Apple
+# XCFramework and therefore require macOS with Xcode, which they check for
+# rather than failing obscurely.
+
+SWIFT ?= swift
+CARGO ?= cargo
+BUILD_SUPPORT := BuildSupport
+SCRIPTS := Scripts
+
+# The XCFramework the Swift package links against when built locally.
+XCFRAMEWORK := $(BUILD_SUPPORT)/products/libzcashlc.xcframework
+
+# Empty by default so a local build is quiet; CI passes -v for a full log.
+SWIFT_BUILD_FLAGS ?=
+
+# The test suite that runs without network or a live lightwalletd.
+OFFLINE_TEST_FILTER := OfflineTests
+
+# Which slice rebuild-ffi rebuilds: ios-sim, ios-device or macos.
+REBUILD_TARGET ?= ios-sim
+
+# SwiftPM and Cargo parallelize internally; running two at once only contends
+# on their own locks, so never run these targets concurrently.
+.NOTPARALLEL:
 
 .DEFAULT_GOAL := help
 
-SCRIPTS := Scripts
+.PHONY: help
+help: ## Ask for help!
+	@grep -E '^[a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | \
+		awk 'BEGIN {FS = ":.*?## "}; \
+		{printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
-.PHONY: help init-ffi rebuild-ffi reset-ffi swift-build test-offline
+.PHONY: info
+info: ## Print the resolved toolchain and FFI state
+	@printf "Swift:        "; \
+		if command -v $(SWIFT) >/dev/null 2>&1; then \
+			$(SWIFT) --version 2>&1 | head -1; else echo "absent"; fi
+	@printf "Cargo:        "; \
+		if command -v $(CARGO) >/dev/null 2>&1; then $(CARGO) --version; \
+		else echo "absent"; fi
+	@printf "Xcode:        "; \
+		if command -v xcode-select >/dev/null 2>&1; then \
+			xcode-select -p 2>/dev/null || echo "not selected"; \
+		else echo "absent (not macOS)"; fi
+	@printf "XCFramework:  "; \
+		if [ -d "$(XCFRAMEWORK)" ]; then echo "$(XCFRAMEWORK)"; \
+		else echo "<not built; run make ffi-macos>"; fi
+	@printf "LocalPackages:"; \
+		if [ -d LocalPackages ]; then echo " present (local FFI in use)"; \
+		else echo " absent (Package.swift uses the released FFI)"; fi
 
-help:
-	@echo "Convenience targets (repo root):"
-	@echo "  make init-ffi              ./$(SCRIPTS)/init-local-ffi.sh"
-	@echo "  make rebuild-ffi           ./$(SCRIPTS)/rebuild-local-ffi.sh (default: ios-sim)"
-	@echo "  make rebuild-ffi REBUILD_TARGET=ios-device"
-	@echo "  make rebuild-ffi REBUILD_TARGET=macos"
-	@echo "  make reset-ffi             ./$(SCRIPTS)/reset-local-ffi.sh"
-	@echo "  make swift-build           swift build"
-	@echo "  make test-offline          swift test --filter OfflineTests"
+# The FFI targets produce an Apple XCFramework, which only Xcode can do.
+.PHONY: require-macos
+require-macos:
+	@[ "$$(uname -s)" = "Darwin" ] || { \
+		echo "This target builds an Apple XCFramework and needs macOS"; \
+		echo "with Xcode. The build and test targets work here."; \
+		exit 1; }
 
-# Initialize the local FFI development environment
-init-ffi:
+# ---------------------------------------------------------------------------
+# Aggregate targets
+# ---------------------------------------------------------------------------
+
+.PHONY: build
+build: ## Build the Swift package
+	$(SWIFT) build $(SWIFT_BUILD_FLAGS)
+
+.PHONY: build-release
+build-release: ## Build the Swift package in release mode
+	$(SWIFT) build -c release $(SWIFT_BUILD_FLAGS)
+
+.PHONY: test
+test: test-offline ## Run the offline test suite
+
+.PHONY: check
+check: build test ## Build and run the offline tests
+
+.PHONY: clean
+clean: ## Clean the SwiftPM build directory
+	$(SWIFT) package clean
+
+.PHONY: clean-all
+clean-all: clean clean-ffi ## Clean SwiftPM and FFI build artifacts
+
+.PHONY: setup
+setup: ## Set up the development environment
+	@$(MAKE) --no-print-directory info
+	@echo ""
+	@echo "For a local FFI build, run: make init-ffi"
+
+# ---------------------------------------------------------------------------
+# Swift package
+# ---------------------------------------------------------------------------
+
+.PHONY: resolve
+resolve: ## Resolve the SwiftPM dependencies
+	$(SWIFT) package resolve
+
+.PHONY: test-offline
+test-offline: ## Run the offline tests (no network, no lightwalletd)
+	$(SWIFT) test --filter $(OFFLINE_TEST_FILTER)
+
+.PHONY: test-all
+test-all: ## Run the whole test suite, including networked tests
+	$(SWIFT) test
+
+.PHONY: lint
+lint: ## Lint the Swift sources with SwiftLint
+	@command -v swiftlint >/dev/null 2>&1 || { \
+		echo "swiftlint not found. Install it with: brew install swiftlint"; \
+		exit 1; }
+	swiftlint lint --quiet
+
+.PHONY: format
+format: ## Apply SwiftLint autocorrections
+	@command -v swiftlint >/dev/null 2>&1 || { \
+		echo "swiftlint not found. Install it with: brew install swiftlint"; \
+		exit 1; }
+	swiftlint --fix
+
+# Kept as an alias: this was the target name before the Makefile grew.
+.PHONY: swift-build
+swift-build: build ## Alias for `make build`
+
+# ---------------------------------------------------------------------------
+# Rust FFI (BuildSupport/)
+# ---------------------------------------------------------------------------
+#
+# ffi-macos reproduces the CI "Build FFI for macOS" step exactly: build the
+# macOS slice, then assemble the XCFramework around it. macOS alone is enough
+# to build and test the Swift package.
+
+.PHONY: ffi-macos
+ffi-macos: require-macos ## Build the macOS FFI and assemble the XCFramework
+	$(MAKE) -C $(BUILD_SUPPORT) macos
+	cd $(BUILD_SUPPORT) && mkdir -p products/libzcashlc.xcframework
+	cd $(BUILD_SUPPORT) && cp -R products/macos/frameworks \
+		products/libzcashlc.xcframework/macos-arm64_x86_64
+	cd $(BUILD_SUPPORT) && cp Info.plist products/libzcashlc.xcframework
+
+.PHONY: ffi-all
+ffi-all: require-macos ## Build the full XCFramework for every platform
+	$(MAKE) -C $(BUILD_SUPPORT) xcframework
+
+.PHONY: verify-ffi
+verify-ffi: ## Check the XCFramework exists and show its contents
+	@if [ ! -d "$(XCFRAMEWORK)" ]; then \
+		echo "Error: $(XCFRAMEWORK) not found"; \
+		exit 1; fi
+	@echo "XCFramework contents:"
+	@ls -la $(XCFRAMEWORK)/
+
+# Package.swift auto-detects LocalPackages/ and links the local FFI instead of
+# the released binary target.
+.PHONY: configure-local-ffi
+configure-local-ffi: ## Point Package.swift at the locally built FFI
+	mkdir -p LocalPackages
+	cp -R $(XCFRAMEWORK) LocalPackages/
+	cp $(BUILD_SUPPORT)/LocalPackages-Package.swift LocalPackages/Package.swift
+	@echo "LocalPackages created; Package.swift will use the local FFI"
+
+.PHONY: clean-ffi
+clean-ffi: ## Clean the FFI build artifacts
+	$(MAKE) -C $(BUILD_SUPPORT) clean
+
+# ---------------------------------------------------------------------------
+# Local FFI development helpers (Scripts/)
+# ---------------------------------------------------------------------------
+
+.PHONY: init-ffi
+init-ffi: ## Initialize the local FFI development environment
 	./$(SCRIPTS)/init-local-ffi.sh
 
-REBUILD_TARGET ?= ios-sim
-# Rebuild the local FFI development environment
-rebuild-ffi:
+.PHONY: rebuild-ffi
+rebuild-ffi: ## Rebuild the local FFI (REBUILD_TARGET=ios-sim by default)
 	./$(SCRIPTS)/rebuild-local-ffi.sh $(REBUILD_TARGET)
 
-# Reset the local FFI development environment
-reset-ffi:
+.PHONY: reset-ffi
+reset-ffi: ## Reset the local FFI development environment
 	./$(SCRIPTS)/reset-local-ffi.sh
-
-# Build the Swift package
-swift-build:
-	swift build
-
-# Run offline Swift tests
-test-offline:
-	swift test --filter OfflineTests


### PR DESCRIPTION
The root Makefile held five convenience targets while CI repeated its own
swift and FFI commands inline, so reproducing a CI failure locally meant
reading the workflow and retyping the steps, and the two drifted. This expands
the Makefile to own every command the project needs and has the workflows call
the targets.

Mirrors zcash-android-wallet-sdk#2094. Independent of, and not stacked on, the
`proposal.proto` PR (#1915).

## Nine steps now run a target

- `swift.yml`: `ffi-macos`, `verify-ffi`, `configure-local-ffi`, `build`,
  `test-offline`
- `codeql.yml`: `ffi-macos`, `configure-local-ffi`, `resolve`, `build`

Each expands to exactly what the step ran before. The verbose build is
preserved via `make build SWIFT_BUILD_FLAGS=-v`, so CI keeps its full log while
a local `make build` stays quiet.

## Compatible with what was there

Every previous target name still works; `swift-build` is now an alias for
`build`. The additions are the standard set (`build`, `test`, `check`, `clean`,
`setup`, `info`) plus the FFI graph the workflows needed: `ffi-macos`
reproduces the CI step of building the macOS slice and assembling the
XCFramework around it, and `configure-local-ffi` points `Package.swift` at the
result. `BuildSupport/Makefile` remains the FFI build graph; the root targets
delegate to it with `$(MAKE) -C`.

## What is deliberately not converted

SwiftLint, zizmor and the CodeQL analysis step are GitHub Actions rather than
commands, so converting them would change what they do. A local `make lint` is
provided for SwiftLint. The FFI cache-key hashing and the release workflow
(`build-ffi.yml`, which already calls `Scripts/prepare-release.sh`) are also
left alone.

## Portability

Targets GNU Make **3.81**, the version macOS ships, so none of the 4.x-only
features are used. The `build` and `test` targets work anywhere SwiftPM does;
the `ffi-*` targets produce an Apple XCFramework, so they check for macOS via
`require-macos` and say so, rather than failing obscurely partway through a
cargo build.

## Verification

- 0 lines over 80 chars; parses under GNU Make 3.81; all targets register.
- `make info` ran for real and correctly reported Swift 6.2.3, cargo, the Xcode
  path, and that no XCFramework is built yet.
- `make help` renders; `require-macos` passes on macOS.
- Dry-ran each converted target and compared against the original step, e.g.
  `make build SWIFT_BUILD_FLAGS=-v` -> `swift build -v`, `test-offline` ->
  `swift test --filter OfflineTests`, `ffi-macos` -> `make -C BuildSupport
  macos` followed by the same three assembly commands.
- All five workflow files still parse with their jobs intact.

I did not run a full Xcode or FFI build, only verified the commands issued.

Based on `maint/v2.7.x`, matching the Android PR.

Generated with [Claude Code](https://claude.com/claude-code)