### PR TITLE
[MOB-1466] Interim librustzcash pin + NULL trust_status decode fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,15 @@ Changes are relative to `2.8.0-rc.3`.
 
 ## Changed
 
-- The librustzcash family rides an interim git pin (librustzcash PR #2909) so a wallet's own
-  scheduled migration transactions carry their ZIP 318 classification (`Overview.zip318Kind`)
-  from the moment they are STORED at proving time, instead of only after they mine and are
-  scanned. This is what lets a wallet hold stored-but-unmined migration transactions out of its
-  activity list. The pin reverts to published crates at the first rc containing that PR.
+- The librustzcash family rides an interim git pin (librustzcash main at the #2909 merge) so a
+  wallet's own scheduled migration transactions carry their ZIP 318 classification
+  (`Overview.zip318Kind`) from the moment they are STORED at proving time, instead of only after
+  they mine and are scanned. This is what lets a wallet hold stored-but-unmined migration
+  transactions out of its activity list. The rev also carries librustzcash #2907: the engine's
+  advance-path selection (prove/broadcast steps) now picks transfers by scheduled height instead
+  of internal id. (The SDK's own next-due delivery query still selects by id — tracked
+  separately as the MOB-1466 M2 residual.) The pin reverts to published crates at the first rc
+  containing both.
 
 ## Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Changes are relative to `2.8.0-rc.3`.
 
+## Changed
+
+- The librustzcash family rides an interim git pin (librustzcash PR #2909) so a wallet's own
+  scheduled migration transactions carry their ZIP 318 classification (`Overview.zip318Kind`)
+  from the moment they are STORED at proving time, instead of only after they mine and are
+  scanned. This is what lets a wallet hold stored-but-unmined migration transactions out of its
+  activity list. The pin reverts to published crates at the first rc containing that PR.
+
 ## Fixed
 
 - `SimpleConnectionProvider`'s lazy connection init is now lock-guarded: two concurrent

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,13 @@ Changes are relative to `2.8.0-rc.3`.
 
 ## Fixed
 
+- Fetching transactions no longer fails on wallets whose `trust_status` column is NULL — which is
+  every wallet today, since transaction trust (`set_tx_trust`) is an opt-in marker with no default,
+  no backfill, and no caller yet. The strict `Overview` decode threw on the first row and the whole
+  `getAllTransactions` failed, rendering an empty transaction list over a fully-populated wallet. A
+  NULL now decodes as untrusted, matching librustzcash's own `IFNULL(trust_status, 0)` readers, and
+  a regression test decodes real migrated rows through `v_transactions` so no future nullable view
+  column can silently kill the fetch again.
 - `SimpleConnectionProvider`'s lazy connection init is now lock-guarded: two concurrent
   first-touch reads (possible since read-only calls left the database actor) could race the
   unsynchronized check-then-assign and construct two SQLite connections, silently dropping

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -488,7 +488,7 @@ dependencies = [
  "bitflags",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "log",
  "prettyplease 0.2.37",
  "proc-macro2",
@@ -1318,7 +1318,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d308ebe4b10924331bd079044b418da7b227d724d3e2408567a47ad7c3da2a0"
 dependencies = [
  "derive-deftly-macros",
- "heck 0.4.1",
+ "heck 0.5.0",
 ]
 
 [[package]]
@@ -1327,9 +1327,9 @@ version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd5f2b7218a51c827a11d22d1439b598121fac94bf9b99452e4afffe512d78c9"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "indexmap 2.14.0",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "proc-macro-crate",
  "proc-macro2",
  "quote",
@@ -1454,7 +1454,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1680,7 +1680,7 @@ dependencies = [
 [[package]]
 name = "equihash"
 version = "0.3.0"
-source = "git+https://github.com/zcash/librustzcash?rev=ebee7a8ad8803121180d494351a9fc76ba270a60#ebee7a8ad8803121180d494351a9fc76ba270a60"
+source = "git+https://github.com/zcash/librustzcash?rev=b49e2cb3f96e77cd97a0b350cbf0eadfaa0ef05c#b49e2cb3f96e77cd97a0b350cbf0eadfaa0ef05c"
 dependencies = [
  "blake2b_simd",
  "corez",
@@ -1699,7 +1699,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1716,7 +1716,7 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.1"
-source = "git+https://github.com/zcash/librustzcash?rev=ebee7a8ad8803121180d494351a9fc76ba270a60#ebee7a8ad8803121180d494351a9fc76ba270a60"
+source = "git+https://github.com/zcash/librustzcash?rev=b49e2cb3f96e77cd97a0b350cbf0eadfaa0ef05c#b49e2cb3f96e77cd97a0b350cbf0eadfaa0ef05c"
 dependencies = [
  "blake2b_simd",
 ]
@@ -2786,7 +2786,7 @@ version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a1886916523694cd6ea3d175f03a1e5010699a2a4cc13696d83d7bea1d80638"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3234,7 +3234,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3610,7 +3610,7 @@ checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
 [[package]]
 name = "pczt"
 version = "0.9.2"
-source = "git+https://github.com/zcash/librustzcash?rev=ebee7a8ad8803121180d494351a9fc76ba270a60#ebee7a8ad8803121180d494351a9fc76ba270a60"
+source = "git+https://github.com/zcash/librustzcash?rev=b49e2cb3f96e77cd97a0b350cbf0eadfaa0ef05c#b49e2cb3f96e77cd97a0b350cbf0eadfaa0ef05c"
 dependencies = [
  "blake2b_simd",
  "bls12_381",
@@ -4050,8 +4050,8 @@ version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
 dependencies = [
- "heck 0.4.1",
- "itertools 0.10.5",
+ "heck 0.5.0",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "petgraph 0.8.3",
@@ -4083,7 +4083,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -4550,7 +4550,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5137,7 +5137,7 @@ version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -5354,7 +5354,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7355,7 +7355,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7797,7 +7797,7 @@ dependencies = [
 [[package]]
 name = "zcash_address"
 version = "0.13.0"
-source = "git+https://github.com/zcash/librustzcash?rev=ebee7a8ad8803121180d494351a9fc76ba270a60#ebee7a8ad8803121180d494351a9fc76ba270a60"
+source = "git+https://github.com/zcash/librustzcash?rev=b49e2cb3f96e77cd97a0b350cbf0eadfaa0ef05c#b49e2cb3f96e77cd97a0b350cbf0eadfaa0ef05c"
 dependencies = [
  "bech32",
  "bs58",
@@ -7810,7 +7810,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_backend"
 version = "0.24.0-rc.7"
-source = "git+https://github.com/zcash/librustzcash?rev=ebee7a8ad8803121180d494351a9fc76ba270a60#ebee7a8ad8803121180d494351a9fc76ba270a60"
+source = "git+https://github.com/zcash/librustzcash?rev=b49e2cb3f96e77cd97a0b350cbf0eadfaa0ef05c#b49e2cb3f96e77cd97a0b350cbf0eadfaa0ef05c"
 dependencies = [
  "arti-client",
  "base64",
@@ -7877,7 +7877,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_sqlite"
 version = "0.22.0-rc.7"
-source = "git+https://github.com/zcash/librustzcash?rev=ebee7a8ad8803121180d494351a9fc76ba270a60#ebee7a8ad8803121180d494351a9fc76ba270a60"
+source = "git+https://github.com/zcash/librustzcash?rev=b49e2cb3f96e77cd97a0b350cbf0eadfaa0ef05c#b49e2cb3f96e77cd97a0b350cbf0eadfaa0ef05c"
 dependencies = [
  "bip32",
  "bitflags",
@@ -7937,7 +7937,7 @@ dependencies = [
 [[package]]
 name = "zcash_keys"
 version = "0.16.1"
-source = "git+https://github.com/zcash/librustzcash?rev=ebee7a8ad8803121180d494351a9fc76ba270a60#ebee7a8ad8803121180d494351a9fc76ba270a60"
+source = "git+https://github.com/zcash/librustzcash?rev=b49e2cb3f96e77cd97a0b350cbf0eadfaa0ef05c#b49e2cb3f96e77cd97a0b350cbf0eadfaa0ef05c"
 dependencies = [
  "bech32",
  "bip32",
@@ -7979,7 +7979,7 @@ dependencies = [
 [[package]]
 name = "zcash_pool_migration"
 version = "0.1.0-rc.6"
-source = "git+https://github.com/zcash/librustzcash?rev=ebee7a8ad8803121180d494351a9fc76ba270a60#ebee7a8ad8803121180d494351a9fc76ba270a60"
+source = "git+https://github.com/zcash/librustzcash?rev=b49e2cb3f96e77cd97a0b350cbf0eadfaa0ef05c#b49e2cb3f96e77cd97a0b350cbf0eadfaa0ef05c"
 dependencies = [
  "corez",
  "getset",
@@ -7999,7 +7999,7 @@ dependencies = [
 [[package]]
 name = "zcash_primitives"
 version = "0.30.0"
-source = "git+https://github.com/zcash/librustzcash?rev=ebee7a8ad8803121180d494351a9fc76ba270a60#ebee7a8ad8803121180d494351a9fc76ba270a60"
+source = "git+https://github.com/zcash/librustzcash?rev=b49e2cb3f96e77cd97a0b350cbf0eadfaa0ef05c#b49e2cb3f96e77cd97a0b350cbf0eadfaa0ef05c"
 dependencies = [
  "blake2b_simd",
  "block-buffer 0.11.0-rc.3",
@@ -8029,7 +8029,7 @@ dependencies = [
 [[package]]
 name = "zcash_proofs"
 version = "0.30.0"
-source = "git+https://github.com/zcash/librustzcash?rev=ebee7a8ad8803121180d494351a9fc76ba270a60#ebee7a8ad8803121180d494351a9fc76ba270a60"
+source = "git+https://github.com/zcash/librustzcash?rev=b49e2cb3f96e77cd97a0b350cbf0eadfaa0ef05c#b49e2cb3f96e77cd97a0b350cbf0eadfaa0ef05c"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -8050,7 +8050,7 @@ dependencies = [
 [[package]]
 name = "zcash_protocol"
 version = "0.10.4"
-source = "git+https://github.com/zcash/librustzcash?rev=ebee7a8ad8803121180d494351a9fc76ba270a60#ebee7a8ad8803121180d494351a9fc76ba270a60"
+source = "git+https://github.com/zcash/librustzcash?rev=b49e2cb3f96e77cd97a0b350cbf0eadfaa0ef05c#b49e2cb3f96e77cd97a0b350cbf0eadfaa0ef05c"
 dependencies = [
  "corez",
  "document-features",
@@ -8088,7 +8088,7 @@ dependencies = [
 [[package]]
 name = "zcash_transparent"
 version = "0.10.0"
-source = "git+https://github.com/zcash/librustzcash?rev=ebee7a8ad8803121180d494351a9fc76ba270a60#ebee7a8ad8803121180d494351a9fc76ba270a60"
+source = "git+https://github.com/zcash/librustzcash?rev=b49e2cb3f96e77cd97a0b350cbf0eadfaa0ef05c#b49e2cb3f96e77cd97a0b350cbf0eadfaa0ef05c"
 dependencies = [
  "bip32",
  "bs58",
@@ -8181,7 +8181,7 @@ dependencies = [
 [[package]]
 name = "zip321"
 version = "0.9.0-rc.1"
-source = "git+https://github.com/zcash/librustzcash?rev=ebee7a8ad8803121180d494351a9fc76ba270a60#ebee7a8ad8803121180d494351a9fc76ba270a60"
+source = "git+https://github.com/zcash/librustzcash?rev=b49e2cb3f96e77cd97a0b350cbf0eadfaa0ef05c#b49e2cb3f96e77cd97a0b350cbf0eadfaa0ef05c"
 dependencies = [
  "base64",
  "nom",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -488,7 +488,7 @@ dependencies = [
  "bitflags",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.10.5",
  "log",
  "prettyplease 0.2.37",
  "proc-macro2",
@@ -1318,7 +1318,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d308ebe4b10924331bd079044b418da7b227d724d3e2408567a47ad7c3da2a0"
 dependencies = [
  "derive-deftly-macros",
- "heck 0.5.0",
+ "heck 0.4.1",
 ]
 
 [[package]]
@@ -1327,9 +1327,9 @@ version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd5f2b7218a51c827a11d22d1439b598121fac94bf9b99452e4afffe512d78c9"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "indexmap 2.14.0",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro-crate",
  "proc-macro2",
  "quote",
@@ -1454,7 +1454,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1680,8 +1680,7 @@ dependencies = [
 [[package]]
 name = "equihash"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "306286e8dcc39ab3dfceb74c792ce8baffdab90591321d3ffaae64829734c37f"
+source = "git+https://github.com/zcash/librustzcash?rev=ebee7a8ad8803121180d494351a9fc76ba270a60#ebee7a8ad8803121180d494351a9fc76ba270a60"
 dependencies = [
  "blake2b_simd",
  "corez",
@@ -1700,7 +1699,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1717,8 +1716,7 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d42773cb15447644d170be20231a3268600e0c4cea8987d013b93ac973d3cf7"
+source = "git+https://github.com/zcash/librustzcash?rev=ebee7a8ad8803121180d494351a9fc76ba270a60#ebee7a8ad8803121180d494351a9fc76ba270a60"
 dependencies = [
  "blake2b_simd",
 ]
@@ -2788,7 +2786,7 @@ version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a1886916523694cd6ea3d175f03a1e5010699a2a4cc13696d83d7bea1d80638"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3236,7 +3234,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3604,10 +3602,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "pastey"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
+
+[[package]]
 name = "pczt"
 version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aead0b7ecb4363d8560ac76687c02ef896292fb836c1c68f3a4d99443f32e1a0"
+source = "git+https://github.com/zcash/librustzcash?rev=ebee7a8ad8803121180d494351a9fc76ba270a60#ebee7a8ad8803121180d494351a9fc76ba270a60"
 dependencies = [
  "blake2b_simd",
  "bls12_381",
@@ -4047,8 +4050,8 @@ version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
 dependencies = [
- "heck 0.5.0",
- "itertools 0.14.0",
+ "heck 0.4.1",
+ "itertools 0.10.5",
  "log",
  "multimap",
  "petgraph 0.8.3",
@@ -4080,7 +4083,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -4547,7 +4550,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5134,7 +5137,7 @@ version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -5351,7 +5354,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7352,7 +7355,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7794,8 +7797,7 @@ dependencies = [
 [[package]]
 name = "zcash_address"
 version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a854b28c07dba372f4410ea8ad62b4bf7d5c2bf8be32fc4b31bc0db6521a975"
+source = "git+https://github.com/zcash/librustzcash?rev=ebee7a8ad8803121180d494351a9fc76ba270a60#ebee7a8ad8803121180d494351a9fc76ba270a60"
 dependencies = [
  "bech32",
  "bs58",
@@ -7808,8 +7810,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_backend"
 version = "0.24.0-rc.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f49636f1d22b0511b2a117548cc9dcf569440a3589b06bf6df422c6b738f6231"
+source = "git+https://github.com/zcash/librustzcash?rev=ebee7a8ad8803121180d494351a9fc76ba270a60#ebee7a8ad8803121180d494351a9fc76ba270a60"
 dependencies = [
  "arti-client",
  "base64",
@@ -7876,8 +7877,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_sqlite"
 version = "0.22.0-rc.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc7a9511b23d123fabf23b797e9d750dabe69bd31ebcfd2de9423e0f5c0a3c73"
+source = "git+https://github.com/zcash/librustzcash?rev=ebee7a8ad8803121180d494351a9fc76ba270a60#ebee7a8ad8803121180d494351a9fc76ba270a60"
 dependencies = [
  "bip32",
  "bitflags",
@@ -7891,6 +7891,7 @@ dependencies = [
  "maybe-rayon",
  "nonempty",
  "orchard",
+ "pastey",
  "pczt",
  "prost 0.14.4",
  "rand 0.8.7",
@@ -7936,8 +7937,7 @@ dependencies = [
 [[package]]
 name = "zcash_keys"
 version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "def800f128e459eedebc900f36f408eaf0687634128dcf64ecfeaeebc3e16c14"
+source = "git+https://github.com/zcash/librustzcash?rev=ebee7a8ad8803121180d494351a9fc76ba270a60#ebee7a8ad8803121180d494351a9fc76ba270a60"
 dependencies = [
  "bech32",
  "bip32",
@@ -7979,8 +7979,7 @@ dependencies = [
 [[package]]
 name = "zcash_pool_migration"
 version = "0.1.0-rc.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efb981e23ad66171cfad0bd4e0ed481f771d317ff7f14148a4fd49e85f0a1307"
+source = "git+https://github.com/zcash/librustzcash?rev=ebee7a8ad8803121180d494351a9fc76ba270a60#ebee7a8ad8803121180d494351a9fc76ba270a60"
 dependencies = [
  "corez",
  "getset",
@@ -8000,8 +7999,7 @@ dependencies = [
 [[package]]
 name = "zcash_primitives"
 version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34ca4de11896f704ffe6319c2cd7bc8fc6ab31a55cec80d26def15c009d83678"
+source = "git+https://github.com/zcash/librustzcash?rev=ebee7a8ad8803121180d494351a9fc76ba270a60#ebee7a8ad8803121180d494351a9fc76ba270a60"
 dependencies = [
  "blake2b_simd",
  "block-buffer 0.11.0-rc.3",
@@ -8031,8 +8029,7 @@ dependencies = [
 [[package]]
 name = "zcash_proofs"
 version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea125021aaa749e966989c7f7aaa18afe2f89474573f5f0dfac8b98083a6d095"
+source = "git+https://github.com/zcash/librustzcash?rev=ebee7a8ad8803121180d494351a9fc76ba270a60#ebee7a8ad8803121180d494351a9fc76ba270a60"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -8053,8 +8050,7 @@ dependencies = [
 [[package]]
 name = "zcash_protocol"
 version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "043686451284bcb72e40ffa18e2cdcea3108e8468e3d021062c0b32c4a060c98"
+source = "git+https://github.com/zcash/librustzcash?rev=ebee7a8ad8803121180d494351a9fc76ba270a60#ebee7a8ad8803121180d494351a9fc76ba270a60"
 dependencies = [
  "corez",
  "document-features",
@@ -8092,8 +8088,7 @@ dependencies = [
 [[package]]
 name = "zcash_transparent"
 version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "547c012778bae17f58007731af074d638aa146ab0ecfc120adebf23d049aff6c"
+source = "git+https://github.com/zcash/librustzcash?rev=ebee7a8ad8803121180d494351a9fc76ba270a60#ebee7a8ad8803121180d494351a9fc76ba270a60"
 dependencies = [
  "bip32",
  "bs58",
@@ -8186,8 +8181,7 @@ dependencies = [
 [[package]]
 name = "zip321"
 version = "0.9.0-rc.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb464491970d9b61889e4f2b7b00fb9f471a33692e5c0de3122fdc575d8067ab"
+source = "git+https://github.com/zcash/librustzcash?rev=ebee7a8ad8803121180d494351a9fc76ba270a60#ebee7a8ad8803121180d494351a9fc76ba270a60"
 dependencies = [
  "base64",
  "nom",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -163,20 +163,21 @@ lto = true
 slipstream-core = { git = "https://github.com/zodl-inc/slipstream.git", rev = "ab89ada45f2ef893a05fcefa0ead99f87d848a4e" }
 
 ## Update the `rev` value in the following lines to use a hash-pinned version of the librustzcash crates.
-# INTERIM PIN (MOB-1466 M3): librustzcash PR #2909 — migration transactions classified against
-# ZIP 318 at store time, which is what activates the app's unmined-migration Activity filter.
-# Remove this pin (recomment the block) at the first published rc that contains the PR.
-pczt = { git = "https://github.com/zcash/librustzcash", rev = "ebee7a8ad8803121180d494351a9fc76ba270a60" }
-zcash_address = { git = "https://github.com/zcash/librustzcash", rev = "ebee7a8ad8803121180d494351a9fc76ba270a60" }
-zcash_client_backend = { git = "https://github.com/zcash/librustzcash", rev = "ebee7a8ad8803121180d494351a9fc76ba270a60" }
-zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash", rev = "ebee7a8ad8803121180d494351a9fc76ba270a60" }
-zcash_keys = { git = "https://github.com/zcash/librustzcash", rev = "ebee7a8ad8803121180d494351a9fc76ba270a60" }
-zcash_pool_migration = { git = "https://github.com/zcash/librustzcash", rev = "ebee7a8ad8803121180d494351a9fc76ba270a60" }
-zcash_primitives = { git = "https://github.com/zcash/librustzcash", rev = "ebee7a8ad8803121180d494351a9fc76ba270a60" }
-zcash_proofs = { git = "https://github.com/zcash/librustzcash", rev = "ebee7a8ad8803121180d494351a9fc76ba270a60" }
-zcash_protocol = { git = "https://github.com/zcash/librustzcash", rev = "ebee7a8ad8803121180d494351a9fc76ba270a60" }
-zcash_transparent = { git = "https://github.com/zcash/librustzcash", rev = "ebee7a8ad8803121180d494351a9fc76ba270a60" }
-zip321 = { git = "https://github.com/zcash/librustzcash", rev = "ebee7a8ad8803121180d494351a9fc76ba270a60" }
+# INTERIM PIN (MOB-1466 M3): librustzcash main at the #2909 merge — migration transactions
+# classified against ZIP 318 at store time (activates the app's unmined-migration Activity
+# filter). This rev also carries #2907 (engine next_* selection ordered by height). Remove the
+# pin (recomment the block) at the first published rc that contains both.
+pczt = { git = "https://github.com/zcash/librustzcash", rev = "b49e2cb3f96e77cd97a0b350cbf0eadfaa0ef05c" }
+zcash_address = { git = "https://github.com/zcash/librustzcash", rev = "b49e2cb3f96e77cd97a0b350cbf0eadfaa0ef05c" }
+zcash_client_backend = { git = "https://github.com/zcash/librustzcash", rev = "b49e2cb3f96e77cd97a0b350cbf0eadfaa0ef05c" }
+zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash", rev = "b49e2cb3f96e77cd97a0b350cbf0eadfaa0ef05c" }
+zcash_keys = { git = "https://github.com/zcash/librustzcash", rev = "b49e2cb3f96e77cd97a0b350cbf0eadfaa0ef05c" }
+zcash_pool_migration = { git = "https://github.com/zcash/librustzcash", rev = "b49e2cb3f96e77cd97a0b350cbf0eadfaa0ef05c" }
+zcash_primitives = { git = "https://github.com/zcash/librustzcash", rev = "b49e2cb3f96e77cd97a0b350cbf0eadfaa0ef05c" }
+zcash_proofs = { git = "https://github.com/zcash/librustzcash", rev = "b49e2cb3f96e77cd97a0b350cbf0eadfaa0ef05c" }
+zcash_protocol = { git = "https://github.com/zcash/librustzcash", rev = "b49e2cb3f96e77cd97a0b350cbf0eadfaa0ef05c" }
+zcash_transparent = { git = "https://github.com/zcash/librustzcash", rev = "b49e2cb3f96e77cd97a0b350cbf0eadfaa0ef05c" }
+zip321 = { git = "https://github.com/zcash/librustzcash", rev = "b49e2cb3f96e77cd97a0b350cbf0eadfaa0ef05c" }
 
 # Reinstate together with the voting dependencies above:
 # zcash_voting = { git = "https://github.com/valargroup/zcash_voting.git", rev = "e53e74487d31ad0f5713580fb2f0222b53ae9db8" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -163,17 +163,20 @@ lto = true
 slipstream-core = { git = "https://github.com/zodl-inc/slipstream.git", rev = "ab89ada45f2ef893a05fcefa0ead99f87d848a4e" }
 
 ## Update the `rev` value in the following lines to use a hash-pinned version of the librustzcash crates.
-# pczt = { git = "https://github.com/zcash/librustzcash", rev = "REPLACE_ME" }
-# zcash_address = { git = "https://github.com/zcash/librustzcash", rev = "REPLACE_ME" }
-# zcash_client_backend = { git = "https://github.com/zcash/librustzcash", rev = "REPLACE_ME" }
-# zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash", rev = "REPLACE_ME" }
-# zcash_keys = { git = "https://github.com/zcash/librustzcash", rev = "REPLACE_ME" }
-# zcash_pool_migration = { git = "https://github.com/zcash/librustzcash", rev = "REPLACE_ME" }
-# zcash_primitives = { git = "https://github.com/zcash/librustzcash", rev = "REPLACE_ME" }
-# zcash_proofs = { git = "https://github.com/zcash/librustzcash", rev = "REPLACE_ME" }
-# zcash_protocol = { git = "https://github.com/zcash/librustzcash", rev = "REPLACE_ME" }
-# zcash_transparent = { git = "https://github.com/zcash/librustzcash", rev = "REPLACE_ME" }
-# zip321 = { git = "https://github.com/zcash/librustzcash", rev = "REPLACE_ME" }
+# INTERIM PIN (MOB-1466 M3): librustzcash PR #2909 — migration transactions classified against
+# ZIP 318 at store time, which is what activates the app's unmined-migration Activity filter.
+# Remove this pin (recomment the block) at the first published rc that contains the PR.
+pczt = { git = "https://github.com/zcash/librustzcash", rev = "ebee7a8ad8803121180d494351a9fc76ba270a60" }
+zcash_address = { git = "https://github.com/zcash/librustzcash", rev = "ebee7a8ad8803121180d494351a9fc76ba270a60" }
+zcash_client_backend = { git = "https://github.com/zcash/librustzcash", rev = "ebee7a8ad8803121180d494351a9fc76ba270a60" }
+zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash", rev = "ebee7a8ad8803121180d494351a9fc76ba270a60" }
+zcash_keys = { git = "https://github.com/zcash/librustzcash", rev = "ebee7a8ad8803121180d494351a9fc76ba270a60" }
+zcash_pool_migration = { git = "https://github.com/zcash/librustzcash", rev = "ebee7a8ad8803121180d494351a9fc76ba270a60" }
+zcash_primitives = { git = "https://github.com/zcash/librustzcash", rev = "ebee7a8ad8803121180d494351a9fc76ba270a60" }
+zcash_proofs = { git = "https://github.com/zcash/librustzcash", rev = "ebee7a8ad8803121180d494351a9fc76ba270a60" }
+zcash_protocol = { git = "https://github.com/zcash/librustzcash", rev = "ebee7a8ad8803121180d494351a9fc76ba270a60" }
+zcash_transparent = { git = "https://github.com/zcash/librustzcash", rev = "ebee7a8ad8803121180d494351a9fc76ba270a60" }
+zip321 = { git = "https://github.com/zcash/librustzcash", rev = "ebee7a8ad8803121180d494351a9fc76ba270a60" }
 
 # Reinstate together with the voting dependencies above:
 # zcash_voting = { git = "https://github.com/valargroup/zcash_voting.git", rev = "e53e74487d31ad0f5713580fb2f0222b53ae9db8" }

--- a/Sources/ZcashLightClientKit/Entity/TransactionEntity.swift
+++ b/Sources/ZcashLightClientKit/Entity/TransactionEntity.swift
@@ -241,7 +241,12 @@ extension ZcashTransaction.Overview {
         static let totalReceived = SQLite.Expression<Int64?>("total_received")
         static let spentNoteCount = SQLite.Expression<Int>("spent_note_count")
         static let poolCrossingValue = SQLite.Expression<Int64?>("pool_crossing_value")
-        static let trustStatus = SQLite.Expression<Bool>("trust_status")
+        // Optional by contract: `trust_status` is an opt-in marker (`set_tx_trust`) with no
+        // default, no backfill, and — today — no caller anywhere, so it is NULL on every row of
+        // every real wallet. librustzcash's own readers consume it as IFNULL(trust_status, 0);
+        // decoding it strictly threw on the first row and emptied the entire transaction list
+        // (field, 2026-08-04). NULL decodes as "never evaluated" → untrusted.
+        static let trustStatus = SQLite.Expression<Bool?>("trust_status")
         static let zip318Kind = SQLite.Expression<Int>("zip318_kind")
     }
 
@@ -260,7 +265,7 @@ extension ZcashTransaction.Overview {
             self.value = Zatoshi(try row.get(Column.value))
             self.isExpiredUmined = try row.get(Column.expiredUnmined)
             self.spentNoteCount = try row.get(Column.spentNoteCount)
-            self.isTrusted = try row.get(Column.trustStatus)
+            self.isTrusted = (try row.get(Column.trustStatus)) ?? false
             self.zip318Kind = .init(rawValue: try row.get(Column.zip318Kind))
 
             if let poolCrossingValue = try row.get(Column.poolCrossingValue) {

--- a/Tests/OfflineTests/TransactionRepositoryTests.swift
+++ b/Tests/OfflineTests/TransactionRepositoryTests.swift
@@ -39,6 +39,24 @@ class TransactionRepositoryTests: XCTestCase {
         XCTAssertEqual(count, 0)
     }
 
+    /// Regression (2026-08-04, field): every row of a real wallet decodes through `v_transactions`
+    /// even though its stored `trust_status` is NULL — which it IS on every wallet today, because
+    /// `set_tx_trust` is an opt-in API nothing calls yet and the column ships without a default or
+    /// backfill. A strict non-optional decode threw on the FIRST row, the whole fetch failed, and
+    /// the app rendered an empty transaction list over a fully-populated wallet.
+    ///
+    /// This is also the suite's only live test that decodes an `Overview` from the real migrated
+    /// schema (the `_testFind…` family above is disabled, #1518): if a future migration adds
+    /// another nullable column to the view that the decode reads strictly, this is what fails.
+    func testFindAllDecodesRowsWhoseStoredTrustStatusIsNull() async throws {
+        let transactions = try await self.transactionRepository.find(offset: 0, limit: Int.max, kind: .all)
+
+        XCTAssertEqual(transactions.count, 21, "every fixture row must decode — one NULL must never empty the list")
+        transactions.forEach {
+            XCTAssertFalse($0.isTrusted, "an unevaluated (NULL) trust_status reads as untrusted, matching IFNULL(trust_status, 0)")
+        }
+    }
+
     // TODO: [#1518] Fix the test, https://github.com/Electric-Coin-Company/zcash-swift-wallet-sdk/issues/1518
     func _testFindInRange() async throws {
         let transactions = try await self.transactionRepository.find(in: 663218...663974, limit: 3, kind: .received)


### PR DESCRIPTION
Three commits, two concerns:

## Interim librustzcash pin (8f962d47, da94c695)

Pins the librustzcash family via the `[patch.crates-io]` template to **main at the zcash/librustzcash#2909 merge** (`b49e2cb3`). What it delivers over the published rc.7/rc.6 line:

- **zcash/librustzcash#2909** — migration transactions are ZIP 318-classified at store-at-prove time, not only after they mine. This is what activates the app's unmined-migration Activity filter for the whole prove→broadcast window (M3).
- **zcash/librustzcash#2907** — the engine's advance-path selection picks prove/broadcast steps by scheduled height instead of internal id (M2's engine half). Note: the SDK's own next-due delivery query still selects by id — tracked separately as the M2 residual.

Interim by design: the Cargo.toml comment and CHANGELOG both say to recomment the block at the first published rc containing both PRs. Pinned to the merge-commit hash (permanently reachable), never a branch.

## NULL `trust_status` decode fix (bc63f42f)

`trust_status` is an opt-in marker (`set_tx_trust`) with no default, no backfill, and no production caller anywhere yet, so it is NULL on every row of every real wallet. The `Overview` decode read it as a strict non-optional `Bool`: the first row threw, the entire `getAllTransactions` failed, and the app rendered an **empty transaction list over a fully-populated wallet** (field, 2026-08-04) — silently, because the only live tests on this path were COUNT queries (the `_testFind…` family has been disabled since #1518).

NULL now decodes as untrusted — the same interpretation librustzcash's own readers apply with `IFNULL(trust_status, 0)`. The new regression test decodes every row of the real migrated fixture through `v_transactions` (the suite's only live `Overview` decode against the real schema) and reproduced the exact field error red before the fix. The upstream view-side fix is zcash/librustzcash#2919; this decode tolerance protects builds regardless of pin generation.

## Verification

- SDK offline suite: **796/796** (795 + the new regression test), on both pin revs.
- All three FFI slices rebuilt against the pin; full zodl suite on top of this SDK: **1037 tests / 157 suites green**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)