### PR TITLE
TEMPORARY: pin librustzcash to 59ed8930 and adapt to its API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1680,7 +1680,7 @@ dependencies = [
 [[package]]
 name = "equihash"
 version = "0.3.0"
-source = "git+https://github.com/zcash/librustzcash?rev=b49e2cb3f96e77cd97a0b350cbf0eadfaa0ef05c#b49e2cb3f96e77cd97a0b350cbf0eadfaa0ef05c"
+source = "git+https://github.com/zcash/librustzcash?rev=59ed8930b8c6d96ce7c0c44a756d480f7311be8a#59ed8930b8c6d96ce7c0c44a756d480f7311be8a"
 dependencies = [
  "blake2b_simd",
  "corez",
@@ -1716,7 +1716,7 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.1"
-source = "git+https://github.com/zcash/librustzcash?rev=b49e2cb3f96e77cd97a0b350cbf0eadfaa0ef05c#b49e2cb3f96e77cd97a0b350cbf0eadfaa0ef05c"
+source = "git+https://github.com/zcash/librustzcash?rev=59ed8930b8c6d96ce7c0c44a756d480f7311be8a#59ed8930b8c6d96ce7c0c44a756d480f7311be8a"
 dependencies = [
  "blake2b_simd",
 ]
@@ -3610,7 +3610,7 @@ checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
 [[package]]
 name = "pczt"
 version = "0.9.2"
-source = "git+https://github.com/zcash/librustzcash?rev=b49e2cb3f96e77cd97a0b350cbf0eadfaa0ef05c#b49e2cb3f96e77cd97a0b350cbf0eadfaa0ef05c"
+source = "git+https://github.com/zcash/librustzcash?rev=59ed8930b8c6d96ce7c0c44a756d480f7311be8a#59ed8930b8c6d96ce7c0c44a756d480f7311be8a"
 dependencies = [
  "blake2b_simd",
  "bls12_381",
@@ -7797,7 +7797,7 @@ dependencies = [
 [[package]]
 name = "zcash_address"
 version = "0.13.0"
-source = "git+https://github.com/zcash/librustzcash?rev=b49e2cb3f96e77cd97a0b350cbf0eadfaa0ef05c#b49e2cb3f96e77cd97a0b350cbf0eadfaa0ef05c"
+source = "git+https://github.com/zcash/librustzcash?rev=59ed8930b8c6d96ce7c0c44a756d480f7311be8a#59ed8930b8c6d96ce7c0c44a756d480f7311be8a"
 dependencies = [
  "bech32",
  "bs58",
@@ -7810,7 +7810,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_backend"
 version = "0.24.0-rc.7"
-source = "git+https://github.com/zcash/librustzcash?rev=b49e2cb3f96e77cd97a0b350cbf0eadfaa0ef05c#b49e2cb3f96e77cd97a0b350cbf0eadfaa0ef05c"
+source = "git+https://github.com/zcash/librustzcash?rev=59ed8930b8c6d96ce7c0c44a756d480f7311be8a#59ed8930b8c6d96ce7c0c44a756d480f7311be8a"
 dependencies = [
  "arti-client",
  "base64",
@@ -7877,7 +7877,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_sqlite"
 version = "0.22.0-rc.7"
-source = "git+https://github.com/zcash/librustzcash?rev=b49e2cb3f96e77cd97a0b350cbf0eadfaa0ef05c#b49e2cb3f96e77cd97a0b350cbf0eadfaa0ef05c"
+source = "git+https://github.com/zcash/librustzcash?rev=59ed8930b8c6d96ce7c0c44a756d480f7311be8a#59ed8930b8c6d96ce7c0c44a756d480f7311be8a"
 dependencies = [
  "bip32",
  "bitflags",
@@ -7937,7 +7937,7 @@ dependencies = [
 [[package]]
 name = "zcash_keys"
 version = "0.16.1"
-source = "git+https://github.com/zcash/librustzcash?rev=b49e2cb3f96e77cd97a0b350cbf0eadfaa0ef05c#b49e2cb3f96e77cd97a0b350cbf0eadfaa0ef05c"
+source = "git+https://github.com/zcash/librustzcash?rev=59ed8930b8c6d96ce7c0c44a756d480f7311be8a#59ed8930b8c6d96ce7c0c44a756d480f7311be8a"
 dependencies = [
  "bech32",
  "bip32",
@@ -7979,8 +7979,9 @@ dependencies = [
 [[package]]
 name = "zcash_pool_migration"
 version = "0.1.0-rc.6"
-source = "git+https://github.com/zcash/librustzcash?rev=b49e2cb3f96e77cd97a0b350cbf0eadfaa0ef05c#b49e2cb3f96e77cd97a0b350cbf0eadfaa0ef05c"
+source = "git+https://github.com/zcash/librustzcash?rev=59ed8930b8c6d96ce7c0c44a756d480f7311be8a#59ed8930b8c6d96ce7c0c44a756d480f7311be8a"
 dependencies = [
+ "blake2b_simd",
  "corez",
  "getset",
  "incrementalmerkletree",
@@ -7999,7 +8000,7 @@ dependencies = [
 [[package]]
 name = "zcash_primitives"
 version = "0.30.0"
-source = "git+https://github.com/zcash/librustzcash?rev=b49e2cb3f96e77cd97a0b350cbf0eadfaa0ef05c#b49e2cb3f96e77cd97a0b350cbf0eadfaa0ef05c"
+source = "git+https://github.com/zcash/librustzcash?rev=59ed8930b8c6d96ce7c0c44a756d480f7311be8a#59ed8930b8c6d96ce7c0c44a756d480f7311be8a"
 dependencies = [
  "blake2b_simd",
  "block-buffer 0.11.0-rc.3",
@@ -8029,7 +8030,7 @@ dependencies = [
 [[package]]
 name = "zcash_proofs"
 version = "0.30.0"
-source = "git+https://github.com/zcash/librustzcash?rev=b49e2cb3f96e77cd97a0b350cbf0eadfaa0ef05c#b49e2cb3f96e77cd97a0b350cbf0eadfaa0ef05c"
+source = "git+https://github.com/zcash/librustzcash?rev=59ed8930b8c6d96ce7c0c44a756d480f7311be8a#59ed8930b8c6d96ce7c0c44a756d480f7311be8a"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -8050,7 +8051,7 @@ dependencies = [
 [[package]]
 name = "zcash_protocol"
 version = "0.10.4"
-source = "git+https://github.com/zcash/librustzcash?rev=b49e2cb3f96e77cd97a0b350cbf0eadfaa0ef05c#b49e2cb3f96e77cd97a0b350cbf0eadfaa0ef05c"
+source = "git+https://github.com/zcash/librustzcash?rev=59ed8930b8c6d96ce7c0c44a756d480f7311be8a#59ed8930b8c6d96ce7c0c44a756d480f7311be8a"
 dependencies = [
  "corez",
  "document-features",
@@ -8088,7 +8089,7 @@ dependencies = [
 [[package]]
 name = "zcash_transparent"
 version = "0.10.0"
-source = "git+https://github.com/zcash/librustzcash?rev=b49e2cb3f96e77cd97a0b350cbf0eadfaa0ef05c#b49e2cb3f96e77cd97a0b350cbf0eadfaa0ef05c"
+source = "git+https://github.com/zcash/librustzcash?rev=59ed8930b8c6d96ce7c0c44a756d480f7311be8a#59ed8930b8c6d96ce7c0c44a756d480f7311be8a"
 dependencies = [
  "bip32",
  "bs58",
@@ -8181,7 +8182,7 @@ dependencies = [
 [[package]]
 name = "zip321"
 version = "0.9.0-rc.1"
-source = "git+https://github.com/zcash/librustzcash?rev=b49e2cb3f96e77cd97a0b350cbf0eadfaa0ef05c#b49e2cb3f96e77cd97a0b350cbf0eadfaa0ef05c"
+source = "git+https://github.com/zcash/librustzcash?rev=59ed8930b8c6d96ce7c0c44a756d480f7311be8a#59ed8930b8c6d96ce7c0c44a756d480f7311be8a"
 dependencies = [
  "base64",
  "nom",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -163,21 +163,32 @@ lto = true
 slipstream-core = { git = "https://github.com/zodl-inc/slipstream.git", rev = "ab89ada45f2ef893a05fcefa0ead99f87d848a4e" }
 
 ## Update the `rev` value in the following lines to use a hash-pinned version of the librustzcash crates.
-# INTERIM PIN (MOB-1466 M3): librustzcash main at the #2909 merge — migration transactions
-# classified against ZIP 318 at store time (activates the app's unmined-migration Activity
-# filter). This rev also carries #2907 (engine next_* selection ordered by height). Remove the
-# pin (recomment the block) at the first published rc that contains both.
-pczt = { git = "https://github.com/zcash/librustzcash", rev = "b49e2cb3f96e77cd97a0b350cbf0eadfaa0ef05c" }
-zcash_address = { git = "https://github.com/zcash/librustzcash", rev = "b49e2cb3f96e77cd97a0b350cbf0eadfaa0ef05c" }
-zcash_client_backend = { git = "https://github.com/zcash/librustzcash", rev = "b49e2cb3f96e77cd97a0b350cbf0eadfaa0ef05c" }
-zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash", rev = "b49e2cb3f96e77cd97a0b350cbf0eadfaa0ef05c" }
-zcash_keys = { git = "https://github.com/zcash/librustzcash", rev = "b49e2cb3f96e77cd97a0b350cbf0eadfaa0ef05c" }
-zcash_pool_migration = { git = "https://github.com/zcash/librustzcash", rev = "b49e2cb3f96e77cd97a0b350cbf0eadfaa0ef05c" }
-zcash_primitives = { git = "https://github.com/zcash/librustzcash", rev = "b49e2cb3f96e77cd97a0b350cbf0eadfaa0ef05c" }
-zcash_proofs = { git = "https://github.com/zcash/librustzcash", rev = "b49e2cb3f96e77cd97a0b350cbf0eadfaa0ef05c" }
-zcash_protocol = { git = "https://github.com/zcash/librustzcash", rev = "b49e2cb3f96e77cd97a0b350cbf0eadfaa0ef05c" }
-zcash_transparent = { git = "https://github.com/zcash/librustzcash", rev = "b49e2cb3f96e77cd97a0b350cbf0eadfaa0ef05c" }
-zip321 = { git = "https://github.com/zcash/librustzcash", rev = "b49e2cb3f96e77cd97a0b350cbf0eadfaa0ef05c" }
+#
+# TEMPORARY, TEST-ONLY PIN: librustzcash at 59ed8930, for the `zcash_pool_migration` note-locking
+# work (librustzcash#2929 and its stack) that no published crate carries. A version requirement
+# cannot express this: the pinned crate calls itself `zcash_pool_migration` 0.1.0-rc.6, and so
+# does the published rc.6 — but the published one still has the THREE-parameter
+# `WalletProveError`, no `MigrationProver::lock_spent_notes`, and the two-argument
+# `set_transaction_proved`. Only a revision distinguishes them.
+#
+# A COMMIT HASH, not a branch, for the reason the slipstream pin above gives: a branch pin
+# silently follows a force-push, so a build can pick up code nobody reviewed, whereas a stale
+# hash fails loudly.
+#
+# THE PIN MUST NOT OUTLIVE THE RELEASE THAT CARRIES THESE CHANGES. Replace this block with the
+# published version numbers (recomment it) at the first rc containing them; the source adaptation
+# in `rust/src/migration*.rs` stays as it is.
+pczt = { git = "https://github.com/zcash/librustzcash", rev = "59ed8930b8c6d96ce7c0c44a756d480f7311be8a" }
+zcash_address = { git = "https://github.com/zcash/librustzcash", rev = "59ed8930b8c6d96ce7c0c44a756d480f7311be8a" }
+zcash_client_backend = { git = "https://github.com/zcash/librustzcash", rev = "59ed8930b8c6d96ce7c0c44a756d480f7311be8a" }
+zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash", rev = "59ed8930b8c6d96ce7c0c44a756d480f7311be8a" }
+zcash_keys = { git = "https://github.com/zcash/librustzcash", rev = "59ed8930b8c6d96ce7c0c44a756d480f7311be8a" }
+zcash_pool_migration = { git = "https://github.com/zcash/librustzcash", rev = "59ed8930b8c6d96ce7c0c44a756d480f7311be8a" }
+zcash_primitives = { git = "https://github.com/zcash/librustzcash", rev = "59ed8930b8c6d96ce7c0c44a756d480f7311be8a" }
+zcash_proofs = { git = "https://github.com/zcash/librustzcash", rev = "59ed8930b8c6d96ce7c0c44a756d480f7311be8a" }
+zcash_protocol = { git = "https://github.com/zcash/librustzcash", rev = "59ed8930b8c6d96ce7c0c44a756d480f7311be8a" }
+zcash_transparent = { git = "https://github.com/zcash/librustzcash", rev = "59ed8930b8c6d96ce7c0c44a756d480f7311be8a" }
+zip321 = { git = "https://github.com/zcash/librustzcash", rev = "59ed8930b8c6d96ce7c0c44a756d480f7311be8a" }
 
 # Reinstate together with the voting dependencies above:
 # zcash_voting = { git = "https://github.com/valargroup/zcash_voting.git", rev = "e53e74487d31ad0f5713580fb2f0222b53ae9db8" }

--- a/rust/src/migration.rs
+++ b/rust/src/migration.rs
@@ -495,8 +495,8 @@ fn resolve_immediate_run(
 // ----- reconciliation, planning, committing -----
 
 /// Loads the stored run with its `Broadcast` transactions promoted to `Mined` wherever the
-/// wallet's scan has since seen them, persisting once if anything changed. `None` means no
-/// migration is stored.
+/// wallet's scan has since seen them, persisting once if anything changed. `None` means the
+/// account has never stored a migration at all.
 ///
 /// The promotion itself is the ENGINE's — [`PoolMigrationRead::mined_height`], the same query
 /// `advance_migration` sweeps with, bounded by the wallet's fully-scanned height rather than by
@@ -504,9 +504,16 @@ fn resolve_immediate_run(
 /// drive path gets the promotion inside `advance_migration` and does not call this, while the
 /// read-only entry points (progress, statuses, the delivery queries) run it so a standalone read
 /// is not answered from a state the wallet's own scan has already moved past.
+///
+/// The load is [`Backend::latest_migration`], NOT the pending-only `get_migration`: a finished or
+/// cancelled run must stay READABLE — `zcashlc_migration_transaction_statuses` lists the
+/// transactions it mined, and nothing else would ever surface them again — even though nothing
+/// will drive it further. Every caller keeps its own `is_terminal()` branch for what a terminal
+/// run means to its particular answer, and the reconciliation below never touches one: there is
+/// nothing left to promote in a run the engine has already settled.
 fn reconcile_mined(ctx: &mut CallCtx) -> anyhow::Result<Option<MigrationState>> {
     let mut backend = Backend::new(&ctx.wallet, ctx.account, None, &mut ctx.store_conn)?;
-    let Some(mut state) = backend.get_migration()? else {
+    let Some(mut state) = backend.latest_migration()? else {
         return Ok(None);
     };
     if state.is_terminal() {
@@ -1254,13 +1261,16 @@ fn due_assuming_proving(
     next_ready_action(state, targets, NextAction::Prove)?;
     let mut scratch = state.clone();
     while let Some(id) = next_ready_action(&scratch, targets, NextAction::Prove) {
-        let bytes = scratch
+        // The row's own bytes and its own lock owner, so this virtual proof is purely a lifecycle
+        // flip: no prover runs, so no reservation is taken, and re-stating the stored token leaves
+        // the scratch row's reservation exactly as the real one stands.
+        let (bytes, lock_owner) = scratch
             .transactions()
             .iter()
             .find(|t| t.id() == id)
-            .map(|t| t.pczt().clone())
+            .map(|t| (t.pczt().clone(), t.lock_owner()))
             .unwrap_or_default();
-        scratch.set_transaction_proved(id, bytes);
+        scratch.set_transaction_proved(id, bytes, lock_owner);
     }
     next_ready_action(&scratch, targets, NextAction::Broadcast)
 }
@@ -2189,14 +2199,18 @@ fn remaining_orchard(ctx: &mut CallCtx) -> anyhow::Result<Zatoshis> {
 /// targets plus a ten-block reorg-settle depth. Reevaluate and Replan are projected onto the
 /// existing Attend DTO case so the Swift public enum remains source-compatible.
 ///
-/// Returns NULL **with no error recorded** when `get_migration()` returns `None` — no run is
-/// stored, so there is nothing to advance and no step to report. Distinguish that benign NULL
-/// from an error NULL via `zcashlc_last_error_length`. A stored TERMINAL run (Complete, or
-/// Failed/cancelled) reports the `Complete` step VERBATIM, exactly as upstream's `next_step`
-/// does — a cancelled run is never driven further, and is NEVER remapped to any other step.
-/// (The terminal check here is upstream's own first check, hoisted only so the answer needs no
-/// chain-tip lookup — the same answer `next_step` would give, available on a wallet that never
-/// saw a chain tip.)
+/// Returns NULL **with no error recorded** when the account has never stored a migration — there
+/// is nothing to advance and no step to report. Distinguish that benign NULL from an error NULL
+/// via `zcashlc_last_error_length`. A stored TERMINAL run (Complete, or Failed/cancelled) reports
+/// the `Complete` step VERBATIM, exactly as upstream's `next_step` does — a cancelled run is never
+/// driven further, and is NEVER remapped to any other step. (The terminal check here is upstream's
+/// own first check, hoisted only so the answer needs no chain-tip lookup — the same answer
+/// `next_step` would give, available on a wallet that never saw a chain tip.)
+///
+/// Reporting that verbatim `Complete` is why the load is [`Backend::latest_migration`] rather than
+/// the pending-only `get_migration`, which stops reporting a run at the exact moment it becomes
+/// terminal: reading through the pending-only accessor would answer NULL — "no run was ever
+/// stored" — for the one case this function exists to name.
 ///
 /// # Safety
 /// See [`open`]. Free the returned pointer with [`zcashlc_free_migration_advance_step`].
@@ -2212,10 +2226,11 @@ pub unsafe extern "C" fn zcashlc_migration_advance_step(
         let mut ctx = unsafe { open(db_data, db_data_len, account_uuid_bytes, network_id)? };
         // A plain load, NOT `reconcile_mined`: `advance_migration` sweeps every in-flight
         // transaction and promotes the ones the wallet's scan has seen mine, so reconciling first
-        // would only ask the same question twice.
+        // would only ask the same question twice. History-inclusive, so the terminal check below
+        // still has a run to check (see the function doc).
         let Some(mut state) = ({
             let backend = Backend::new(&ctx.wallet, ctx.account, None, &mut ctx.store_conn)?;
-            backend.get_migration()?
+            backend.latest_migration()?
         }) else {
             // No stored run: NULL with NO error (see the function doc). Returned before any
             // chain-tip lookup, so it holds even before the wallet ever saw a chain tip.
@@ -2229,11 +2244,20 @@ pub unsafe extern "C" fn zcashlc_migration_advance_step(
         }
         let targets = dueness_targets(ctx.tip()?, estimated_tip);
         let mut backend = Backend::new(&ctx.wallet, ctx.account, None, &mut ctx.store_conn)?;
+        // `OsRng`, the same source every other engine entry point here is given, because these
+        // draws are PRIVACY-BEARING rather than incidental. The rng feeds upstream's re-spread of
+        // a broadcast schedule the wallet slept through, and specifically the anchor-boundary
+        // REDRAW that accompanies it: a still-unproved transfer whose schedule shifts forward but
+        // whose boundary did not would broadcast an anchor older than any honest draw, by exactly
+        // the shift — and every deferred transfer of this wallet older by the SAME amount, which
+        // is a linkable fingerprint. A weak or reproducible source here is an on-chain disclosure,
+        // not a test-determinism concern.
         let step = advance_migration(
             &mut backend,
             &mut state,
             targets,
             &AdvanceConfig::new(ReorgSettleDepth::new(10)),
+            &mut OsRng,
         )?;
         Ok(match step {
             AdvanceStep::Reevaluate | AdvanceStep::Replan => {
@@ -4227,6 +4251,7 @@ mod tests {
     use rand::rngs::StdRng;
     use zcash_client_backend::data_api::WalletWrite;
     use zcash_pool_migration::denomination::DenominationPlan;
+    use zcash_pool_migration::engine::MigrationLockOwner;
     use zcash_pool_migration::preparation::PreparationPlan;
     use zcash_pool_migration::scheduling::{self, AnchorBucketInterval, SchedulingParams};
     use zcash_pool_migration::signing_rounds::min_signing_rounds;
@@ -4249,7 +4274,7 @@ mod tests {
         expiry_height: BlockHeight,
         anchor_boundary: Option<BlockHeight>,
         state: MigrationTxState,
-        lock_owner: Option<[u8; 32]>,
+        lock_owner: Option<MigrationLockOwner>,
     ) -> MigrationTransaction {
         MigrationTransaction::from_parts(
             id,
@@ -6931,7 +6956,7 @@ mod tests {
     /// The prover error type the dispatch tests fail with: the REAL upstream
     /// [`WalletProveError`] (so the classification under test is the production one), with unit
     /// tree/note/chain-state error parameters.
-    type TestProveError = WalletProveError<(), (), ()>;
+    type TestProveError = WalletProveError<(), (), (), ()>;
 
     /// Which prover method the dispatch routed a transaction to, and with which anchor.
     #[derive(Debug, PartialEq, Eq)]
@@ -7477,6 +7502,11 @@ mod tests {
     }
 
     /// Re-reads the stored migration for `account`, for asserting what the sweep persisted.
+    ///
+    /// History-inclusive (`latest_migration`, not the pending-only `get_migration`): a fixture
+    /// whose last transaction the write under test promoted to `Mined` has by that act become
+    /// terminal, and asserting on WHAT was written must not be defeated by the accessor that
+    /// stops reporting a run once it is finished.
     fn read_fixture_state(path: &std::path::Path, account: &[u8; 16]) -> MigrationState {
         let mut conn = Connection::open(path).expect("the verification connection opens");
         let account_id = account_uuid_from_bytes(account.as_ptr()).expect("16 uuid bytes");
@@ -7488,7 +7518,7 @@ mod tests {
         )
         .expect("the account-keyed store resolves the fixture account");
         store
-            .get_migration()
+            .latest_migration()
             .expect("the store reads")
             .expect("a migration is stored")
     }

--- a/rust/src/migration_engine.rs
+++ b/rust/src/migration_engine.rs
@@ -89,6 +89,25 @@ impl<'a> Backend<'a> {
         })
     }
 
+    /// The account's most recent stored migration WHATEVER its status, where
+    /// [`PoolMigrationRead::get_migration`] reports only a PENDING one.
+    ///
+    /// The two answers coincide until a run reaches a terminal status; from that moment
+    /// `get_migration` returns `None` and the record is readable only here. Every SDK entry point
+    /// that must still SEE a finished or cancelled run — reporting it complete, or listing the
+    /// transactions it mined — reads through this, and keeps its own `is_terminal()` branch to
+    /// decide what a terminal run means for that particular answer. Entry points that act ON a run
+    /// (committing, signing, proving, broadcasting, replanning) read `get_migration` instead, so
+    /// the store's own pending-only filter is what keeps them off a record nothing will drive.
+    ///
+    /// Inherent rather than part of [`PoolMigrationRead`] because the engine never reads history:
+    /// upstream keeps it off the trait for the same reason.
+    pub(crate) fn latest_migration(&self) -> anyhow::Result<Option<MigrationState>> {
+        self.store
+            .latest_migration()
+            .map_err(|e| anyhow!("migration store history read failed: {e}"))
+    }
+
     /// The target height for note selection (the chain tip plus one).
     fn selection_target(&self) -> anyhow::Result<TargetHeight> {
         let tip = self

--- a/rust/src/migration_finalize.rs
+++ b/rust/src/migration_finalize.rs
@@ -52,6 +52,7 @@
 
 use anyhow::anyhow;
 use zcash_client_backend::data_api::WalletRead;
+use zcash_client_backend::data_api::locking::LockError;
 use zcash_pool_migration::engine::{
     self, MigrationProver, MigrationState, MigrationTransferId, MigrationTxKind,
 };
@@ -86,21 +87,33 @@ pub(crate) trait ProveErrorClass {
     fn is_transient(&self) -> bool;
 }
 
-impl<TE, NE, RE> ProveErrorClass for WalletProveError<TE, NE, RE> {
+impl<TE, NE, RE, LE> ProveErrorClass for WalletProveError<TE, NE, RE, LE> {
     /// Transient = "not scanned/retained yet or transiently unqueryable — resolves as the wallet
     /// syncs": no spendable note yet matches the spend's revealed nullifier (`UnknownSpentNote` —
     /// a late-mining dependency's note the wallet has not seen yet), no root at the anchor
     /// checkpoint yet (`AnchorNotFound`), the spent note not witnessable there yet
     /// (`WitnessNotFound`), a commitment-tree QUERY failure (`Tree(ShardTreeError::Query(_))` —
     /// shard-tree query races during sync; this exact case crash-looped a prove batch on Android
-    /// on 2026-07-28), or no chain data at all (`ChainTipUnknown`).
+    /// on 2026-07-28), no chain data at all (`ChainTipUnknown`), or a lost race for a spent note's
+    /// reservation (`Lock(LockError::LockFailure(_))`).
+    ///
+    /// The lock case is transient for the same reason upstream declines to call it fatal: another
+    /// flow — typically a user payment proposed while this transaction was being proved — holds an
+    /// ADVISORY reservation on a note this transaction spends, and that flow may release the lock
+    /// or let it expire without ever broadcasting, in which case a later sweep proves the
+    /// transaction unchanged. Deferring is also the only response available: the notes were fixed
+    /// by the transaction's signature, so nothing here can re-select around the conflict. Once the
+    /// rival transaction actually mines, the conflict stops presenting as a lock failure and
+    /// arrives as `UnknownSpentNote` instead, which the satisfiability sweep — not this
+    /// classification — adjudicates.
     ///
     /// Hard = genuinely unrecoverable, must not be swallowed: everything else, including
     /// `IronwoodTreeUnavailable` explicitly — the backend tracks no Ironwood commitment tree at
     /// all, which no amount of syncing produces — and the NON-query `Tree` variants (A6): a
     /// `Storage(_)` failure is the persistence layer erroring and an `Insert(_)` a corrupt tree
     /// write, neither of which more syncing repairs, so deferring them would stall the sweep
-    /// silently forever.
+    /// silently forever. `Lock(LockError::Storage(_))` is hard on that same reading — it is the
+    /// lock table failing, not a rival owner holding it.
     fn is_transient(&self) -> bool {
         matches!(
             self,
@@ -109,6 +122,7 @@ impl<TE, NE, RE> ProveErrorClass for WalletProveError<TE, NE, RE> {
                 | WalletProveError::WitnessNotFound(_)
                 | WalletProveError::Tree(shardtree::error::ShardTreeError::Query(_))
                 | WalletProveError::ChainTipUnknown
+                | WalletProveError::Lock(LockError::LockFailure(_))
         )
     }
 }


### PR DESCRIPTION
Adopts `librustzcash` revision `59ed8930b8c6d96ce7c0c44a756d480f7311be8a` and fixes the resulting
compilation errors.

Part of #1806 — deliberately closes nothing, since the pin is meant to be replaced by released
version numbers rather than merged and left standing.

Depends on https://github.com/zcash/librustzcash/pull/2929 and the associated PR stack. Counterpart
to zcash/zcash-android-wallet-sdk#2134, which adapts the same revision on the Android side.

## Why a pin

The `zcash_pool_migration` changes this adapts to are in no published crate, and a version
requirement cannot reach them: the pinned crate calls itself `zcash_pool_migration` 0.1.0-rc.6, and
so does the latest published rc.6 — but the published one still has the three-parameter
`WalletProveError`, no `MigrationProver::lock_spent_notes`, and the two-argument
`set_transaction_proved`. Only a revision distinguishes the two. This pins a specific revision
rather than a branch, so the build stays reproducible while the upstream branch moves.

**The pin must not outlive the upstream release that carries these changes.** Replace it with the
released version numbers before merging; the source adaptation stays.

## What changed upstream

**`wallet::WalletProveError` gains a fourth type parameter** (the lock store's error) and a
`Lock(LockError<LE>)` variant, reporting a note another flow has already reserved.

`ProveErrorClass::is_transient` classifies a lock **conflict** as transient. It resolves without the
prove sweep's help either way: the competing flow releases or expires its lock, after which a later
attempt proves; or its transaction mines, after which the next attempt reports `UnknownSpentNote`,
already transient here. Deferring is also the only response available, since the notes were fixed by
the transaction's signature and nothing can re-select around the conflict. A lock-store **write
failure** is not a conflict, does not self-resolve, and still surfaces as hard — the same reading
this impl already applies to `Tree(ShardTreeError::Storage(_))`.

**`satisfiability::advance_migration` takes a `CryptoRng`**, for the anchor-boundary redraws it now
performs when re-spreading a broadcast schedule the wallet slept through. `zcashlc_migration_advance_step`
passes `OsRng`, the source every other engine entry point in this crate is given: a still-unproved
transfer whose schedule shifts forward but whose boundary did not would broadcast an anchor older
than any honest draw by exactly the shift — and every deferred transfer of the wallet older by the
*same* amount, a linkable fingerprint. These draws are privacy-bearing, not incidental.

**`MigrationState::set_transaction_proved` takes the lock owner** the proof's spent notes were
reserved under, and `MigrationTransaction::from_parts` now types that field as
`MigrationLockOwner` rather than `[u8; 32]`. The one production call site is `due_assuming_proving`'s
scratch simulation, which re-states the row's own stored token so the virtual proof stays a pure
lifecycle flip.

**`PoolMigrationRead::get_migration` is now PENDING-ONLY**: a migration persisted with a terminal
status is retained as history and no longer returned there. This one is silent — it compiles
unchanged and changes behavior — and it broke two tests.

Reviewing all fourteen `get_migration()` call sites, the `None` answer and the `is_terminal()` answer
already coincided at every one except two, which now read through the new history accessor
(`PoolMigrations::latest_migration`, exposed on this SDK's `Backend`):

- `zcashlc_migration_advance_step` reports the `Complete` step verbatim for a terminal run. Read
  through the pending-only accessor it would answer NULL — "no run was ever stored" — for the one
  case the function exists to name.
- `reconcile_mined`, which backs the read-only entry points. `zcashlc_migration_transaction_statuses`
  lists the transactions a finished run mined, and nothing else would ever surface them again.

Every caller keeps its own `is_terminal()` branch; the entry points that *act* on a run (committing,
signing, proving, broadcasting, replanning) still read `get_migration`, so the store's own
pending-only filter is what keeps them off a record nothing will drive.

## Verification

- `cargo check --all-targets` — clean; the two remaining warnings are pre-existing dead-code ones.
- `cargo test` — 138 passed, 1 failed. The failure is pre-existing and unrelated; see below.
- `cargo fmt` — applied.
- `./Scripts/update-proposal-proto.sh --check` — `proposal.proto` matches the new revision.
- `make ffi-macos` then `make check` — the documented gate for a Rust-internals change. Exit 0;
  the offline suite executed 796 tests with 0 failures. No FFI signature changed, so `zcashlc.h`
  regenerates identically and the Swift layer is untouched.

## Noted, not fixed

**The wallet-side record seam moved from prove to broadcast, and this SDK has not followed it.**
Upstream's `store_proved_transaction` no longer writes the finalized transaction into the wallet's
own tables; the new `PoolMigrations::take_transaction_for_broadcast` does, atomically with handing
out the broadcastable bytes. This SDK's `serve_proved` extracts those bytes from the stored proven
PCZT in memory and never calls the new seam, so as things stand a migration transaction is never
recorded in the wallet's tables at all — no spend marks, no status-retrieval queue entry, no
`v_transactions` row ever. Adopting the seam is a change to the delivery lane's shape rather than a
compile fix, so it is left out of this PR.

**The unmined-migration Activity filter has nothing to show until broadcast.** The same upstream
change means a pending migration transaction no longer appears in `v_transactions` before broadcast
— which is the feed `TransactionDao` reads and the feature the previous interim pin
(`8f962d47`) was taken for. Upstream's answer is the new `v_transactions_with_pending_migrations`
view, a union that leaves `v_transactions` itself unchanged, so a consumer opts in by switching view
names. That is a deliberate choice about this SDK's read surface (and about the AGENTS.md
views-only rule, which currently sanctions exactly two views), not a mechanical swap.

**The hand-rolled cancel is now upstream's job.** `zcashlc_migration_schedule` cancels a pending run
by writing `MigrationStatus::Failed` directly. Upstream's `cancel_migration` additionally releases
the note reservations the run's never-broadcast transactions hold and works without deserializing
the state; its companion schema migration exists specifically to clean up the rows this SDK's
hand-rolled version left in the field. Worth adopting, separately.

**One pre-existing test failure, unrelated to this bump.**
`migration_keystone::tests::build_sign_batch_qr_parts_retains_the_dummy_orchard_spend_auth_sig`
asserts that a dummy Orchard `spend_auth_sig` survives `redact_pczt_for_batch_signer`. Upstream
clears it, deliberately ("deployed batch Signers reject requests that already carry signatures"), and
`build_sign_batch_qr_parts`'s own doc comment in this repo says the same. The function is
byte-identical between the previous pin and this one; checked out at the previous pin the test fails
identically, so this bump neither caused nor could fix it. There is a worktree on
`fix/pczt-v6-wallet-spend-derivations` that looks like where it belongs.

---

Filed with Claude Code assistance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
