### PR TITLE
Add Proposal.spendsLegacyOrchardFunds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
+## Added
+- `Proposal.spendsLegacyOrchardFunds` — whether the proposal spends notes from
+  the legacy Orchard pool, so wallets can warn before a turnstile-crossing send.
+  `Proposal.testOnlyFakeProposal(totalFee:spendsLegacyOrchardFunds:)` gained a
+  defaulted parameter for building test fixtures.
+
 # 2.8.0-rc.3 - 2026-07-29
 
 ## Changed

--- a/Sources/ZcashLightClientKit/Model/Proposal.swift
+++ b/Sources/ZcashLightClientKit/Model/Proposal.swift
@@ -27,6 +27,27 @@ public struct Proposal: Equatable {
             acc + Zatoshi(Int64(step.balance.feeRequired))
         }
     }
+
+    /// Whether any transaction in this proposal spends notes received in the legacy
+    /// Orchard pool.
+    ///
+    /// Post-NU6.3 (Ironwood), spending legacy Orchard notes crosses the Orchard
+    /// turnstile, publicly revealing the value that leaves the pool. Wallets use this
+    /// to warn before sending. Only wallet notes (`receivedOutput` inputs) are
+    /// considered — prior-step references (e.g. the ephemeral transparent leg of a
+    /// ZIP 320 TEX proposal) are not wallet notes. Ironwood inputs (which the FFI
+    /// encodes as a raw value the current generated enum does not name) do not count
+    /// as Orchard.
+    public var spendsLegacyOrchardFunds: Bool {
+        inner.steps.contains { step in
+            step.inputs.contains { input in
+                guard case .receivedOutput(let output) = input.value else {
+                    return false
+                }
+                return output.valuePool == .orchard
+            }
+        }
+    }
 }
 
 public extension Proposal {
@@ -34,11 +55,30 @@ public extension Proposal {
     /// data that can be used to check UI elements, but will always produce an error when
     /// passed to `Synchronizer.createProposedTransactions`. It should never be called in
     /// production code.
-    static func testOnlyFakeProposal(totalFee: UInt64) -> Self {
-        let ffiProposal = FfiProposal()
+    ///
+    /// Set `spendsLegacyOrchardFunds` to `true` to produce a fake proposal whose
+    /// `spendsLegacyOrchardFunds` property is `true`.
+    static func testOnlyFakeProposal(totalFee: UInt64, spendsLegacyOrchardFunds: Bool = false) -> Self {
+        var ffiProposal = FfiProposal()
         var balance = FfiTransactionBalance()
 
         balance.feeRequired = totalFee
+
+        if spendsLegacyOrchardFunds {
+            var receivedOutput = FfiReceivedOutput()
+            receivedOutput.txid = Data(repeating: 0, count: 32)
+            receivedOutput.valuePool = .orchard
+            receivedOutput.index = 0
+            receivedOutput.value = 0
+
+            var input = FfiProposedInput()
+            input.value = FfiProposedInput.OneOf_Value.receivedOutput(receivedOutput)
+
+            var step = FfiProposalStep()
+            step.inputs = [input]
+
+            ffiProposal.steps = [step]
+        }
 
         return Self(inner: ffiProposal)
     }

--- a/Sources/ZcashLightClientKit/Model/Proposal.swift
+++ b/Sources/ZcashLightClientKit/Model/Proposal.swift
@@ -31,13 +31,11 @@ public struct Proposal: Equatable {
     /// Whether any transaction in this proposal spends notes received in the legacy
     /// Orchard pool.
     ///
-    /// Post-NU6.3 (Ironwood), spending legacy Orchard notes crosses the Orchard
-    /// turnstile, publicly revealing the value that leaves the pool. Wallets use this
-    /// to warn before sending. Only wallet notes (`receivedOutput` inputs) are
-    /// considered — prior-step references (e.g. the ephemeral transparent leg of a
-    /// ZIP 320 TEX proposal) are not wallet notes. Ironwood inputs (which the FFI
-    /// encodes as a raw value the current generated enum does not name) do not count
-    /// as Orchard.
+    /// This property describes the proposal's inputs only — it does not know or care whether NU6.3 is active; callers
+    /// deciding whether to warn should apply their own network/activation context if they support pre-activation
+    /// networks. Only wallet notes (`receivedOutput` inputs) are considered: prior-step references point at outputs
+    /// created by an earlier step of this same proposal, so any legacy-Orchard value entering the proposal necessarily
+    /// appears as a `receivedOutput` in some step. Ironwood (ZIP 2005) inputs do not count as Orchard.
     public var spendsLegacyOrchardFunds: Bool {
         inner.steps.contains { step in
             step.inputs.contains { input in

--- a/Tests/OfflineTests/ProposalSpendsOrchardTests.swift
+++ b/Tests/OfflineTests/ProposalSpendsOrchardTests.swift
@@ -1,0 +1,122 @@
+//
+//  ProposalSpendsOrchardTests.swift
+//  OfflineTests
+//
+
+import XCTest
+@testable import ZcashLightClientKit
+
+final class ProposalSpendsOrchardTests: XCTestCase {
+    func testReceivedOrchardOutputSpendsLegacyOrchardFunds() {
+        let output = Self.makeReceivedOutput(valuePool: .orchard)
+        let input = Self.makeProposedInput(FfiProposedInput.OneOf_Value.receivedOutput(output))
+        let proposal = Self.makeProposal(steps: [Self.makeStep(inputs: [input])])
+
+        XCTAssertTrue(proposal.spendsLegacyOrchardFunds)
+    }
+
+    func testSaplingAndTransparentInputsDoNotSpendLegacyOrchardFunds() {
+        let saplingOutput = Self.makeReceivedOutput(valuePool: .sapling)
+        let transparentOutput = Self.makeReceivedOutput(valuePool: .transparent)
+        let inputs = [
+            Self.makeProposedInput(FfiProposedInput.OneOf_Value.receivedOutput(saplingOutput)),
+            Self.makeProposedInput(FfiProposedInput.OneOf_Value.receivedOutput(transparentOutput))
+        ]
+        let proposal = Self.makeProposal(steps: [Self.makeStep(inputs: inputs)])
+
+        XCTAssertFalse(proposal.spendsLegacyOrchardFunds)
+    }
+
+    func testIronwoodInputDoesNotCountAsOrchard() {
+        let output = Self.makeReceivedOutput(valuePool: FfiValuePool.UNRECOGNIZED(4))
+        let input = Self.makeProposedInput(FfiProposedInput.OneOf_Value.receivedOutput(output))
+        let proposal = Self.makeProposal(steps: [Self.makeStep(inputs: [input])])
+
+        XCTAssertFalse(proposal.spendsLegacyOrchardFunds)
+    }
+
+    func testPriorStepReferencesDoNotCountAsWalletNotes() {
+        var priorStepOutput = FfiPriorStepOutput()
+        priorStepOutput.stepIndex = 0
+        priorStepOutput.paymentIndex = 0
+
+        var priorStepChange = FfiPriorStepChange()
+        priorStepChange.stepIndex = 0
+        priorStepChange.changeIndex = 0
+
+        let inputs = [
+            Self.makeProposedInput(FfiProposedInput.OneOf_Value.priorStepOutput(priorStepOutput)),
+            Self.makeProposedInput(FfiProposedInput.OneOf_Value.priorStepChange(priorStepChange))
+        ]
+        let proposal = Self.makeProposal(steps: [Self.makeStep(inputs: inputs)])
+
+        XCTAssertFalse(proposal.spendsLegacyOrchardFunds)
+    }
+
+    func testOrchardInputInSecondStepIsDetected() {
+        let transparentOutput = Self.makeReceivedOutput(valuePool: .transparent)
+        let firstStep = Self.makeStep(
+            inputs: [Self.makeProposedInput(FfiProposedInput.OneOf_Value.receivedOutput(transparentOutput))]
+        )
+
+        let orchardOutput = Self.makeReceivedOutput(valuePool: .orchard)
+        let secondStep = Self.makeStep(
+            inputs: [Self.makeProposedInput(FfiProposedInput.OneOf_Value.receivedOutput(orchardOutput))]
+        )
+
+        let proposal = Self.makeProposal(steps: [firstStep, secondStep])
+
+        XCTAssertTrue(proposal.spendsLegacyOrchardFunds)
+    }
+
+    func testProposalWithNoStepsDoesNotSpendLegacyOrchardFunds() {
+        let proposal = Self.makeProposal(steps: [])
+
+        XCTAssertFalse(proposal.spendsLegacyOrchardFunds)
+    }
+
+    func testFactoryDefaultsToNotSpendingLegacyOrchardFunds() {
+        let proposal = Proposal.testOnlyFakeProposal(totalFee: 0)
+
+        XCTAssertFalse(proposal.spendsLegacyOrchardFunds)
+    }
+
+    func testFactoryCanProduceProposalThatSpendsLegacyOrchardFunds() {
+        let proposal = Proposal.testOnlyFakeProposal(totalFee: 0, spendsLegacyOrchardFunds: true)
+
+        XCTAssertTrue(proposal.spendsLegacyOrchardFunds)
+    }
+
+    // MARK: - Helpers
+
+    private static func makeReceivedOutput(
+        valuePool: FfiValuePool,
+        index: UInt32 = 0,
+        value: UInt64 = 0
+    ) -> FfiReceivedOutput {
+        var output = FfiReceivedOutput()
+        output.txid = Data(repeating: 0xAB, count: 32)
+        output.valuePool = valuePool
+        output.index = index
+        output.value = value
+        return output
+    }
+
+    private static func makeProposedInput(_ value: FfiProposedInput.OneOf_Value) -> FfiProposedInput {
+        var input = FfiProposedInput()
+        input.value = value
+        return input
+    }
+
+    private static func makeStep(inputs: [FfiProposedInput]) -> FfiProposalStep {
+        var step = FfiProposalStep()
+        step.inputs = inputs
+        return step
+    }
+
+    private static func makeProposal(steps: [FfiProposalStep]) -> Proposal {
+        var ffiProposal = FfiProposal()
+        ffiProposal.steps = steps
+        return Proposal(inner: ffiProposal)
+    }
+}

--- a/Tests/OfflineTests/ProposalSpendsOrchardTests.swift
+++ b/Tests/OfflineTests/ProposalSpendsOrchardTests.swift
@@ -27,8 +27,11 @@ final class ProposalSpendsOrchardTests: XCTestCase {
         XCTAssertFalse(proposal.spendsLegacyOrchardFunds)
     }
 
-    func testIronwoodInputDoesNotCountAsOrchard() {
-        let output = Self.makeReceivedOutput(valuePool: FfiValuePool.UNRECOGNIZED(4))
+    func testIronwoodInputDoesNotCountAsOrchard() throws {
+        // Construct via `rawValue:` rather than `.UNRECOGNIZED(4)` directly, so this test keeps covering
+        // Ironwood decode-path-stable even after a future proto regeneration names case 4.
+        let ironwoodPool = try XCTUnwrap(FfiValuePool(rawValue: 4))
+        let output = Self.makeReceivedOutput(valuePool: ironwoodPool)
         let input = Self.makeProposedInput(FfiProposedInput.OneOf_Value.receivedOutput(output))
         let proposal = Self.makeProposal(steps: [Self.makeStep(inputs: [input])])
 
@@ -85,6 +88,20 @@ final class ProposalSpendsOrchardTests: XCTestCase {
         let proposal = Proposal.testOnlyFakeProposal(totalFee: 0, spendsLegacyOrchardFunds: true)
 
         XCTAssertTrue(proposal.spendsLegacyOrchardFunds)
+    }
+
+    func testFactoryTotalFeeIsZeroInBothBranches() {
+        // testOnlyFakeProposal never attaches its `balance` (and thus `totalFee`) to any step, in either
+        // branch, so totalFeeRequired() is always Zatoshi.zero. Pin both branches so a future edit can't
+        // change fee behavior in only one of them.
+        XCTAssertEqual(
+            Proposal.testOnlyFakeProposal(totalFee: 10, spendsLegacyOrchardFunds: false).totalFeeRequired(),
+            Zatoshi.zero
+        )
+        XCTAssertEqual(
+            Proposal.testOnlyFakeProposal(totalFee: 10, spendsLegacyOrchardFunds: true).totalFeeRequired(),
+            Zatoshi.zero
+        )
     }
 
     // MARK: - Helpers


### PR DESCRIPTION
## Summary

Adds a public `Proposal.spendsLegacyOrchardFunds` property so wallets can detect — before creating the transactions — that a payment proposal will spend notes from the legacy Orchard pool. Post-NU6.3, spending legacy Orchard notes crosses the Orchard turnstile, publicly revealing the value that leaves the pool; wallets use this to warn the user before sending (ZODL's send-confirmation screen is the first consumer).

## Semantics

- `true` iff any proposal step has an input whose oneof value is a `receivedOutput` with `valuePool == .orchard`.
- Prior-step references never count: they point at outputs created by an earlier step of the same proposal, so any legacy-Orchard value entering the proposal necessarily appears as a `receivedOutput` in some step (this also keeps ZIP 320 TEX two-step proposals correct).
- Ironwood (ZIP 2005) inputs — FFI pool value 4, currently decoding as `UNRECOGNIZED(4)` under the vendored proto — never count as Orchard. Refreshing the vendored `proposal.proto` to name the Ironwood case is deliberately out of scope here.
- The property describes the proposal's inputs only; it is activation-agnostic. Callers that warn should apply their own network context if they support pre-activation networks.

`Proposal.testOnlyFakeProposal(totalFee:)` gains a defaulted `spendsLegacyOrchardFunds:` parameter (source-compatible) so client apps can build fixtures for both cases; its pre-existing fee behavior (fakes report a zero `totalFeeRequired()`) is intentionally unchanged and now pinned by a test in both branches.

## Testing

- New `Tests/OfflineTests/ProposalSpendsOrchardTests.swift`: orchard input, sapling/transparent-only, Ironwood raw-4 input (built via `FfiValuePool(rawValue: 4)` so the test survives a future proto regeneration), prior-step-only inputs, orchard in a later step, empty proposal, factory both variants, and the factory fee pin.
- `swift test --filter OfflineTests`: 405 tests, 0 failures.

No linked issue by agreement for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
