### PR TITLE
AGENTS.md: only v_transactions and v_tx_outputs may be read directly

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,6 +117,57 @@ Every public API parameter that carries a domain value — key material, seeds, 
 - When logging errors, log `error.message` or `localizedDescription` (generic, code-prefixed, safe). NEVER log errors via `String(describing:)`, `"\(error)"`, or `dump(...)` — default reflection prints the associated values, and that output ends up in logs users mail to support.
 - New error cases added to `Error/ZcashErrorCodeDefinition.swift` must keep raw input out of their `message` text; carry context via the error code, not the offending value.
 
+## Database access: views only, everything else through the FFI
+
+`dataDb` is owned by Rust. `zcash_client_sqlite` defines both its tables and a
+set of `v_*` views, and only the views are a supported interface. The tables
+are an implementation detail that upstream reshapes freely, and a schema
+migration that leaves a view's columns intact can still rename, split or drop
+the tables underneath it.
+
+**Swift may read `v_transactions` and `v_tx_outputs` directly. Every other
+query goes through the FFI.** Never read a table from Swift, and never write
+anything at all: writes belong to Rust, which owns invariants across tables
+that no single statement can preserve.
+
+Those two views are the client-facing read surface. `zcash_client_sqlite`
+defines other `v_*` views, but they serve the scanning and note-commitment
+machinery inside Rust and are not an interface for this SDK; treat them like
+tables. The definitions live in `zcash_client_sqlite/src/wallet/db.rs` in
+[librustzcash][lrz].
+
+[lrz]: https://github.com/zcash/librustzcash
+
+### Why those two, and when to ask for another
+
+Everything the FFI returns is serialized and copied across the boundary, so a
+query yielding many rows can cost more that way than reading it directly.
+That is why `v_transactions` and `v_tx_outputs`, which back the transaction
+history, are exempt at all.
+
+Another query with the same bulk property may deserve the same treatment, but
+that is not a call to make on your own. Do not add a direct read silently:
+flag it to the user, say what the query returns and roughly how much data it
+moves, and let them decide. If they agree, record it in the table below so the
+next reader sees a sanctioned exception rather than a violation.
+
+### Where direct access lives
+
+All of it is under `Sources/ZcashLightClientKit/DAO/`. Adding a query anywhere
+else is a mistake; adding one that names a table is a mistake wherever it is.
+
+| File | Reads | Status |
+|---|---|---|
+| `TransactionDao.swift` | `v_transactions`, `v_tx_outputs` | views, fine |
+| `BlockDao.swift` | `blocks` | **table, pre-existing exception** |
+
+`PagedTransactionDao.swift` and `UnspentTransactionOutputDao.swift` name no
+entities of their own.
+
+The exception predates this rule and is being migrated to the FFI. Do not copy
+it, and do not add to it: if you need something it exposes, add an FFI call
+rather than a second table reader.
+
 ## Pre-push validation
 
 Before opening a PR or pushing to an existing PR branch, run the checks CI runs.


### PR DESCRIPTION
Stacked on #1919. Mirrors zcash/zcash-android-wallet-sdk#2095.

`dataDb` is owned by Rust. `zcash_client_sqlite` treats its `v_*` views as the
interface and its tables as an implementation detail, so a migration that keeps
a view's columns stable is still free to rename, split or drop the tables
beneath it. A Swift query naming a table therefore breaks on a dependency bump
with **no compile error and no test failure** until it runs against an upgraded
wallet.

## The rule

Swift may read `v_transactions` and `v_tx_outputs` directly. Every other query
goes through the FFI, and nothing in Swift writes to the database at all.

The other `v_*` views upstream defines serve Rust's own scanning and
note-commitment machinery rather than this SDK, so they are treated like tables.

## Where direct access lives

All of it is under `Sources/ZcashLightClientKit/DAO/`:

| File | Reads | Status |
|---|---|---|
| `TransactionDao.swift` | `v_transactions`, `v_tx_outputs` | views, fine |
| `BlockDao.swift` | `blocks` | table, pre-existing exception |

I surveyed rather than assumed: a repo-wide search for `Table("` / `View("`
returns only those two files. `PagedTransactionDao.swift` and
`UnspentTransactionOutputDao.swift` name no entities. Re-run against the rebased
base, with the same result.

The exception is documented as an exception, not endorsed; removing it needs an
FFI accessor for block-lookup-by-height that does not exist yet.

## Placement

Rebased onto the reconciled `AGENTS.md` in #1919. The section now sits directly
after **Security-critical API rules**, since both are MUST rules about the code
rather than the workflow. The earlier revision placed it between *Working
documents are not committed* and *Other notes*, two sections #1919 removed as
duplicates of `main`'s conventions list. The section text is unchanged and still
+51 lines.

## Also noticed, not fixed here

`BlockDao.swift` names the table twice with different capitalisation, `:28`
`Table("blocks")` and `:38` `Table("Blocks")`. SQLite ASCII identifiers are
case-insensitive so both resolve and it is harmless today, but it is two
sources of truth for one name, and the instance property shadows the static
one. Worth collapsing when this file moves to the FFI.

Docs only, so no CHANGELOG entry and no behaviour change.

Generated with [Claude Code](https://claude.com/claude-code)
