### PR TITLE
Serve the migration UI reads from read-only connections (no reconcile on the read paths)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,8 @@ Changes are relative to `2.8.0-rc.3`.
   `migrationSyncWakeups`) no longer take the database write actor: the FFI now serves them from
   read-only connections without reconciling first, so they answer in milliseconds even while a
   proof is being generated. A just-mined broadcast can trail in these answers by at most one
-  drive pass (≤30 s foregrounded); checkmark/"done" rendering is unaffected (it derives from the
+  write-lane pass (the platform's next advance-step, prove, or delivery call — typically its next
+  sync edge or UI refresh); checkmark/"done" rendering is unaffected (it derives from the
   wallet's own mined transactions).
 
 ## Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,13 @@ Changes are relative to `2.8.0-rc.3`.
   note reservation its never-broadcast transactions held is released in the same store
   transaction — so the fresh plan the restart previews sees the full balance immediately instead
   of selecting around notes the abandoned run still holds until their locks expire.
+- Migration UI/gate reads (`migrationTransactionStatuses`, `migrationProgress`,
+  `migrationHasOverdueTransfers`, `migrationHasInvalidTransfers`, `migrationHasReadyBroadcast`,
+  `migrationSyncWakeups`) no longer take the database write actor: the FFI now serves them from
+  read-only connections without reconciling first, so they answer in milliseconds even while a
+  proof is being generated. A just-mined broadcast can trail in these answers by at most one
+  drive pass (≤30 s foregrounded); checkmark/"done" rendering is unaffected (it derives from the
+  wallet's own mined transactions).
 
 ## Fixed
 

--- a/Sources/ZcashLightClientKit/Rust/ZcashRustBackend.swift
+++ b/Sources/ZcashLightClientKit/Rust/ZcashRustBackend.swift
@@ -1520,9 +1520,11 @@ struct ZcashRustBackend: ZcashRustBackendWelding {
         return step
     }
 
-    // DB-AUDIT (2026-08-03): read-shaped but WRITE — answers only after reconcile_mined,
-    // which persists Broadcast→Mined promotions (full-run replace_migration). Stays serialized.
-    @DBActor
+    // DB-READ (audited 2026-08-05): zcashlc_migration_sync_wakeups — opens through the
+    // FFI's `open_read` (both connections SQLITE_OPEN_READ_ONLY; no reconcile, no preamble
+    // writes), so read-only-ness is machine-enforced: a write anywhere down this path fails
+    // SQLITE_READONLY rather than silently reclassifying the call. Mined promotion is persisted
+    // by the write lanes (advance-step sweep, prove sweep, delivery serves).
     func migrationSyncWakeups(for account: AccountUUID) async throws -> [MigrationSyncWakeup] {
         let wakeupsPtr = zcashlc_migration_sync_wakeups(
             dbData.0,
@@ -1627,9 +1629,11 @@ struct ZcashRustBackend: ZcashRustBackendWelding {
         return sizes
     }
 
-    // DB-AUDIT (2026-08-03): read-shaped but WRITE — answers only after reconcile_mined,
-    // which persists Broadcast→Mined promotions (full-run replace_migration). Stays serialized.
-    @DBActor
+    // DB-READ (audited 2026-08-05): zcashlc_migration_progress — opens through the
+    // FFI's `open_read` (both connections SQLITE_OPEN_READ_ONLY; no reconcile, no preamble
+    // writes), so read-only-ness is machine-enforced: a write anywhere down this path fails
+    // SQLITE_READONLY rather than silently reclassifying the call. Mined promotion is persisted
+    // by the write lanes (advance-step sweep, prove sweep, delivery serves).
     func migrationProgress(for account: AccountUUID) async throws -> MigrationProgress? {
         let progressPtr = zcashlc_migration_progress(
             dbData.0,
@@ -1647,9 +1651,11 @@ struct ZcashRustBackend: ZcashRustBackendWelding {
         return progressPtr.pointee.unsafeToMigrationProgress()
     }
 
-    // DB-AUDIT (2026-08-03): read-shaped but WRITE — answers only after reconcile_mined,
-    // which persists Broadcast→Mined promotions (full-run replace_migration). Stays serialized.
-    @DBActor
+    // DB-READ (audited 2026-08-05): zcashlc_migration_transaction_statuses — opens through the
+    // FFI's `open_read` (both connections SQLITE_OPEN_READ_ONLY; no reconcile, no preamble
+    // writes), so read-only-ness is machine-enforced: a write anywhere down this path fails
+    // SQLITE_READONLY rather than silently reclassifying the call. Mined promotion is persisted
+    // by the write lanes (advance-step sweep, prove sweep, delivery serves).
     func migrationTransactionStatuses(for account: AccountUUID) async throws -> [MigrationTransactionStatus] {
         let statusesPtr = zcashlc_migration_transaction_statuses(
             dbData.0,
@@ -1704,9 +1710,11 @@ struct ZcashRustBackend: ZcashRustBackendWelding {
         return needed
     }
 
-    // DB-AUDIT (2026-08-03): read-shaped but WRITE — answers only after reconcile_mined,
-    // which persists Broadcast→Mined promotions (full-run replace_migration). Stays serialized.
-    @DBActor
+    // DB-READ (audited 2026-08-05): zcashlc_migration_has_overdue_transfers — opens through the
+    // FFI's `open_read` (both connections SQLITE_OPEN_READ_ONLY; no reconcile, no preamble
+    // writes), so read-only-ness is machine-enforced: a write anywhere down this path fails
+    // SQLITE_READONLY rather than silently reclassifying the call. Mined promotion is persisted
+    // by the write lanes (advance-step sweep, prove sweep, delivery serves).
     func migrationHasOverdueTransfers(for account: AccountUUID, estimatedTip: BlockHeight?) async throws -> Bool {
         // Clear any stale, unconsumed last-error before this sentinel read (see
         // `migrationIsNoteSplitNeeded` above).
@@ -1731,9 +1739,11 @@ struct ZcashRustBackend: ZcashRustBackendWelding {
         return hasOverdue
     }
 
-    // DB-AUDIT (2026-08-03): read-shaped but WRITE — answers only after reconcile_mined,
-    // which persists Broadcast→Mined promotions (full-run replace_migration). Stays serialized.
-    @DBActor
+    // DB-READ (audited 2026-08-05): zcashlc_migration_has_ready_broadcast — opens through the
+    // FFI's `open_read` (both connections SQLITE_OPEN_READ_ONLY; no reconcile, no preamble
+    // writes), so read-only-ness is machine-enforced: a write anywhere down this path fails
+    // SQLITE_READONLY rather than silently reclassifying the call. Mined promotion is persisted
+    // by the write lanes (advance-step sweep, prove sweep, delivery serves).
     func migrationHasReadyBroadcast(for account: AccountUUID, estimatedTip: BlockHeight?) async throws -> Bool {
         let outcome = zcashlc_migration_has_ready_broadcast(
             dbData.0,
@@ -1755,9 +1765,11 @@ struct ZcashRustBackend: ZcashRustBackendWelding {
         return outcome == 1
     }
 
-    // DB-AUDIT (2026-08-03): read-shaped but WRITE — answers only after reconcile_mined,
-    // which persists Broadcast→Mined promotions (full-run replace_migration). Stays serialized.
-    @DBActor
+    // DB-READ (audited 2026-08-05): zcashlc_migration_has_invalid_transfers — opens through the
+    // FFI's `open_read` (both connections SQLITE_OPEN_READ_ONLY; no reconcile, no preamble
+    // writes), so read-only-ness is machine-enforced: a write anywhere down this path fails
+    // SQLITE_READONLY rather than silently reclassifying the call. Mined promotion is persisted
+    // by the write lanes (advance-step sweep, prove sweep, delivery serves).
     func migrationHasInvalidTransfers(for account: AccountUUID) async throws -> Bool {
         // Clear any stale, unconsumed last-error before this sentinel read (see
         // `migrationIsNoteSplitNeeded` above).

--- a/Sources/ZcashLightClientKit/Utils/DBActor.swift
+++ b/Sources/ZcashLightClientKit/Utils/DBActor.swift
@@ -16,6 +16,10 @@ import Foundation
 /// with a comment saying so. When the librustzcash pin moves, any FFI function whose Rust body
 /// changed needs its classification re-checked before the marker date is trusted.
 ///
+/// The migration read entry points are the exception that needs no re-check: they open through
+/// the FFI's `open_read` (SQLITE_OPEN_READ_ONLY on both connections), so their read-only-ness
+/// is enforced by SQLite itself, not by audit.
+///
 /// WHAT THIS ACTOR GUARANTEES: no two Swift-initiated writes ever interleave.
 ///
 /// WHAT IT DOES NOT AND CANNOT GUARANTEE: the slipstream engine writes to the same database

--- a/Tests/OfflineTests/DBActorIsolationTests.swift
+++ b/Tests/OfflineTests/DBActorIsolationTests.swift
@@ -9,10 +9,13 @@
 //  test controls. The block being synchronous is the point: an `await` inside the actor is a
 //  suspension point that RELEASES the actor (reentrancy, SE-0306) and would hold nothing.
 //
-//  Three converted reads are pinned — one per conversion area: the migration family
-//  (blockRateSamples), the turnstile proposal (proposeOrchardToIronwoodMigration, which needs
-//  the account fixture), and the wallet getters (maxScannedHeight). The DAO conversions are
-//  exercised transitively by the rest of OfflineTests.
+//  Four conversion areas are pinned, one test per converted call: the migration family
+//  (blockRateSamples); the migration UI/gate reads reclassified 2026-08-05 — migrationSyncWakeups,
+//  migrationProgress, migrationTransactionStatuses, migrationHasOverdueTransfers,
+//  migrationHasReadyBroadcast, migrationHasInvalidTransfers — pinned individually so a re-add on
+//  any single one of the six fails on its own, not just as a group; the turnstile proposal
+//  (proposeOrchardToIronwoodMigration, which needs the account fixture); and the wallet getters
+//  (maxScannedHeight). The DAO conversions are exercised transitively by the rest of OfflineTests.
 //
 
 import XCTest
@@ -65,6 +68,54 @@ final class DBActorIsolationTests: XCTestCase {
         let backend = rustBackend!
         await assertCompletesWhileDBActorIsHeld("migrationBlockRateSamples completed while actor held") {
             _ = try? await backend.migrationBlockRateSamples(window: 100)
+        }
+    }
+
+    func testSyncWakeupsReadCompletesWhileDBActorIsHeld() async throws {
+        let backend = rustBackend!
+        let accountUUID = account!
+        await assertCompletesWhileDBActorIsHeld("migrationSyncWakeups completed while actor held") {
+            _ = try? await backend.migrationSyncWakeups(for: accountUUID)
+        }
+    }
+
+    func testProgressReadCompletesWhileDBActorIsHeld() async throws {
+        let backend = rustBackend!
+        let accountUUID = account!
+        await assertCompletesWhileDBActorIsHeld("migrationProgress completed while actor held") {
+            _ = try? await backend.migrationProgress(for: accountUUID)
+        }
+    }
+
+    func testTransactionStatusesReadCompletesWhileDBActorIsHeld() async throws {
+        let backend = rustBackend!
+        let accountUUID = account!
+        await assertCompletesWhileDBActorIsHeld("migrationTransactionStatuses completed while actor held") {
+            _ = try? await backend.migrationTransactionStatuses(for: accountUUID)
+        }
+    }
+
+    func testHasOverdueTransfersReadCompletesWhileDBActorIsHeld() async throws {
+        let backend = rustBackend!
+        let accountUUID = account!
+        await assertCompletesWhileDBActorIsHeld("migrationHasOverdueTransfers completed while actor held") {
+            _ = try? await backend.migrationHasOverdueTransfers(for: accountUUID, estimatedTip: nil)
+        }
+    }
+
+    func testHasReadyBroadcastReadCompletesWhileDBActorIsHeld() async throws {
+        let backend = rustBackend!
+        let accountUUID = account!
+        await assertCompletesWhileDBActorIsHeld("migrationHasReadyBroadcast completed while actor held") {
+            _ = try? await backend.migrationHasReadyBroadcast(for: accountUUID, estimatedTip: nil)
+        }
+    }
+
+    func testHasInvalidTransfersReadCompletesWhileDBActorIsHeld() async throws {
+        let backend = rustBackend!
+        let accountUUID = account!
+        await assertCompletesWhileDBActorIsHeld("migrationHasInvalidTransfers completed while actor held") {
+            _ = try? await backend.migrationHasInvalidTransfers(for: accountUUID)
         }
     }
 

--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -173,6 +173,14 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   outside the region a reorg truncation would roll back — and is the same bound the drive path
   promotes under, so a status read can no longer report `Mined` for a row `advance_migration`
   would refuse to promote.
+- The six migration read entry points (`zcashlc_migration_transaction_statuses`,
+  `zcashlc_migration_progress`, `zcashlc_migration_has_overdue_transfers`,
+  `zcashlc_migration_has_invalid_transfers`, `zcashlc_migration_has_ready_broadcast`,
+  `zcashlc_migration_sync_wakeups`) now open the database read-only and report the persisted
+  run without reconciling mined transactions first. Broadcast→Mined promotion is persisted by
+  the write lanes (the advance-step engine sweep, the prove sweep, the delivery serves), which
+  every live run drives at least once per open-lane pass and 30 s tick; a read can therefore
+  trail a just-mined broadcast by at most one such pass. Reads no longer contend with proving.
 
 ### Removed
 - `zcashlc_migration_debug_reschedule_transfers` is removed. It was the only FFI entry point that

--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -179,8 +179,9 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `zcashlc_migration_sync_wakeups`) now open the database read-only and report the persisted
   run without reconciling mined transactions first. Broadcast→Mined promotion is persisted by
   the write lanes (the advance-step engine sweep, the prove sweep, the delivery serves), which
-  every live run drives at least once per open-lane pass and 30 s tick; a read can therefore
-  trail a just-mined broadcast by at most one such pass. Reads no longer contend with proving.
+  every live run drives at least once per open-lane pass, sync edge, and UI refresh; a read can
+  therefore trail a just-mined broadcast by at most one such pass. Reads no longer contend with
+  proving.
 
 ### Removed
 - `zcashlc_migration_debug_reschedule_transfers` is removed. It was the only FFI entry point that

--- a/rust/src/migration.rs
+++ b/rust/src/migration.rs
@@ -250,8 +250,10 @@ unsafe fn wallet_db_read_only(
         .map_err(|e| anyhow!("Error setting read-only wallet database busy_timeout: {e}"))?;
     rusqlite::vtab::array::load_module(&conn)
         .map_err(|e| anyhow!("Error loading wallet database array module: {e}"))?;
-    Ok(MigrationWallet::from_connection(conn, network, SystemClock, OsRng)
-        .with_anchor_retention_interval(crate::anchor_retention_interval(network)))
+    Ok(
+        MigrationWallet::from_connection(conn, network, SystemClock, OsRng)
+            .with_anchor_retention_interval(crate::anchor_retention_interval(network)),
+    )
 }
 
 /// Open the per-call context from the common FFI arguments. Every entry point calls this fresh and
@@ -6415,7 +6417,11 @@ mod tests {
             .unwrap_err();
         match err {
             rusqlite::Error::SqliteFailure(e, _) => {
-                assert_eq!(e.code, rusqlite::ErrorCode::ReadOnly, "write must fail READONLY, got {e:?}")
+                assert_eq!(
+                    e.code,
+                    rusqlite::ErrorCode::ReadOnly,
+                    "write must fail READONLY, got {e:?}"
+                )
             }
             other => panic!("expected SqliteFailure(ReadOnly), got {other:?}"),
         }
@@ -6432,7 +6438,10 @@ mod tests {
         ));
         let _ = std::fs::remove_file(&path);
         assert!(open_store_conn_read_only(&path).is_err());
-        assert!(!path.exists(), "a read-only open must not create the database file");
+        assert!(
+            !path.exists(),
+            "a read-only open must not create the database file"
+        );
     }
 
     /// The pure `zcashlc_migration_progress` path may run before any rw migration call ever
@@ -6442,11 +6451,18 @@ mod tests {
     fn immediate_run_row_if_table_exists_tolerates_a_missing_table() {
         let conn = Connection::open_in_memory().unwrap();
         let account = [9u8; 16];
-        assert!(immediate_run_row_if_table_exists(&conn, &account).unwrap().is_none());
+        assert!(
+            immediate_run_row_if_table_exists(&conn, &account)
+                .unwrap()
+                .is_none()
+        );
         init_immediate_runs(&conn).unwrap();
         record_immediate_run(&conn, &account, [1u8; 32], h(100)).unwrap();
         assert_eq!(
-            immediate_run_row_if_table_exists(&conn, &account).unwrap().unwrap().txid,
+            immediate_run_row_if_table_exists(&conn, &account)
+                .unwrap()
+                .unwrap()
+                .txid,
             [1u8; 32]
         );
     }
@@ -6465,7 +6481,9 @@ mod tests {
             h(1_000),
             h(1_040),
             None,
-            MigrationTxState::Broadcast { txid: TxId::from_bytes([1u8; 32]) },
+            MigrationTxState::Broadcast {
+                txid: TxId::from_bytes([1u8; 32]),
+            },
             None,
         );
         let state = test_state_from_parts(
@@ -8499,8 +8517,14 @@ mod tests {
             row.mined_height, -1,
             "unreconciled, the row carries no mined height"
         );
-        assert!(row.has_txid, "the broadcast lifecycle state retains its txid");
-        assert_eq!(row.txid, txid, "the broadcast lifecycle state retains its txid");
+        assert!(
+            row.has_txid,
+            "the broadcast lifecycle state retains its txid"
+        );
+        assert_eq!(
+            row.txid, txid,
+            "the broadcast lifecycle state retains its txid"
+        );
         unsafe { zcashlc_free_migration_transaction_statuses(statuses_ptr) };
 
         // No reconciliation happened, so nothing was persisted either — the read-only
@@ -9607,44 +9631,69 @@ mod tests {
         };
         assert!(init >= 0, "wallet-db initialization must succeed");
         assert!(unsafe {
-            crate::zcashlc_update_chain_tip(path_bytes.as_ptr(), path_bytes.len(), 3_000_000, NETWORK_ID_MAINNET)
+            crate::zcashlc_update_chain_tip(
+                path_bytes.as_ptr(),
+                path_bytes.len(),
+                3_000_000,
+                NETWORK_ID_MAINNET,
+            )
         });
         let account = [7u8; 16];
         // Unknown account: the store constructor reports AccountUnknown down every one of these
         // paths, and each wrapper coerces per ITS OWN error convention — pinned here verbatim.
         let overdue = unsafe {
             zcashlc_migration_has_overdue_transfers(
-                path_bytes.as_ptr(), path_bytes.len(), account.as_ptr(), NETWORK_ID_MAINNET, -1,
+                path_bytes.as_ptr(),
+                path_bytes.len(),
+                account.as_ptr(),
+                NETWORK_ID_MAINNET,
+                -1,
             )
         };
         assert!(!overdue, "error path coerces to false");
         let invalid = unsafe {
             zcashlc_migration_has_invalid_transfers(
-                path_bytes.as_ptr(), path_bytes.len(), account.as_ptr(), NETWORK_ID_MAINNET,
+                path_bytes.as_ptr(),
+                path_bytes.len(),
+                account.as_ptr(),
+                NETWORK_ID_MAINNET,
             )
         };
         assert!(!invalid, "error path coerces to false");
         let ready = unsafe {
             zcashlc_migration_has_ready_broadcast(
-                path_bytes.as_ptr(), path_bytes.len(), account.as_ptr(), NETWORK_ID_MAINNET, -1,
+                path_bytes.as_ptr(),
+                path_bytes.len(),
+                account.as_ptr(),
+                NETWORK_ID_MAINNET,
+                -1,
             )
         };
         assert_eq!(ready, -1, "error path reports -1");
         let statuses = unsafe {
             zcashlc_migration_transaction_statuses(
-                path_bytes.as_ptr(), path_bytes.len(), account.as_ptr(), NETWORK_ID_MAINNET,
+                path_bytes.as_ptr(),
+                path_bytes.len(),
+                account.as_ptr(),
+                NETWORK_ID_MAINNET,
             )
         };
         assert!(statuses.is_null(), "error path reports null");
         let progress = unsafe {
             zcashlc_migration_progress(
-                path_bytes.as_ptr(), path_bytes.len(), account.as_ptr(), NETWORK_ID_MAINNET,
+                path_bytes.as_ptr(),
+                path_bytes.len(),
+                account.as_ptr(),
+                NETWORK_ID_MAINNET,
             )
         };
         assert!(progress.is_null(), "error path reports null");
         let wakeups = unsafe {
             zcashlc_migration_sync_wakeups(
-                path_bytes.as_ptr(), path_bytes.len(), account.as_ptr(), NETWORK_ID_MAINNET,
+                path_bytes.as_ptr(),
+                path_bytes.len(),
+                account.as_ptr(),
+                NETWORK_ID_MAINNET,
             )
         };
         assert!(wakeups.is_null(), "error path reports null");

--- a/rust/src/migration.rs
+++ b/rust/src/migration.rs
@@ -215,6 +215,45 @@ fn open_store_conn(db_path: &Path) -> anyhow::Result<Connection> {
     Ok(conn)
 }
 
+/// Read-only twin of [`open_store_conn`]: same busy_timeout, but the connection can neither
+/// write nor create the database file. This is the Q2-1 enforcement layer — the pure read
+/// entry points open through this, so an accidental write anywhere down their call graph
+/// fails loudly with `SQLITE_READONLY` instead of silently reclassifying the call.
+fn open_store_conn_read_only(db_path: &Path) -> anyhow::Result<Connection> {
+    let conn = Connection::open_with_flags(
+        db_path,
+        rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY | rusqlite::OpenFlags::SQLITE_OPEN_NO_MUTEX,
+    )
+    .map_err(|e| anyhow!("Error opening read-only migration store connection: {e}"))?;
+    conn.busy_timeout(crate::WALLET_DB_BUSY_TIMEOUT)
+        .map_err(|e| anyhow!("Error setting read-only migration store busy_timeout: {e}"))?;
+    Ok(conn)
+}
+
+/// Read-only twin of [`crate::wallet_db`] (lib.rs): open + array vtab + wrap, with
+/// `SQLITE_OPEN_READ_ONLY` so the wallet handle cannot write either. The vtab module load is
+/// connection-local registration, not a database write.
+unsafe fn wallet_db_read_only(
+    db_data: *const u8,
+    db_data_len: usize,
+    network: NetworkParams,
+) -> anyhow::Result<MigrationWallet> {
+    let db_data = Path::new(OsStr::from_bytes(unsafe {
+        slice::from_raw_parts(db_data, db_data_len)
+    }));
+    let conn = Connection::open_with_flags(
+        db_data,
+        rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY | rusqlite::OpenFlags::SQLITE_OPEN_NO_MUTEX,
+    )
+    .map_err(|e| anyhow!("Error opening read-only wallet database connection: {e}"))?;
+    conn.busy_timeout(crate::WALLET_DB_BUSY_TIMEOUT)
+        .map_err(|e| anyhow!("Error setting read-only wallet database busy_timeout: {e}"))?;
+    rusqlite::vtab::array::load_module(&conn)
+        .map_err(|e| anyhow!("Error loading wallet database array module: {e}"))?;
+    Ok(MigrationWallet::from_connection(conn, network, SystemClock, OsRng)
+        .with_anchor_retention_interval(crate::anchor_retention_interval(network)))
+}
+
 /// Open the per-call context from the common FFI arguments. Every entry point calls this fresh and
 /// drops it at the end (no persistent handle). All tables are created by the wallet schema
 /// migrations during `init_data_db`: the engine's store tables by `zcash_client_sqlite`'s own
@@ -246,6 +285,40 @@ unsafe fn open(
         .map(|metadata| metadata.block_height())
         .unwrap_or(BlockHeight::from(0));
     migrate_legacy_invalid_marks(&mut store_conn, network, fully_scanned_height)?;
+    let account = account_uuid_from_bytes(account_uuid_bytes)
+        .map_err(|e| anyhow!("account uuid must be 16 bytes: {e}"))?;
+    let account_bytes = *account.expose_uuid().as_bytes();
+    Ok(CallCtx {
+        network,
+        wallet,
+        store_conn,
+        db_path,
+        account,
+        account_bytes,
+    })
+}
+
+/// Read-only twin of [`open`]: both connections opened `SQLITE_OPEN_READ_ONLY`, and the two
+/// preamble writers deliberately skipped — `init_immediate_runs` (its table is created by any
+/// rw migration call; pure readers tolerate its absence via
+/// [`immediate_run_row_if_table_exists`]) and `migrate_legacy_invalid_marks` (a one-time fold
+/// only rw callers may perform). The pure read entry points open through this; see
+/// `open_store_conn_read_only` for what that enforces.
+///
+/// # Safety
+/// Same contract as [`open`].
+unsafe fn open_read(
+    db_data: *const u8,
+    db_data_len: usize,
+    account_uuid_bytes: *const u8,
+    network_id: u32,
+) -> anyhow::Result<CallCtx> {
+    let network = parse_network(network_id)?;
+    let db_path = PathBuf::from(OsStr::from_bytes(unsafe {
+        slice::from_raw_parts(db_data, db_data_len)
+    }));
+    let wallet = unsafe { wallet_db_read_only(db_data, db_data_len, network.clone())? };
+    let store_conn = open_store_conn_read_only(&db_path)?;
     let account = account_uuid_from_bytes(account_uuid_bytes)
         .map_err(|e| anyhow!("account uuid must be 16 bytes: {e}"))?;
     let account_bytes = *account.expose_uuid().as_bytes();
@@ -458,6 +531,25 @@ fn immediate_run_row(
         },
     )
     .optional()
+}
+
+/// [`immediate_run_row`] for the READ-ONLY paths: `sdk_immediate_runs` is created lazily by the
+/// rw [`open`], so a wallet whose migration surface has only ever been READ (fresh install,
+/// UI-before-first-drive) legitimately lacks the table — that is the "no immediate run recorded"
+/// answer, not an error.
+fn immediate_run_row_if_table_exists(
+    conn: &Connection,
+    account: &[u8; 16],
+) -> rusqlite::Result<Option<ImmediateRunRow>> {
+    match immediate_run_row(conn, account) {
+        Err(rusqlite::Error::SqliteFailure(e, Some(ref msg)))
+            if msg.contains("no such table: sdk_immediate_runs") =>
+        {
+            let _ = e;
+            Ok(None)
+        }
+        other => other,
+    }
 }
 
 /// Resolves an immediate-run row against the wallet database's own `transactions` table: the same
@@ -6267,6 +6359,106 @@ mod tests {
             zero_expiry.expiry_height, None,
             "expiry_height=0 must read as missing"
         );
+    }
+
+    // ----- read-only open helpers (Q2-1 enforcement) -----
+
+    /// Q2-1 enforcement: the read-only store connection makes accidental writes on the pure
+    /// read paths impossible — any INSERT/UPDATE/DDL errors with SQLITE_READONLY, forever,
+    /// including after future pin moves change what the engine calls do internally.
+    #[test]
+    fn read_only_store_conn_rejects_writes() {
+        let path = std::env::temp_dir().join(format!(
+            "zcashlc_readonly_store_{}.sqlite",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_file(&path);
+        {
+            let rw = Connection::open(&path).unwrap();
+            init_immediate_runs(&rw).unwrap();
+        }
+        let ro = open_store_conn_read_only(&path).unwrap();
+        let err = ro
+            .execute(
+                "INSERT INTO sdk_immediate_runs (account_uuid, txid, recorded_at_height) VALUES (?1, ?2, ?3)",
+                rusqlite::params![&[9u8; 16][..], &[1u8; 32][..], 100i64],
+            )
+            .unwrap_err();
+        match err {
+            rusqlite::Error::SqliteFailure(e, _) => {
+                assert_eq!(e.code, rusqlite::ErrorCode::ReadOnly, "write must fail READONLY, got {e:?}")
+            }
+            other => panic!("expected SqliteFailure(ReadOnly), got {other:?}"),
+        }
+        let _ = std::fs::remove_file(&path);
+    }
+
+    /// A read-only open of a wallet-database FILE that does not exist must error — and must NOT
+    /// create the file (the rw `open()` path's `Connection::open` would).
+    #[test]
+    fn read_only_store_conn_on_missing_file_errors_without_creating_it() {
+        let path = std::env::temp_dir().join(format!(
+            "zcashlc_readonly_missing_{}.sqlite",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_file(&path);
+        assert!(open_store_conn_read_only(&path).is_err());
+        assert!(!path.exists(), "a read-only open must not create the database file");
+    }
+
+    /// The pure `zcashlc_migration_progress` path may run before any rw migration call ever
+    /// created `sdk_immediate_runs` (the table is created lazily by the rw `open()`, not by the
+    /// schema graph) — the tolerant reader answers None instead of erroring on the missing table.
+    #[test]
+    fn immediate_run_row_if_table_exists_tolerates_a_missing_table() {
+        let conn = Connection::open_in_memory().unwrap();
+        let account = [9u8; 16];
+        assert!(immediate_run_row_if_table_exists(&conn, &account).unwrap().is_none());
+        init_immediate_runs(&conn).unwrap();
+        record_immediate_run(&conn, &account, [1u8; 32], h(100)).unwrap();
+        assert_eq!(
+            immediate_run_row_if_table_exists(&conn, &account).unwrap().unwrap().txid,
+            [1u8; 32]
+        );
+    }
+
+    /// The accepted semantic shift, pinned: a pure statuses read reports what is PERSISTED — a
+    /// `Broadcast` row stays `Broadcast` in its answer until a write lane (`advance_step`'s
+    /// engine sweep, `prove_pending`, `next_due_transfer`) persists the Mined promotion. Display
+    /// green is unaffected (the app derives it from the wallet's own mined-txid set).
+    #[test]
+    fn pure_statuses_report_broadcast_until_a_write_lane_promotes() {
+        let tx = test_transaction_from_parts(
+            MigrationTransferId::new(1),
+            MigrationTxKind::Transfer { crossing: 0 },
+            vec![0u8; 8],
+            Vec::new(),
+            h(1_000),
+            h(1_040),
+            None,
+            MigrationTxState::Broadcast { txid: TxId::from_bytes([1u8; 32]) },
+            None,
+        );
+        let state = test_state_from_parts(
+            MigrationStatus::InProgress,
+            DenominationPlan::from_stored_parts(
+                vec![zat(100_000_000)],
+                zat(10_000),
+                None,
+                zat(20_000),
+                zat(1_000_000_000),
+                zat(999_000_000),
+            )
+            .unwrap(),
+            PreparationPlan::from_parts(Vec::new(), Vec::new()),
+            vec![tx],
+            AnchorBucketInterval::ZIP_318,
+        );
+        let statuses = state.transaction_statuses(DuenessTargets::at(h(1_050)));
+        assert!(matches!(
+            statuses[0].state(),
+            MigrationTxState::Broadcast { .. }
+        ));
     }
 
     /// A freshly initialized wallet database has no stored migration, so

--- a/rust/src/migration.rs
+++ b/rust/src/migration.rs
@@ -2421,8 +2421,11 @@ pub unsafe extern "C" fn zcashlc_migration_progress(
     network_id: u32,
 ) -> *mut FfiMigrationProgress {
     let res = catch_panic(|| {
-        let mut ctx = unsafe { open(db_data, db_data_len, account_uuid_bytes, network_id)? };
-        let engine_state = reconcile_mined(&mut ctx)?;
+        let mut ctx = unsafe { open_read(db_data, db_data_len, account_uuid_bytes, network_id)? };
+        let engine_state = {
+            let backend = Backend::new(&ctx.wallet, ctx.account, None, &mut ctx.store_conn)?;
+            backend.get_migration()?
+        };
         if let Some(state) = engine_state.as_ref().filter(|state| !state.is_terminal()) {
             let (completed, total, next_ready) = active_run_progress(state);
             return Ok(Box::into_raw(Box::new(FfiMigrationProgress {
@@ -2436,7 +2439,7 @@ pub unsafe extern "C" fn zcashlc_migration_progress(
         }
         // No active engine run (none stored, or terminal): the immediate lane is the only thing
         // left that could report progress.
-        let immediate_row = immediate_run_row(&ctx.store_conn, &ctx.account_bytes)
+        let immediate_row = immediate_run_row_if_table_exists(&ctx.store_conn, &ctx.account_bytes)
             .map_err(|e| anyhow!("immediate run read failed: {e}"))?;
         let Some(row) = immediate_row else {
             // No row either: absent, and (crucially) with no chain-tip lookup, which a
@@ -2469,7 +2472,10 @@ pub unsafe extern "C" fn zcashlc_migration_progress(
 /// the transfer ids it is responsible for proving. Wake-up heights are floored at the tip (a row
 /// at exactly the tip means "right now"); jitter is re-drawn on every call, so two calls may
 /// legitimately differ — recompute (and re-register with the OS) after any state change rather
-/// than caching. Reconciles mined transactions first, like every other read.
+/// than caching. Pure read of the PERSISTED run (read-only connections; no reconcile): a Broadcast
+/// row the wallet has since scanned as mined is reported Mined only after a write lane — the
+/// advance-step engine sweep, the prove sweep, or a delivery serve — persists the promotion; while
+/// a run is live the platform drives one of those at least every open-lane pass and 30 s tick.
 ///
 /// No stored run, a terminal run, or no transfer still needing a proof returns the EMPTY schedule
 /// (`len == 0`, valid pointer) — not an error. A stored transfer that admits NO valid wake-up
@@ -2492,8 +2498,11 @@ pub unsafe extern "C" fn zcashlc_migration_sync_wakeups(
                 len: 0,
             }))
         };
-        let mut ctx = unsafe { open(db_data, db_data_len, account_uuid_bytes, network_id)? };
-        let Some(state) = reconcile_mined(&mut ctx)? else {
+        let mut ctx = unsafe { open_read(db_data, db_data_len, account_uuid_bytes, network_id)? };
+        let Some(state) = ({
+            let backend = Backend::new(&ctx.wallet, ctx.account, None, &mut ctx.store_conn)?;
+            backend.get_migration()?
+        }) else {
             return Ok(empty());
         };
         if state.is_terminal() {
@@ -2715,9 +2724,11 @@ fn encode_transaction_status(
 /// The LIVE status of every committed migration transaction, keyed by its stable id — a verbatim
 /// marshal of `MigrationState::transaction_statuses(target)` at `target = tip + 1` (see
 /// [`CallCtx::target`]), the engine's own per-transaction view a wallet renders progress from and
-/// decides what to sign/prove/broadcast next. Reconciles mined transactions first (the same
-/// read-path convention as [`zcashlc_migration_advance_step`]), so a `Broadcast` row the wallet's
-/// own scan has since observed mined is reported `Mined` here too. No stored run, or a stored run
+/// decides what to sign/prove/broadcast next. Pure read of the PERSISTED run (read-only
+/// connections; no reconcile): a Broadcast row the wallet has since scanned as mined is reported
+/// Mined only after a write lane — the advance-step engine sweep, the prove sweep, or a delivery
+/// serve — persists the promotion; while a run is live the platform drives one of those at least
+/// every open-lane pass and 30 s tick. No stored run, or a stored run
 /// with no transactions, returns an EMPTY container (`len == 0`) — not an error, the same
 /// convention as [`encode_empty_schedule`].
 ///
@@ -2735,8 +2746,14 @@ pub unsafe extern "C" fn zcashlc_migration_transaction_statuses(
     network_id: u32,
 ) -> *mut FfiMigrationTransactionStatuses {
     let res = catch_panic(|| {
-        let mut ctx = unsafe { open(db_data, db_data_len, account_uuid_bytes, network_id)? };
-        let Some(state) = reconcile_mined(&mut ctx)? else {
+        let mut ctx = unsafe { open_read(db_data, db_data_len, account_uuid_bytes, network_id)? };
+        let Some(state) = ({
+            let backend = Backend::new(&ctx.wallet, ctx.account, None, &mut ctx.store_conn)?;
+            // `latest_migration`, not the pending-only `get_migration`: unlike the sibling reads
+            // (whose terminal answer equals their no-run answer), this view keeps rendering a
+            // TERMINAL run's rows — a completed migration's mined transfers stay listed.
+            backend.latest_migration()?
+        }) else {
             return Ok(encode_empty_transaction_statuses());
         };
         if state.transactions().is_empty() {
@@ -2817,8 +2834,11 @@ pub unsafe extern "C" fn zcashlc_migration_has_overdue_transfers(
     estimated_tip: i64,
 ) -> bool {
     let res = catch_panic(|| {
-        let mut ctx = unsafe { open(db_data, db_data_len, account_uuid_bytes, network_id)? };
-        let Some(state) = reconcile_mined(&mut ctx)? else {
+        let mut ctx = unsafe { open_read(db_data, db_data_len, account_uuid_bytes, network_id)? };
+        let Some(state) = ({
+            let backend = Backend::new(&ctx.wallet, ctx.account, None, &mut ctx.store_conn)?;
+            backend.get_migration()?
+        }) else {
             return Ok(false);
         };
         if state.is_terminal() {
@@ -2848,8 +2868,11 @@ pub unsafe extern "C" fn zcashlc_migration_has_invalid_transfers(
     network_id: u32,
 ) -> bool {
     let res = catch_panic(|| {
-        let mut ctx = unsafe { open(db_data, db_data_len, account_uuid_bytes, network_id)? };
-        let Some(state) = reconcile_mined(&mut ctx)? else {
+        let mut ctx = unsafe { open_read(db_data, db_data_len, account_uuid_bytes, network_id)? };
+        let Some(state) = ({
+            let backend = Backend::new(&ctx.wallet, ctx.account, None, &mut ctx.store_conn)?;
+            backend.get_migration()?
+        }) else {
             return Ok(false);
         };
         if state.is_terminal() {
@@ -2883,9 +2906,12 @@ pub unsafe extern "C" fn zcashlc_migration_has_invalid_transfers(
 /// Whether the stored, NON-TERMINAL run has a broadcast the platform could serve RIGHT NOW: a
 /// `Proved`, schedule-due, dependency-mined, unexpired transaction, per upstream's own
 /// broadcast-queue read (`next_due_broadcast`) at the [`dueness_targets`] of the scanned tip and
-/// `estimated_tip` (`-1` = disabled). Reconciles mined transactions first, like every other
-/// read. Returns `1` for yes, `0` for no (including no stored run and a terminal run), `-1` on
-/// error (see `zcashlc_last_error_message`).
+/// `estimated_tip` (`-1` = disabled). Pure read of the PERSISTED run (read-only connections; no
+/// reconcile): a Broadcast row the wallet has since scanned as mined is reported Mined only after
+/// a write lane — the advance-step engine sweep, the prove sweep, or a delivery serve — persists
+/// the promotion; while a run is live the platform drives one of those at least every open-lane
+/// pass and 30 s tick. Returns `1` for yes, `0` for no (including no stored run and a terminal
+/// run), `-1` on error (see `zcashlc_last_error_message`).
 ///
 /// This is the sync-gate's work-pending predicate: `1` means exactly "a PROVED, due, unexpired,
 /// valid transfer is waiting", the one situation where the platform should broadcast instead of
@@ -2908,8 +2934,11 @@ pub unsafe extern "C" fn zcashlc_migration_has_ready_broadcast(
     estimated_tip: i64,
 ) -> i32 {
     let res = catch_panic(|| {
-        let mut ctx = unsafe { open(db_data, db_data_len, account_uuid_bytes, network_id)? };
-        let Some(state) = reconcile_mined(&mut ctx)? else {
+        let mut ctx = unsafe { open_read(db_data, db_data_len, account_uuid_bytes, network_id)? };
+        let Some(state) = ({
+            let backend = Backend::new(&ctx.wallet, ctx.account, None, &mut ctx.store_conn)?;
+            backend.get_migration()?
+        }) else {
             return Ok(0);
         };
         if state.is_terminal() {
@@ -8389,17 +8418,20 @@ mod tests {
         let _ = std::fs::remove_file(&path);
     }
 
-    /// 3. Reconciliation runs at the head of this read too (the same convention as
-    /// [`zcashlc_migration_advance_step`]): a stored `Broadcast` transfer whose txid the WALLET's own
-    /// `transactions` table now shows mined is reported — and PERSISTED — as `Mined`, not
-    /// `Broadcast`. Mirrors
-    /// [`resolve_immediate_run_reads_mined_and_expiry_from_transactions_table`]'s technique of
-    /// inserting directly into a `transactions` table, but against the REAL wallet schema (that
-    /// test's table is a hand-rolled two-column stand-in; `ctx.wallet.get_tx_height` reads the
-    /// real `zcash_client_sqlite` schema, so this fixture inserts the columns that schema
-    /// requires: `txid`, `mined_height`, and the `NOT NULL` `min_observed_height`).
+    /// 3. RO-T2: `zcashlc_migration_transaction_statuses` is a PURE read of the persisted run — it
+    /// no longer reconciles at the head of the read (unlike [`zcashlc_migration_advance_step`],
+    /// which still sweeps as part of driving). A stored `Broadcast` transfer whose txid the
+    /// WALLET's own `transactions` table already shows mined (and which the wallet has already
+    /// scanned through) is still reported — and stays stored — as `Broadcast`: only a write lane
+    /// (the advance-step sweep, the prove sweep, or a delivery serve) persists that promotion.
+    /// Mirrors [`resolve_immediate_run_reads_mined_and_expiry_from_transactions_table`]'s
+    /// technique of inserting directly into a `transactions` table, but against the REAL wallet
+    /// schema (that test's table is a hand-rolled two-column stand-in;
+    /// `ctx.wallet.get_tx_height` reads the real `zcash_client_sqlite` schema, so this fixture
+    /// inserts the columns that schema requires: `txid`, `mined_height`, and the `NOT NULL`
+    /// `min_observed_height`).
     #[test]
-    fn migration_transaction_statuses_reconciles_a_mined_broadcast_transfer() {
+    fn migration_transaction_statuses_does_not_reconcile_a_mined_broadcast_transfer() {
         let path = init_fixture_db("zcashlc_migration_tx_statuses_reconcile");
         let path_bytes = path.to_str().unwrap().as_bytes();
         let account = create_fixture_account(&path);
@@ -8459,20 +8491,21 @@ mod tests {
         assert_eq!(statuses.len, 1);
         let row = unsafe { &*statuses.ptr };
         assert_eq!(
-            row.state, 4,
-            "the row must report Mined once the wallet shows it mined"
+            row.state, 3,
+            "a pure read reports the PERSISTED state (Broadcast) even once the wallet's own scan \
+             shows the txid mined"
         );
         assert_eq!(
-            row.mined_height,
-            i64::from(mined_at),
-            "the reported mined height must be the wallet's"
+            row.mined_height, -1,
+            "unreconciled, the row carries no mined height"
         );
-        assert!(row.has_txid, "the mined lifecycle state retains its txid");
-        assert_eq!(row.txid, txid, "the mined lifecycle state retains its txid");
+        assert!(row.has_txid, "the broadcast lifecycle state retains its txid");
+        assert_eq!(row.txid, txid, "the broadcast lifecycle state retains its txid");
         unsafe { zcashlc_free_migration_transaction_statuses(statuses_ptr) };
 
-        // The reconciliation must be PERSISTED, not just reported for this one read — the
-        // read-path convention every sibling read follows.
+        // No reconciliation happened, so nothing was persisted either — the read-only
+        // connections this entry point opens through (`open_read`) could not write even if it
+        // tried.
         let stored = read_fixture_state(&path, &account);
         let stored_tx = stored
             .transactions()
@@ -8482,9 +8515,9 @@ mod tests {
         assert!(
             matches!(
                 stored_tx.state(),
-                MigrationTxState::Mined { height, .. } if height == h(mined_at)
+                MigrationTxState::Broadcast { txid: stored_txid } if stored_txid == TxId::from_bytes(txid)
             ),
-            "reconciliation must persist Broadcast -> Mined"
+            "a pure read must not mutate the stored run"
         );
 
         let _ = std::fs::remove_file(&path);
@@ -9546,6 +9579,75 @@ mod tests {
             matches!(stored.transactions()[1].state(), MigrationTxState::Signed),
             "the unrelated row must be untouched"
         );
+        let _ = std::fs::remove_file(&path);
+    }
+
+    // ----- pure-read rewire parity (RO-T2) -----
+
+    /// Parity harness for the pure-read rewire: on a freshly initialized wallet database (no
+    /// accounts, chain tip set) the four boolean/scalar read wrappers answer exactly what they
+    /// answer today. Written BEFORE the rewire (green against the reconcile-first bodies) and
+    /// kept green after it.
+    #[test]
+    fn pure_read_wrappers_fresh_db_answers_are_stable() {
+        let path = std::env::temp_dir().join(format!(
+            "zcashlc_pure_read_parity_{}.sqlite",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_file(&path);
+        let path_bytes = path.to_str().unwrap().as_bytes();
+        let init = unsafe {
+            crate::zcashlc_init_data_database(
+                path_bytes.as_ptr(),
+                path_bytes.len(),
+                std::ptr::null(),
+                0,
+                NETWORK_ID_MAINNET,
+            )
+        };
+        assert!(init >= 0, "wallet-db initialization must succeed");
+        assert!(unsafe {
+            crate::zcashlc_update_chain_tip(path_bytes.as_ptr(), path_bytes.len(), 3_000_000, NETWORK_ID_MAINNET)
+        });
+        let account = [7u8; 16];
+        // Unknown account: the store constructor reports AccountUnknown down every one of these
+        // paths, and each wrapper coerces per ITS OWN error convention — pinned here verbatim.
+        let overdue = unsafe {
+            zcashlc_migration_has_overdue_transfers(
+                path_bytes.as_ptr(), path_bytes.len(), account.as_ptr(), NETWORK_ID_MAINNET, -1,
+            )
+        };
+        assert!(!overdue, "error path coerces to false");
+        let invalid = unsafe {
+            zcashlc_migration_has_invalid_transfers(
+                path_bytes.as_ptr(), path_bytes.len(), account.as_ptr(), NETWORK_ID_MAINNET,
+            )
+        };
+        assert!(!invalid, "error path coerces to false");
+        let ready = unsafe {
+            zcashlc_migration_has_ready_broadcast(
+                path_bytes.as_ptr(), path_bytes.len(), account.as_ptr(), NETWORK_ID_MAINNET, -1,
+            )
+        };
+        assert_eq!(ready, -1, "error path reports -1");
+        let statuses = unsafe {
+            zcashlc_migration_transaction_statuses(
+                path_bytes.as_ptr(), path_bytes.len(), account.as_ptr(), NETWORK_ID_MAINNET,
+            )
+        };
+        assert!(statuses.is_null(), "error path reports null");
+        let progress = unsafe {
+            zcashlc_migration_progress(
+                path_bytes.as_ptr(), path_bytes.len(), account.as_ptr(), NETWORK_ID_MAINNET,
+            )
+        };
+        assert!(progress.is_null(), "error path reports null");
+        let wakeups = unsafe {
+            zcashlc_migration_sync_wakeups(
+                path_bytes.as_ptr(), path_bytes.len(), account.as_ptr(), NETWORK_ID_MAINNET,
+            )
+        };
+        assert!(wakeups.is_null(), "error path reports null");
         let _ = std::fs::remove_file(&path);
     }
 }

--- a/rust/src/migration.rs
+++ b/rust/src/migration.rs
@@ -2476,8 +2476,9 @@ pub unsafe extern "C" fn zcashlc_migration_progress(
 /// legitimately differ — recompute (and re-register with the OS) after any state change rather
 /// than caching. Pure read of the PERSISTED run (read-only connections; no reconcile): a Broadcast
 /// row the wallet has since scanned as mined is reported Mined only after a write lane — the
-/// advance-step engine sweep, the prove sweep, or a delivery serve — persists the promotion; while
-/// a run is live the platform drives one of those at least every open-lane pass and 30 s tick.
+/// advance-step engine sweep, the prove sweep, or a delivery serve — persists the promotion; a
+/// platform drives one of those on its open-lane passes, sync edges, and UI-refresh passes, so a
+/// live run's reads trail a just-mined broadcast by at most one such pass.
 ///
 /// No stored run, a terminal run, or no transfer still needing a proof returns the EMPTY schedule
 /// (`len == 0`, valid pointer) — not an error. A stored transfer that admits NO valid wake-up
@@ -2729,10 +2730,10 @@ fn encode_transaction_status(
 /// decides what to sign/prove/broadcast next. Pure read of the PERSISTED run (read-only
 /// connections; no reconcile): a Broadcast row the wallet has since scanned as mined is reported
 /// Mined only after a write lane — the advance-step engine sweep, the prove sweep, or a delivery
-/// serve — persists the promotion; while a run is live the platform drives one of those at least
-/// every open-lane pass and 30 s tick. No stored run, or a stored run
-/// with no transactions, returns an EMPTY container (`len == 0`) — not an error, the same
-/// convention as [`encode_empty_schedule`].
+/// serve — persists the promotion; a platform drives one of those on its open-lane passes, sync
+/// edges, and UI-refresh passes, so a live run's reads trail a just-mined broadcast by at most one
+/// such pass. No stored run, or a stored run with no transactions, returns an EMPTY container
+/// (`len == 0`) — not an error, the same convention as [`encode_empty_schedule`].
 ///
 /// This is a pure read: unlike [`zcashlc_migration_next_due_transfer`] it never drives a
 /// prove-ready `Signed` row through proving — a `Signed` row ready to prove is reported via
@@ -2911,9 +2912,10 @@ pub unsafe extern "C" fn zcashlc_migration_has_invalid_transfers(
 /// `estimated_tip` (`-1` = disabled). Pure read of the PERSISTED run (read-only connections; no
 /// reconcile): a Broadcast row the wallet has since scanned as mined is reported Mined only after
 /// a write lane — the advance-step engine sweep, the prove sweep, or a delivery serve — persists
-/// the promotion; while a run is live the platform drives one of those at least every open-lane
-/// pass and 30 s tick. Returns `1` for yes, `0` for no (including no stored run and a terminal
-/// run), `-1` on error (see `zcashlc_last_error_message`).
+/// the promotion; a platform drives one of those on its open-lane passes, sync edges, and
+/// UI-refresh passes, so a live run's reads trail a just-mined broadcast by at most one such pass.
+/// Returns `1` for yes, `0` for no (including no stored run and a terminal run), `-1` on error (see
+/// `zcashlc_last_error_message`).
 ///
 /// This is the sync-gate's work-pending predicate: `1` means exactly "a PROVED, due, unexpired,
 /// valid transfer is waiting", the one situation where the platform should broadcast instead of


### PR DESCRIPTION
Stacked on #1951 (the D1+D2 + pin-move branch; carries the librustzcash pin at the rebased michal/pool-migration-public-next-due head, 41a1e17c).

The six migration read entry points — statuses, progress, has_overdue, has_invalid,
has_ready_broadcast, sync_wakeups — were "read-shaped but WRITE": each ran `reconcile_mined`
first, whose conditional whole-run rewrite pinned them to the Swift write actor, so every UI
and gate read queued behind in-flight proof chunks. They now open through a new `open_read()`
(both connections SQLITE_OPEN_READ_ONLY, preamble writers skipped) and report the persisted
run as-is.

Correctness: Broadcast→Mined promotion is still persisted on every write-lane call —
`advance_migration` sweeps mined-ness itself (see the advance_step wrapper's comment), and the
prove/serve lanes still reconcile — so a read trails a just-mined broadcast by at most one
drive pass. Read-only-ness is machine-enforced (a write down a read path fails
SQLITE_READONLY, pinned by test); fresh-DB error-path answers are pinned before and after the
switch; the progress path tolerates the lazily-created `sdk_immediate_runs` table being absent.

Swift side: the six methods move to the DB-READ side of the actor split (no signature
changes); DBActor's header documents the machine-enforced exception.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

