### PR TITLE
Surface the v_transactions columns the SDK was dropping

### DIFF
--- a/Sources/ZcashLightClientKit/Entity/TransactionEntity.swift
+++ b/Sources/ZcashLightClientKit/Entity/TransactionEntity.swift
@@ -63,6 +63,19 @@ public enum ZcashTransaction {
         public let isExpiredUmined: Bool?
         public let totalSpent: Zatoshi?
         public let totalReceived: Zatoshi?
+        /// Number of the account's own notes this transaction spent.
+        public let spentNoteCount: Int
+        /// The value that crossed shielded pools when this transaction is a
+        /// wallet-internal transfer between them, such as an Orchard to
+        /// Ironwood migration; `nil` when it is not such a transfer.
+        ///
+        /// For such a transaction `value` is just the negated fee, so this is
+        /// the amount to present to a user rather than the balance delta.
+        public let poolCrossingValue: Zatoshi?
+        /// Whether this transaction is considered trusted, meaning its outputs
+        /// are spendable after the trusted confirmation count rather than the
+        /// untrusted one.
+        public let isTrusted: Bool
         public var state: State?
     }
 
@@ -71,6 +84,7 @@ public enum ZcashTransaction {
             case transaparent
             case sapling
             case orchard
+            case ironwood
             case other(Int)
             init(rawValue: Int) {
                 switch rawValue {
@@ -80,6 +94,8 @@ public enum ZcashTransaction {
                     self = .sapling
                 case 3:
                     self = .orchard
+                case 4:
+                    self = .ironwood
                 default:
                     self = .other(rawValue)
                 }
@@ -173,6 +189,9 @@ extension ZcashTransaction.Overview {
         static let expiredUnmined = SQLite.Expression<Bool?>("expired_unmined")
         static let totalSpent = SQLite.Expression<Int64?>("total_spent")
         static let totalReceived = SQLite.Expression<Int64?>("total_received")
+        static let spentNoteCount = SQLite.Expression<Int>("spent_note_count")
+        static let poolCrossingValue = SQLite.Expression<Int64?>("pool_crossing_value")
+        static let trustStatus = SQLite.Expression<Bool>("trust_status")
     }
 
     init(row: Row) throws {
@@ -189,6 +208,14 @@ extension ZcashTransaction.Overview {
             self.sentNoteCount = try row.get(Column.sentNoteCount)
             self.value = Zatoshi(try row.get(Column.value))
             self.isExpiredUmined = try row.get(Column.expiredUnmined)
+            self.spentNoteCount = try row.get(Column.spentNoteCount)
+            self.isTrusted = try row.get(Column.trustStatus)
+
+            if let poolCrossingValue = try row.get(Column.poolCrossingValue) {
+                self.poolCrossingValue = Zatoshi(poolCrossingValue)
+            } else {
+                self.poolCrossingValue = nil
+            }
             
             if let blockTime = try row.get(Column.blockTime) {
                 self.blockTime = TimeInterval(blockTime)

--- a/Tests/OfflineTests/BroadcasterTests.swift
+++ b/Tests/OfflineTests/BroadcasterTests.swift
@@ -324,7 +324,10 @@ final class BroadcasterTests: ZcashTestCase {
             value: Zatoshi(-1_000),
             isExpiredUmined: false,
             totalSpent: nil,
-            totalReceived: nil
+            totalReceived: nil,
+            spentNoteCount: 0,
+            poolCrossingValue: nil,
+            isTrusted: false
         )
     }
 

--- a/Tests/OfflineTests/CompactBlockProcessorActions/EnhanceActionTests.swift
+++ b/Tests/OfflineTests/CompactBlockProcessorActions/EnhanceActionTests.swift
@@ -159,7 +159,10 @@ final class EnhanceActionTests: ZcashTestCase {
             value: Zatoshi(100000),
             isExpiredUmined: false,
             totalSpent: nil,
-            totalReceived: nil
+            totalReceived: nil,
+            spentNoteCount: 0,
+            poolCrossingValue: nil,
+            isTrusted: false
         )
         
         blockEnhancerMock.enhanceAtDidEnhanceClosure = { _, didEnhance in
@@ -219,7 +222,10 @@ final class EnhanceActionTests: ZcashTestCase {
             value: Zatoshi(100000),
             isExpiredUmined: false,
             totalSpent: nil,
-            totalReceived: nil
+            totalReceived: nil,
+            spentNoteCount: 0,
+            poolCrossingValue: nil,
+            isTrusted: false
         )
         
         blockEnhancerMock.enhanceAtDidEnhanceClosure = { _, didEnhance in
@@ -283,7 +289,10 @@ final class EnhanceActionTests: ZcashTestCase {
             value: Zatoshi(100000),
             isExpiredUmined: false,
             totalSpent: nil,
-            totalReceived: nil
+            totalReceived: nil,
+            spentNoteCount: 0,
+            poolCrossingValue: nil,
+            isTrusted: false
         )
 
         blockEnhancerMock.enhanceAtDidEnhanceClosure = { _, didEnhance in

--- a/Tests/OfflineTests/TransactionRepositoryTests.swift
+++ b/Tests/OfflineTests/TransactionRepositoryTests.swift
@@ -126,7 +126,10 @@ class TransactionRepositoryTests: XCTestCase {
             value: Zatoshi(-1000),
             isExpiredUmined: false,
             totalSpent: nil,
-            totalReceived: nil
+            totalReceived: nil,
+            spentNoteCount: 0,
+            poolCrossingValue: nil,
+            isTrusted: false
         )
 
         let memos = try await self.transactionRepository.findMemos(for: transaction)
@@ -159,7 +162,10 @@ class TransactionRepositoryTests: XCTestCase {
             value: .zero,
             isExpiredUmined: false,
             totalSpent: nil,
-            totalReceived: nil
+            totalReceived: nil,
+            spentNoteCount: 0,
+            poolCrossingValue: nil,
+            isTrusted: false
         )
 
         let memos = try await self.transactionRepository.findMemos(for: transaction)
@@ -187,7 +193,10 @@ class TransactionRepositoryTests: XCTestCase {
             value: .zero,
             isExpiredUmined: false,
             totalSpent: nil,
-            totalReceived: nil
+            totalReceived: nil,
+            spentNoteCount: 0,
+            poolCrossingValue: nil,
+            isTrusted: false
         )
 
         let memos = try await self.transactionRepository.findMemos(for: transaction)

--- a/Tests/TestUtils/MockTransactionRepository.swift
+++ b/Tests/TestUtils/MockTransactionRepository.swift
@@ -155,7 +155,10 @@ extension MockTransactionRepository: TransactionRepository {
             value: Zatoshi(-Int64.random(in: 1 ... Zatoshi.Constants.oneZecInZatoshi)),
             isExpiredUmined: false,
             totalSpent: nil,
-            totalReceived: nil
+            totalReceived: nil,
+            spentNoteCount: 0,
+            poolCrossingValue: nil,
+            isTrusted: false
         )
     }
 
@@ -177,7 +180,10 @@ extension MockTransactionRepository: TransactionRepository {
             value: Zatoshi(Int64.random(in: 1 ... Zatoshi.Constants.oneZecInZatoshi)),
             isExpiredUmined: false,
             totalSpent: nil,
-            totalReceived: nil
+            totalReceived: nil,
+            spentNoteCount: 0,
+            poolCrossingValue: nil,
+            isTrusted: false
         )
     }
 

--- a/Tests/TestUtils/TestsData.swift
+++ b/Tests/TestUtils/TestsData.swift
@@ -54,7 +54,10 @@ class TestsData {
             value: Zatoshi(10),
             isExpiredUmined: false,
             totalSpent: nil,
-            totalReceived: nil
+            totalReceived: nil,
+            spentNoteCount: 0,
+            poolCrossingValue: nil,
+            isTrusted: false
         )
     }()
 
@@ -76,7 +79,10 @@ class TestsData {
             value: Zatoshi(100),
             isExpiredUmined: false,
             totalSpent: nil,
-            totalReceived: nil
+            totalReceived: nil,
+            spentNoteCount: 0,
+            poolCrossingValue: nil,
+            isTrusted: false
         )
     }()
 
@@ -98,7 +104,10 @@ class TestsData {
             value: .zero,
             isExpiredUmined: false,
             totalSpent: nil,
-            totalReceived: nil
+            totalReceived: nil,
+            spentNoteCount: 0,
+            poolCrossingValue: nil,
+            isTrusted: false
         )
     }()
 
@@ -120,7 +129,10 @@ class TestsData {
             value: .zero,
             isExpiredUmined: false,
             totalSpent: nil,
-            totalReceived: nil
+            totalReceived: nil,
+            spentNoteCount: 0,
+            poolCrossingValue: nil,
+            isTrusted: false
         )
     }()
 


### PR DESCRIPTION
Mirrors zcash/zcash-android-wallet-sdk#2098.

`v_transactions` carries three columns the SDK never read.

## What is added

| Column | Exposed as | |
|---|---|---|
| `spent_note_count` | `spentNoteCount: Int` | notes of the account this tx spent |
| `pool_crossing_value` | `poolCrossingValue: Zatoshi?` | see below |
| `trust_status` | `isTrusted: Bool` | outputs spendable at the trusted confirmation count |

`pool_crossing_value` is non-NULL **exactly** when a transaction is a
wallet-internal transfer between shielded pools, such as an Orchard to Ironwood
migration, and its value is the amount that crossed. For such a transaction the
balance delta is just the negated fee, which is why a migration currently
displays as a send of the fee rather than of the migrated amount. Upstream says
so directly: "this is the amount to present to a user rather than the balance
delta".

## A separate bug found on the way

`ZcashTransaction.Output.Pool` had no `ironwood` case, so pool `4` fell through
to `.other(4)` and an Ironwood output was reported as an unknown pool. Since
NU6.3 every payment to an Orchard receiver is delivered in the Ironwood bundle,
so this affected **ordinary received payments**, not only migrations. Added.

## Not included, deliberately

`v_tx_outputs` also has `tx_mined_height`, `tx_trust_status` and
`recipient_key_scope` that Swift does not model. I left them out rather than
add properties nothing reads. `transaction_id` is excluded on principle:
upstream documents it as a database-internal join key that "should not ever be
exposed to end-users".

## Verification

`swift build` clean, and the full `OfflineTests` suite passes: **326 tests, 0
failures**. The compiler found every fixture needing the new arguments, across
five test files, which is what proves the plumbing is complete rather than
merely declared.

Generated with [Claude Code](https://claude.com/claude-code)