### PR TITLE
Move the librustzcash pin to the exact-funding head (batch Prove + outlook + adapter snapshot)

### DIFF
--- a/.github/actions/authorize-slipstream/action.yml
+++ b/.github/actions/authorize-slipstream/action.yml
@@ -35,7 +35,7 @@ runs:
         # The App is installed on zodl-inc, not on this repository's owner, so the installation
         # to mint against has to be named explicitly.
         owner: zodl-inc
-        repositories: slipstream
+        repositories: slipstream-internal
         # Narrow the minted token to exactly what cargo needs, rather than inheriting whatever
         # the App's installation happens to hold. Fetching a git dependency is a read of repository
         # contents and nothing more.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -190,14 +190,14 @@ Changes are relative to `2.8.0-rc.3`.
   `MigrationTransactionStatus`, `DueMigrationTransfer`, `KeystoneBatchDecodeResult`, and
   `KeystoneFirmwareVersion`. Migration transaction ids are `UInt32`.
 - State: `migrationAdvanceStep(accountUUID:)` drives the migration engine's public
-  `advance_migration` decision at the scanned chain tip — `nil` when no run is stored, otherwise
-  `.requiresAttention(id:)` (the engine returned `Reevaluate` after a node rejection or `Replan`
-  after determining a transaction unsatisfiable), `.prove(transactions:)`, `.broadcast(id:)`, `.rebuild(id:)`,
-  `.waiting`, or the terminal `.complete` (per-run, including a cancelled run — never "nothing
-  left to migrate"; ask `proposeMigrationTransfers` for that). The SDK adds no state machine, no
-  ordering shims, and no carve-outs of its own on top of the engine's answer — the attention step
-  and the broadcast-first ordering are native to the pinned librustzcash revision (upstream PR
-  #2871).
+  `advance_migration` decision at the scanned chain tip — `nil` when no run is stored, otherwise a
+  `MigrationAdvance` whose `.step` is `.requiresAttention(id:)` (the engine returned `Reevaluate`
+  after a node rejection or `Replan` after determining a transaction unsatisfiable),
+  `.prove(transactions:)`, `.broadcast(id:)`, `.rebuild(id:)`, `.waiting`, or the terminal
+  `.complete` (per-run, including a cancelled run — never "nothing left to migrate"; ask
+  `proposeMigrationTransfers` for that). The SDK adds no state machine, no ordering shims, and no
+  carve-outs of its own on top of the engine's answer — the attention step and the broadcast-first
+  ordering are native to the pinned librustzcash revision (upstream PR #2871).
 - Planning and delivery: a randomized-cadence schedule proposal committed by
   `signAndStoreMigrationSchedule`, proved opportunistically during sync by the new
   `finalizeReadyMigrationTransfers(accountUUID:)`, then delivered by

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,8 +31,8 @@ Changes are relative to `2.8.0-rc.3`.
   the schedule is due behind it), so a wallet driven in short foreground sessions can actually
   prove and broadcast the released step instead of livelocking with its schedule re-pinned past
   the scan on every open — librustzcash #2936: `advance_migration` returns the verified step
-  together with a next-wake outlook (this FFI marshals the step — now the batch-Prove generation
-  described above — alone for now) — and the engine's
+  together with a next-wake outlook; this FFI marshals both (the outlook surfaces on the Swift
+  side as `MigrationAdvance.next` — see the `migrationAdvanceStep` entry below) — and the engine's
   note-locking generation: a proved migration transaction's spent notes are reserved in the
   wallet database, so an ordinary payment proposed mid-migration can no longer spend a note a
   stored, proved transfer is already committed to. It also carries `MigrationState`'s public
@@ -44,6 +44,14 @@ Changes are relative to `2.8.0-rc.3`.
   (`AdvanceConfig::with_compressed_schedule_floors`) left the pinned lineage, and this SDK no
   longer derives or passes them. The pin reverts to published crates at the first rc containing
   all of it.
+- `migrationAdvanceStep(accountUUID:)` (and the welding pair) now returns `MigrationAdvance?` —
+  the same step wrapped with the engine's advisory OUTLOOK (librustzcash #2936): `next` names the
+  kind of the migration's next serviceable work and the earliest target height it becomes
+  serviceable at, assuming the returned step is executed (`nil` = nothing height-schedulable).
+  Call sites unwrap `.step` where they switched on the step before; the outlook lets a host
+  register its next wake-up from the engine's own plan — a `.broadcast` outlook needs no sync
+  session, a `.prove` one is sync-bound. `migrationSyncWakeups` remains the proving-schedule
+  authority; the outlook is one step of lookahead, superseded by the next call.
 - Restarting a migration (`restartCurrentMigrationStep`) now cancels the stored run through the
   engine's own cancel: the run is recorded with the terminal `Cancelled` status (previously
   `Failed`, which left a deliberate abandonment indistinguishable from a broken run) and every
@@ -184,7 +192,7 @@ Changes are relative to `2.8.0-rc.3`.
 - State: `migrationAdvanceStep(accountUUID:)` drives the migration engine's public
   `advance_migration` decision at the scanned chain tip — `nil` when no run is stored, otherwise
   `.requiresAttention(id:)` (the engine returned `Reevaluate` after a node rejection or `Replan`
-  after determining a transaction unsatisfiable), `.prove(id:kind:)`, `.broadcast(id:)`, `.rebuild(id:)`,
+  after determining a transaction unsatisfiable), `.prove(transactions:)`, `.broadcast(id:)`, `.rebuild(id:)`,
   `.waiting`, or the terminal `.complete` (per-run, including a cancelled run — never "nothing
   left to migrate"; ask `proposeMigrationTransfers` for that). The SDK adds no state machine, no
   ordering shims, and no carve-outs of its own on top of the engine's answer — the attention step

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,14 +10,6 @@ Changes are relative to `2.8.0-rc.3`.
 
 ## Changed
 
-- `MigrationAdvanceStep.prove` now carries the WHOLE provable set —
-  `prove(transactions: [MigrationProveTarget])`, earliest-ready first, never empty — instead of a
-  single `prove(id:kind:)` (librustzcash #2939: proving emits nothing on-chain, so a synced
-  session proves everything provable at once; broadcast stays one-at-a-time on the privacy
-  schedule). An exhaustive `switch` stops compiling until the case is renamed; the discharge is
-  unchanged (`finalizeReadyMigrationTransfers(accountUUID:)` already proves every ready row), so
-  most call sites destructure the first element or the count. `MigrationProveTarget` is the new
-  per-entry pair (`id`, `kind`).
 - The librustzcash family rides an interim git pin (the michal/pool-migration-public-next-due
   branch head, rebased onto librustzcash main) so a wallet's own scheduled migration transactions
   carry their ZIP 318 classification (`Overview.zip318Kind`) from the moment they are STORED at
@@ -32,7 +24,7 @@ Changes are relative to `2.8.0-rc.3`.
   prove and broadcast the released step instead of livelocking with its schedule re-pinned past
   the scan on every open — librustzcash #2936: `advance_migration` returns the verified step
   together with a next-wake outlook; this FFI marshals both (the outlook surfaces on the Swift
-  side as `MigrationAdvance.next` — see the `migrationAdvanceStep` entry below) — and the engine's
+  side as `MigrationAdvance.next` — see the `migrationAdvanceStep` bullet under Added) — and the engine's
   note-locking generation: a proved migration transaction's spent notes are reserved in the
   wallet database, so an ordinary payment proposed mid-migration can no longer spend a note a
   stored, proved transfer is already committed to. It also carries `MigrationState`'s public
@@ -44,14 +36,6 @@ Changes are relative to `2.8.0-rc.3`.
   (`AdvanceConfig::with_compressed_schedule_floors`) left the pinned lineage, and this SDK no
   longer derives or passes them. The pin reverts to published crates at the first rc containing
   all of it.
-- `migrationAdvanceStep(accountUUID:)` (and the welding pair) now returns `MigrationAdvance?` —
-  the same step wrapped with the engine's advisory OUTLOOK (librustzcash #2936): `next` names the
-  kind of the migration's next serviceable work and the earliest target height it becomes
-  serviceable at, assuming the returned step is executed (`nil` = nothing height-schedulable).
-  Call sites unwrap `.step` where they switched on the step before; the outlook lets a host
-  register its next wake-up from the engine's own plan — a `.broadcast` outlook needs no sync
-  session, a `.prove` one is sync-bound. `migrationSyncWakeups` remains the proving-schedule
-  authority; the outlook is one step of lookahead, superseded by the next call.
 - Restarting a migration (`restartCurrentMigrationStep`) now cancels the stored run through the
   engine's own cancel: the run is recorded with the terminal `Cancelled` status (previously
   `Failed`, which left a deliberate abandonment indistinguishable from a broken run) and every
@@ -198,6 +182,15 @@ Changes are relative to `2.8.0-rc.3`.
   `proposeMigrationTransfers` for that). The SDK adds no state machine, no ordering shims, and no
   carve-outs of its own on top of the engine's answer — the attention step and the broadcast-first
   ordering are native to the pinned librustzcash revision (upstream PR #2871).
+  The answer wraps the step with the engine's advisory OUTLOOK (`MigrationAdvance.next`,
+  librustzcash #2936): the kind of the migration's next serviceable work and the earliest target
+  height it becomes serviceable at, assuming the returned step is executed (`nil` = nothing
+  height-schedulable) — a `.broadcast` outlook needs no sync session, a `.prove` one is
+  sync-bound, and `migrationSyncWakeups` remains the proving-schedule authority. A `.prove` step
+  carries the WHOLE provable set (`[MigrationProveTarget]`, earliest-ready first, never empty;
+  librustzcash #2939: proving emits nothing on-chain, so a synced session proves everything
+  provable at once while broadcast stays one-at-a-time on the privacy schedule) — discharge the
+  batch with `finalizeReadyMigrationTransfers(accountUUID:)`.
 - Planning and delivery: a randomized-cadence schedule proposal committed by
   `signAndStoreMigrationSchedule`, proved opportunistically during sync by the new
   `finalizeReadyMigrationTransfers(accountUUID:)`, then delivered by

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ Changes are relative to `2.8.0-rc.3`.
 
 ## Changed
 
+- `MigrationAdvanceStep.prove` now carries the WHOLE provable set —
+  `prove(transactions: [MigrationProveTarget])`, earliest-ready first, never empty — instead of a
+  single `prove(id:kind:)` (librustzcash #2939: proving emits nothing on-chain, so a synced
+  session proves everything provable at once; broadcast stays one-at-a-time on the privacy
+  schedule). An exhaustive `switch` stops compiling until the case is renamed; the discharge is
+  unchanged (`finalizeReadyMigrationTransfers(accountUUID:)` already proves every ready row), so
+  most call sites destructure the first element or the count. `MigrationProveTarget` is the new
+  per-entry pair (`id`, `kind`).
 - The librustzcash family rides an interim git pin (the michal/pool-migration-public-next-due
   branch head, rebased onto librustzcash main) so a wallet's own scheduled migration transactions
   carry their ZIP 318 classification (`Overview.zip318Kind`) from the moment they are STORED at
@@ -23,7 +31,8 @@ Changes are relative to `2.8.0-rc.3`.
   the schedule is due behind it), so a wallet driven in short foreground sessions can actually
   prove and broadcast the released step instead of livelocking with its schedule re-pinned past
   the scan on every open — librustzcash #2936: `advance_migration` returns the verified step
-  together with a next-wake outlook (this FFI marshals the step alone for now) — and the engine's
+  together with a next-wake outlook (this FFI marshals the step — now the batch-Prove generation
+  described above — alone for now) — and the engine's
   note-locking generation: a proved migration transaction's spent notes are reserved in the
   wallet database, so an ordinary payment proposed mid-migration can no longer spend a note a
   stored, proved transfer is already committed to. It also carries `MigrationState`'s public

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1680,7 +1680,7 @@ dependencies = [
 [[package]]
 name = "equihash"
 version = "0.3.0"
-source = "git+https://github.com/zcash/librustzcash?rev=41a1e17c5ac49f30c7424210bfd90db366ef7689#41a1e17c5ac49f30c7424210bfd90db366ef7689"
+source = "git+https://github.com/zcash/librustzcash?rev=4d654982c4cc3d243ba0ee8f595890a19656c15a#4d654982c4cc3d243ba0ee8f595890a19656c15a"
 dependencies = [
  "blake2b_simd",
  "corez",
@@ -1716,7 +1716,7 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.1"
-source = "git+https://github.com/zcash/librustzcash?rev=41a1e17c5ac49f30c7424210bfd90db366ef7689#41a1e17c5ac49f30c7424210bfd90db366ef7689"
+source = "git+https://github.com/zcash/librustzcash?rev=4d654982c4cc3d243ba0ee8f595890a19656c15a#4d654982c4cc3d243ba0ee8f595890a19656c15a"
 dependencies = [
  "blake2b_simd",
 ]
@@ -3610,7 +3610,7 @@ checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
 [[package]]
 name = "pczt"
 version = "0.9.2"
-source = "git+https://github.com/zcash/librustzcash?rev=41a1e17c5ac49f30c7424210bfd90db366ef7689#41a1e17c5ac49f30c7424210bfd90db366ef7689"
+source = "git+https://github.com/zcash/librustzcash?rev=4d654982c4cc3d243ba0ee8f595890a19656c15a#4d654982c4cc3d243ba0ee8f595890a19656c15a"
 dependencies = [
  "blake2b_simd",
  "bls12_381",
@@ -7797,7 +7797,7 @@ dependencies = [
 [[package]]
 name = "zcash_address"
 version = "0.13.0"
-source = "git+https://github.com/zcash/librustzcash?rev=41a1e17c5ac49f30c7424210bfd90db366ef7689#41a1e17c5ac49f30c7424210bfd90db366ef7689"
+source = "git+https://github.com/zcash/librustzcash?rev=4d654982c4cc3d243ba0ee8f595890a19656c15a#4d654982c4cc3d243ba0ee8f595890a19656c15a"
 dependencies = [
  "bech32",
  "bs58",
@@ -7810,7 +7810,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_backend"
 version = "0.24.0-rc.7"
-source = "git+https://github.com/zcash/librustzcash?rev=41a1e17c5ac49f30c7424210bfd90db366ef7689#41a1e17c5ac49f30c7424210bfd90db366ef7689"
+source = "git+https://github.com/zcash/librustzcash?rev=4d654982c4cc3d243ba0ee8f595890a19656c15a#4d654982c4cc3d243ba0ee8f595890a19656c15a"
 dependencies = [
  "arti-client",
  "base64",
@@ -7877,7 +7877,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_sqlite"
 version = "0.22.0-rc.7"
-source = "git+https://github.com/zcash/librustzcash?rev=41a1e17c5ac49f30c7424210bfd90db366ef7689#41a1e17c5ac49f30c7424210bfd90db366ef7689"
+source = "git+https://github.com/zcash/librustzcash?rev=4d654982c4cc3d243ba0ee8f595890a19656c15a#4d654982c4cc3d243ba0ee8f595890a19656c15a"
 dependencies = [
  "bip32",
  "bitflags",
@@ -7937,7 +7937,7 @@ dependencies = [
 [[package]]
 name = "zcash_keys"
 version = "0.16.1"
-source = "git+https://github.com/zcash/librustzcash?rev=41a1e17c5ac49f30c7424210bfd90db366ef7689#41a1e17c5ac49f30c7424210bfd90db366ef7689"
+source = "git+https://github.com/zcash/librustzcash?rev=4d654982c4cc3d243ba0ee8f595890a19656c15a#4d654982c4cc3d243ba0ee8f595890a19656c15a"
 dependencies = [
  "bech32",
  "bip32",
@@ -7979,7 +7979,7 @@ dependencies = [
 [[package]]
 name = "zcash_pool_migration"
 version = "0.1.0-rc.6"
-source = "git+https://github.com/zcash/librustzcash?rev=41a1e17c5ac49f30c7424210bfd90db366ef7689#41a1e17c5ac49f30c7424210bfd90db366ef7689"
+source = "git+https://github.com/zcash/librustzcash?rev=4d654982c4cc3d243ba0ee8f595890a19656c15a#4d654982c4cc3d243ba0ee8f595890a19656c15a"
 dependencies = [
  "blake2b_simd",
  "corez",
@@ -8000,7 +8000,7 @@ dependencies = [
 [[package]]
 name = "zcash_primitives"
 version = "0.30.0"
-source = "git+https://github.com/zcash/librustzcash?rev=41a1e17c5ac49f30c7424210bfd90db366ef7689#41a1e17c5ac49f30c7424210bfd90db366ef7689"
+source = "git+https://github.com/zcash/librustzcash?rev=4d654982c4cc3d243ba0ee8f595890a19656c15a#4d654982c4cc3d243ba0ee8f595890a19656c15a"
 dependencies = [
  "blake2b_simd",
  "block-buffer 0.11.0-rc.3",
@@ -8030,7 +8030,7 @@ dependencies = [
 [[package]]
 name = "zcash_proofs"
 version = "0.30.0"
-source = "git+https://github.com/zcash/librustzcash?rev=41a1e17c5ac49f30c7424210bfd90db366ef7689#41a1e17c5ac49f30c7424210bfd90db366ef7689"
+source = "git+https://github.com/zcash/librustzcash?rev=4d654982c4cc3d243ba0ee8f595890a19656c15a#4d654982c4cc3d243ba0ee8f595890a19656c15a"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -8051,7 +8051,7 @@ dependencies = [
 [[package]]
 name = "zcash_protocol"
 version = "0.10.4"
-source = "git+https://github.com/zcash/librustzcash?rev=41a1e17c5ac49f30c7424210bfd90db366ef7689#41a1e17c5ac49f30c7424210bfd90db366ef7689"
+source = "git+https://github.com/zcash/librustzcash?rev=4d654982c4cc3d243ba0ee8f595890a19656c15a#4d654982c4cc3d243ba0ee8f595890a19656c15a"
 dependencies = [
  "corez",
  "document-features",
@@ -8089,7 +8089,7 @@ dependencies = [
 [[package]]
 name = "zcash_transparent"
 version = "0.10.0"
-source = "git+https://github.com/zcash/librustzcash?rev=41a1e17c5ac49f30c7424210bfd90db366ef7689#41a1e17c5ac49f30c7424210bfd90db366ef7689"
+source = "git+https://github.com/zcash/librustzcash?rev=4d654982c4cc3d243ba0ee8f595890a19656c15a#4d654982c4cc3d243ba0ee8f595890a19656c15a"
 dependencies = [
  "bip32",
  "bs58",
@@ -8182,7 +8182,7 @@ dependencies = [
 [[package]]
 name = "zip321"
 version = "0.9.0-rc.1"
-source = "git+https://github.com/zcash/librustzcash?rev=41a1e17c5ac49f30c7424210bfd90db366ef7689#41a1e17c5ac49f30c7424210bfd90db366ef7689"
+source = "git+https://github.com/zcash/librustzcash?rev=4d654982c4cc3d243ba0ee8f595890a19656c15a#4d654982c4cc3d243ba0ee8f595890a19656c15a"
 dependencies = [
  "base64",
  "nom",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5042,7 +5042,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 [[package]]
 name = "slipstream-core"
 version = "0.6.4"
-source = "git+https://github.com/zodl-inc/slipstream.git?rev=ab89ada45f2ef893a05fcefa0ead99f87d848a4e#ab89ada45f2ef893a05fcefa0ead99f87d848a4e"
+source = "git+https://github.com/zodl-inc/slipstream-internal.git?rev=ab89ada45f2ef893a05fcefa0ead99f87d848a4e#ab89ada45f2ef893a05fcefa0ead99f87d848a4e"
 dependencies = [
  "ff",
  "futures-util",
@@ -5082,7 +5082,7 @@ dependencies = [
 [[package]]
 name = "slipstream-gpuhash"
 version = "0.0.1"
-source = "git+https://github.com/zodl-inc/slipstream.git?rev=ab89ada45f2ef893a05fcefa0ead99f87d848a4e#ab89ada45f2ef893a05fcefa0ead99f87d848a4e"
+source = "git+https://github.com/zodl-inc/slipstream-internal.git?rev=ab89ada45f2ef893a05fcefa0ead99f87d848a4e#ab89ada45f2ef893a05fcefa0ead99f87d848a4e"
 dependencies = [
  "bytemuck",
  "ff",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -163,30 +163,33 @@ lto = true
 slipstream-core = { git = "https://github.com/zodl-inc/slipstream.git", rev = "ab89ada45f2ef893a05fcefa0ead99f87d848a4e" }
 
 ## Update the `rev` value in the following lines to use a hash-pinned version of the librustzcash crates.
-# INTERIM PIN (MOB-1466): the michal/pool-migration-public-next-due branch head, rebased onto
-# librustzcash main. Main itself now carries #2909 (migration transactions classified against
-# ZIP 318 at store time — what the app's Activity labels key on), #2907 (engine next_*
-# selection ordered by height), #2910 (a missed broadcast schedule is re-spread on resume),
-# and #2936 (advance_migration returns satisfiability::Advance: the verified step plus the
-# next-wake outlook). On top of main the pin adds #2927 (the released overdue step lands on
-# scanned chain data, and the re-spread fires only for a due cluster — without this a
-# short-session wallet livelocks, its schedule re-pinned past the scan on every foreground)
-# and MigrationState's public read-only next-due selection (next_due_broadcast/next_provable —
-# a caller reads the engine's own delivery-lane choice instead of recomputing it client-side).
-# The compressed-schedule spacing floors (#2932) left this lineage when the stack was
-# restructured and are no longer carried.
+# INTERIM PIN (MOB-1466): the michal/tmp-next-due-plus-exact-funding-note-count branch head —
+# the previous pin's rebased public next-due selection (#2927's scanned-chain-tip overdue
+# re-spread and MigrationState's public read-only next-due selection,
+# next_due_broadcast/next_provable — a caller reads the engine's own delivery-lane choice
+# instead of recomputing it client-side) merged with the #2949 exact-funding-note-count
+# follow-up. Main itself now also carries #2909 (migration transactions classified against ZIP
+# 318 at store time — what the app's Activity labels key on), #2907 (engine next_* selection
+# ordered by height), #2910 (a missed broadcast schedule is re-spread on resume), #2936
+# (advance_migration returns satisfiability::Advance: the verified step plus the next-wake
+# outlook), #2939 (the Prove step serves the whole provable set, gated on a reorg-stable anchor
+# depth), #2946 (the upstream wallet adapter snapshots spendable notes — commit-time signing
+# linear, not quadratic), #2943 (first-fit-decreasing preparation strategy), #2945/#2947
+# (denomination follow-ups: exact funding notes preserved, quantize-once/truncation,
+# shape-bounded floors), and #2916/#2915/#2911 (ZIP 318 classification written at store time;
+# idempotent sent-transaction stores).
 # Remove the pin (recomment the block) at the first published rc that contains all of it.
-pczt = { git = "https://github.com/zcash/librustzcash", rev = "41a1e17c5ac49f30c7424210bfd90db366ef7689" }
-zcash_address = { git = "https://github.com/zcash/librustzcash", rev = "41a1e17c5ac49f30c7424210bfd90db366ef7689" }
-zcash_client_backend = { git = "https://github.com/zcash/librustzcash", rev = "41a1e17c5ac49f30c7424210bfd90db366ef7689" }
-zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash", rev = "41a1e17c5ac49f30c7424210bfd90db366ef7689" }
-zcash_keys = { git = "https://github.com/zcash/librustzcash", rev = "41a1e17c5ac49f30c7424210bfd90db366ef7689" }
-zcash_pool_migration = { git = "https://github.com/zcash/librustzcash", rev = "41a1e17c5ac49f30c7424210bfd90db366ef7689" }
-zcash_primitives = { git = "https://github.com/zcash/librustzcash", rev = "41a1e17c5ac49f30c7424210bfd90db366ef7689" }
-zcash_proofs = { git = "https://github.com/zcash/librustzcash", rev = "41a1e17c5ac49f30c7424210bfd90db366ef7689" }
-zcash_protocol = { git = "https://github.com/zcash/librustzcash", rev = "41a1e17c5ac49f30c7424210bfd90db366ef7689" }
-zcash_transparent = { git = "https://github.com/zcash/librustzcash", rev = "41a1e17c5ac49f30c7424210bfd90db366ef7689" }
-zip321 = { git = "https://github.com/zcash/librustzcash", rev = "41a1e17c5ac49f30c7424210bfd90db366ef7689" }
+pczt = { git = "https://github.com/zcash/librustzcash", rev = "4d654982c4cc3d243ba0ee8f595890a19656c15a" }
+zcash_address = { git = "https://github.com/zcash/librustzcash", rev = "4d654982c4cc3d243ba0ee8f595890a19656c15a" }
+zcash_client_backend = { git = "https://github.com/zcash/librustzcash", rev = "4d654982c4cc3d243ba0ee8f595890a19656c15a" }
+zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash", rev = "4d654982c4cc3d243ba0ee8f595890a19656c15a" }
+zcash_keys = { git = "https://github.com/zcash/librustzcash", rev = "4d654982c4cc3d243ba0ee8f595890a19656c15a" }
+zcash_pool_migration = { git = "https://github.com/zcash/librustzcash", rev = "4d654982c4cc3d243ba0ee8f595890a19656c15a" }
+zcash_primitives = { git = "https://github.com/zcash/librustzcash", rev = "4d654982c4cc3d243ba0ee8f595890a19656c15a" }
+zcash_proofs = { git = "https://github.com/zcash/librustzcash", rev = "4d654982c4cc3d243ba0ee8f595890a19656c15a" }
+zcash_protocol = { git = "https://github.com/zcash/librustzcash", rev = "4d654982c4cc3d243ba0ee8f595890a19656c15a" }
+zcash_transparent = { git = "https://github.com/zcash/librustzcash", rev = "4d654982c4cc3d243ba0ee8f595890a19656c15a" }
+zip321 = { git = "https://github.com/zcash/librustzcash", rev = "4d654982c4cc3d243ba0ee8f595890a19656c15a" }
 
 # Reinstate together with the voting dependencies above:
 # zcash_voting = { git = "https://github.com/valargroup/zcash_voting.git", rev = "e53e74487d31ad0f5713580fb2f0222b53ae9db8" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -160,7 +160,7 @@ lto = true
 # build can pick up code nobody reviewed, whereas a stale hash fails loudly. Keep it in step with
 # the librustzcash generation the versions above declare: a rev built against an older generation
 # cannot resolve against them.
-slipstream-core = { git = "https://github.com/zodl-inc/slipstream.git", rev = "ab89ada45f2ef893a05fcefa0ead99f87d848a4e" }
+slipstream-core = { git = "https://github.com/zodl-inc/slipstream-internal.git", rev = "ab89ada45f2ef893a05fcefa0ead99f87d848a4e" }
 
 ## Update the `rev` value in the following lines to use a hash-pinned version of the librustzcash crates.
 # INTERIM PIN (MOB-1466): the michal/tmp-next-due-plus-exact-funding-note-count branch head —

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -5,14 +5,16 @@
 The public 5-state `MigrationState` enum, `MigrationAttentionReason`, and
 `migrationState(accountUUID:)` are removed (this was never in a released SDK, so there is no
 deprecation period). The SDK no longer derives a state machine of its own on top of the engine at
-all: `migrationAdvanceStep(accountUUID:) async throws -> MigrationAdvanceStep?` drives the
-upstream engine's public `advance_migration` API. The broadcast-first ordering and prove step's
-kind are native to the pinned librustzcash revision (upstream PR #2871); its `Reevaluate` and
-`Replan` results project onto the existing `.requiresAttention(id:)` case.
-`nil` means no run is stored at all (nothing was ever committed for the account); a stored run
-answers `.requiresAttention(id:)`, `.prove(transactions:)`, `.broadcast(id:)`, `.rebuild(id:)`,
-`.waiting`, or the terminal `.complete` — priority order attend > broadcast > prove > rebuild, and
-a cancelled run also reports `.complete` rather than ever being driven further.
+all: `migrationAdvanceStep(accountUUID:) async throws -> MigrationAdvance?` drives the upstream
+engine's public `advance_migration` API (the return type wraps the step with an advisory outlook —
+see "`migrationAdvanceStep` returns `MigrationAdvance`" below). The broadcast-first ordering and
+prove step's kind are native to the pinned librustzcash revision (upstream PR #2871); its
+`Reevaluate` and `Replan` results project onto the existing `.requiresAttention(id:)` case.
+`nil` means no run is stored at all (nothing was ever committed for the account); a stored run's
+`.step` answers `.requiresAttention(id:)`, `.prove(transactions:)`, `.broadcast(id:)`,
+`.rebuild(id:)`, `.waiting`, or the terminal `.complete` — priority order attend > broadcast >
+prove > rebuild, and a cancelled run also reports `.complete` rather than ever being driven
+further.
 
 Every `MigrationState` case a host rendered UI off has a direct replacement — table below — but note
 the shape is different: `migrationAdvanceStep` answers "what does the run need next", not "what is

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -199,6 +199,39 @@ reasons:
    informational query (re-arm background execution, launch reconciliation); it is no longer
    consulted by any gate path.
 
+## `migrationAdvanceStep` returns `MigrationAdvance`, wrapping the step with an advisory outlook
+
+`migrationAdvanceStep(accountUUID:)` (and the welding pair) now returns `MigrationAdvance?`
+instead of `MigrationAdvanceStep?`: the same step, plus the engine's advisory OUTLOOK
+(librustzcash #2936) — `next: MigrationNextWork?`, naming the kind of the migration's next
+serviceable work and the earliest target height it becomes serviceable at, assuming the returned
+step is executed (`nil` means nothing height-schedulable: what follows is chain-driven,
+user-driven, or the migration is terminal).
+
+```swift
+// Before
+let step = try await synchronizer.migrationAdvanceStep(accountUUID: accountUUID)
+switch step {
+case .prove(let transactions): ...
+case .broadcast(let id): ...
+...
+}
+
+// After
+let advance = try await synchronizer.migrationAdvanceStep(accountUUID: accountUUID)
+switch advance?.step {
+case .prove(let transactions): ...
+case .broadcast(let id): ...
+...
+}
+// `advance?.next`, when present, says what session to plan for once `.step` is executed -- a
+// `.broadcast` outlook needs no sync, a `.prove` one is sync-bound. `migrationSyncWakeups`
+// remains the proving-schedule authority; the outlook is one call's lookahead only.
+```
+
+Existing call sites that only pattern-matched the step's cases now unwrap `.step` first (or switch
+over `advance?.step` directly, as above); the outlook is additive and safe to ignore.
+
 ## The pool-migration surface rides the final engine
 
 The Orchard→Ironwood migration group (never in a released SDK) is rewired onto the final engine

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -10,7 +10,7 @@ upstream engine's public `advance_migration` API. The broadcast-first ordering a
 kind are native to the pinned librustzcash revision (upstream PR #2871); its `Reevaluate` and
 `Replan` results project onto the existing `.requiresAttention(id:)` case.
 `nil` means no run is stored at all (nothing was ever committed for the account); a stored run
-answers `.requiresAttention(id:)`, `.prove(id:kind:)`, `.broadcast(id:)`, `.rebuild(id:)`,
+answers `.requiresAttention(id:)`, `.prove(transactions:)`, `.broadcast(id:)`, `.rebuild(id:)`,
 `.waiting`, or the terminal `.complete` — priority order attend > broadcast > prove > rebuild, and
 a cancelled run also reports `.complete` rather than ever being driven further.
 
@@ -46,13 +46,19 @@ Discharging each step:
   transfer is never served and gates nothing.
 - `.broadcast(id:)` → `executeNextPendingMigrationTransfer(accountUUID:options:useEstimatedTip:)` —
   submit and end the session (a broadcast session must not sync).
-- `.prove(id:kind:)` with a `.transfer(crossing:)` kind → `finalizeReadyMigrationTransfers(accountUUID:)`
-  at a sync wake-up (see `migrationSyncWakeups(accountUUID:)`); the broadcast then follows in its own
-  LATER session. Proving has no deadline of its own — a missed wake-up defers the proof, never
-  invalidates it.
-- `.prove(id:kind:)` with a `.preparation(layer:index:)` kind → the preparation is due by
-  construction and may be proved (`finalizeReadyMigrationTransfers`) and broadcast at the SAME
-  wake-up.
+- `.prove(transactions:)` → the WHOLE provable batch is ready: `finalizeReadyMigrationTransfers(accountUUID:)`
+  proves every ready row in ONE pass, at a sync wake-up (see `migrationSyncWakeups(accountUUID:)`).
+  Each entry's `kind` says what follows for THAT transaction: a `.transfer(crossing:)` entry's
+  broadcast follows in its own LATER session (proving has no deadline of its own — a missed
+  wake-up defers the proof, never invalidates it), while a `.preparation(layer:index:)` entry is
+  due by construction and may broadcast at the SAME wake-up.
+
+  ```swift
+  // Before
+  case let .prove(id, kind): ...
+  // After
+  case let .prove(transactions): ...  // transactions.first carries what the old single step did
+  ```
 - `.rebuild(id:)` → `refreshStaleMigrationTransfers(accountUUID:usk:)` (needs spend authority — a
   spending key in-process, or the external-signer re-serve ceremony for `usk: nil`).
 - `.waiting` → nothing is actionable now: register OS wake-ups at the heights

--- a/Sources/ZcashLightClientKit/Migration/OrchardMigration.swift
+++ b/Sources/ZcashLightClientKit/Migration/OrchardMigration.swift
@@ -267,10 +267,12 @@ actor OrchardMigration {
     // MARK: - State
 
     /// The engine's next step to advance the stored run, driven with the wallet's scanned target
-    /// and wall-clock estimated target. `nil` means no run is stored; a
-    /// terminal (complete or cancelled) run reports ``MigrationAdvanceStep/complete``. See
-    /// ``MigrationAdvanceStep`` for the step semantics and the discharge mapping.
-    func advanceStep() async throws -> MigrationAdvanceStep? {
+    /// and wall-clock estimated target, paired with its advisory outlook (upstream #2936). `nil`
+    /// means no run is stored; a terminal (complete or cancelled) run reports the returned
+    /// advance's `.step` as ``MigrationAdvanceStep/complete`` (`.next` is always `nil` for it). See
+    /// ``MigrationAdvanceStep`` for the step semantics and the discharge mapping, and
+    /// ``MigrationAdvance`` / ``MigrationNextWork`` for the outlook's contract.
+    func advanceStep() async throws -> MigrationAdvance? {
         let estimatedTip = await MigrationTipEstimation.gatingEstimatedTip(welding: welding, now: now())
         return try await welding.migrationAdvanceStep(for: accountUUID, estimatedTip: estimatedTip)
     }

--- a/Sources/ZcashLightClientKit/Model/MigrationModels.swift
+++ b/Sources/ZcashLightClientKit/Model/MigrationModels.swift
@@ -37,16 +37,18 @@ import Foundation
 ///   `restartCurrentMigrationStep(accountUUID:)` to cancel and re-plan.
 /// - ``broadcast(id:)`` → `executeNextPendingMigrationTransfer(accountUUID:options:useEstimatedTip:)`:
 ///   submit the served transaction and end the session — a broadcast session must not sync.
-/// - ``prove(id:kind:)`` with a ``MigrationTransactionStatus/Kind/transfer(crossing:)`` kind →
+/// - ``prove(transactions:)`` → the WHOLE batch is ready: discharge it in one call with
 ///   `finalizeReadyMigrationTransfers(accountUUID:)` at a sync wake-up (see
-///   `migrationSyncWakeups(accountUUID:)`); the broadcast then follows in its own LATER session.
-///   Proving has no deadline of its own — a transfer's boundary anchor checkpoint is durably
-///   retained, so a missed wake-up defers the proof, never invalidates it.
-/// - ``prove(id:kind:)`` with a ``MigrationTransactionStatus/Kind/preparation(layer:index:)`` kind
-///   → the preparation is due by construction (the engine only reports a preparation prove once
-///   its broadcast height has arrived and its dependencies are mined), and a preparation proves
-///   against a near-tip witnessable anchor rather than a drawn boundary — so it may be proved
-///   (`finalizeReadyMigrationTransfers`) and broadcast at the SAME wake-up.
+///   `migrationSyncWakeups(accountUUID:)`), which proves every ready row in that pass. Each
+///   entry's ``MigrationProveTarget/kind`` distinguishes what follows for THAT transaction: a
+///   ``MigrationTransactionStatus/Kind/transfer(crossing:)`` entry's broadcast follows in its own
+///   LATER session — proving has no deadline of its own, a transfer's boundary anchor checkpoint
+///   is durably retained, so a missed wake-up defers the proof, never invalidates it — while a
+///   ``MigrationTransactionStatus/Kind/preparation(layer:index:)`` entry is due by construction
+///   (the engine only reports a preparation prove once its broadcast height has arrived and its
+///   dependencies are mined) and proves against a near-tip witnessable anchor rather than a drawn
+///   boundary, so it may broadcast at the SAME wake-up. Broadcast itself remains a separate later
+///   step, served one transaction at a time.
 /// - ``rebuild(id:)`` → `refreshStaleMigrationTransfers(accountUUID:usk:)` — needs spend
 ///   authority (a spending key in-process, or the external-signer re-serve ceremony).
 /// - ``waiting`` → nothing is actionable now: register OS wake-ups at the heights
@@ -58,11 +60,32 @@ import Foundation
 /// Per-run, not per-account: whether a migratable balance remains (several successive runs, or
 /// funds received later) is answered by `proposeMigrationTransfers(accountUUID:)` — an empty
 /// schedule means no.
+
+/// One transaction of a ``MigrationAdvanceStep/prove(transactions:)`` batch: the transaction to
+/// prove, with the kind that routes it — a verbatim marshal of the upstream engine's
+/// `ProveTarget`. A preparation may prove and broadcast at the same wake-up; a transfer proves
+/// now and broadcasts in its own later session (see the type doc's discharge mapping).
+public struct MigrationProveTarget: Equatable, Sendable {
+    /// The engine's stable transaction id.
+    public let id: UInt32
+    /// The preparation/transfer distinction, with its payload.
+    public let kind: MigrationTransactionStatus.Kind
+
+    /// Creates a `MigrationProveTarget`.
+    public init(id: UInt32, kind: MigrationTransactionStatus.Kind) {
+        self.id = id
+        self.kind = kind
+    }
+}
+
 public enum MigrationAdvanceStep: Equatable, Sendable {
-    /// The transaction identified by `id` is ready to be proved; `kind` tells a preparation (may
-    /// prove and broadcast at the same wake-up) from a transfer (prove now, broadcast in its own
-    /// later session) — see the type doc's discharge mapping.
-    case prove(id: UInt32, kind: MigrationTransactionStatus.Kind)
+    /// The WHOLE provable set is ready to be proved in one synced session (upstream #2939):
+    /// earliest-ready first, never empty, preparations and transfers possibly mixed. Proving
+    /// emits nothing on-chain, so nothing is gained by leaving provable work on the table while
+    /// a synced session is open — discharge the entire batch with
+    /// `finalizeReadyMigrationTransfers(accountUUID:)`, which proves every ready row in one
+    /// pass. Broadcast remains a separate later step, served one transaction at a time.
+    case prove(transactions: [MigrationProveTarget])
     /// The transaction identified by `id` is proved and due: broadcast it (and end the session).
     case broadcast(id: UInt32)
     /// The transfer identified by `id` expired unmined and must be rebuilt in place.

--- a/Sources/ZcashLightClientKit/Model/MigrationModels.swift
+++ b/Sources/ZcashLightClientKit/Model/MigrationModels.swift
@@ -60,24 +60,6 @@ import Foundation
 /// Per-run, not per-account: whether a migratable balance remains (several successive runs, or
 /// funds received later) is answered by `proposeMigrationTransfers(accountUUID:)` — an empty
 /// schedule means no.
-
-/// One transaction of a ``MigrationAdvanceStep/prove(transactions:)`` batch: the transaction to
-/// prove, with the kind that routes it — a verbatim marshal of the upstream engine's
-/// `ProveTarget`. A preparation may prove and broadcast at the same wake-up; a transfer proves
-/// now and broadcasts in its own later session (see the type doc's discharge mapping).
-public struct MigrationProveTarget: Equatable, Sendable {
-    /// The engine's stable transaction id.
-    public let id: UInt32
-    /// The preparation/transfer distinction, with its payload.
-    public let kind: MigrationTransactionStatus.Kind
-
-    /// Creates a `MigrationProveTarget`.
-    public init(id: UInt32, kind: MigrationTransactionStatus.Kind) {
-        self.id = id
-        self.kind = kind
-    }
-}
-
 public enum MigrationAdvanceStep: Equatable, Sendable {
     /// The WHOLE provable set is ready to be proved in one synced session (upstream #2939):
     /// earliest-ready first, never empty, preparations and transfers possibly mixed. Proving
@@ -100,6 +82,23 @@ public enum MigrationAdvanceStep: Equatable, Sendable {
     /// remains, show the status and use `restartCurrentMigrationStep` (see the type doc's
     /// mapping).
     case requiresAttention(id: UInt32)
+}
+
+/// One transaction of a ``MigrationAdvanceStep/prove(transactions:)`` batch: the transaction to
+/// prove, with the kind that routes it — a verbatim marshal of the upstream engine's
+/// `ProveTarget`. A preparation may prove and broadcast at the same wake-up; a transfer proves
+/// now and broadcasts in its own later session (see the type doc's discharge mapping).
+public struct MigrationProveTarget: Equatable, Sendable {
+    /// The engine's stable transaction id.
+    public let id: UInt32
+    /// The preparation/transfer distinction, with its payload.
+    public let kind: MigrationTransactionStatus.Kind
+
+    /// Creates a `MigrationProveTarget`.
+    public init(id: UInt32, kind: MigrationTransactionStatus.Kind) {
+        self.id = id
+        self.kind = kind
+    }
 }
 
 /// The kind of upcoming work named by a ``MigrationAdvance/next`` outlook — a verbatim marshal of

--- a/Sources/ZcashLightClientKit/Model/MigrationModels.swift
+++ b/Sources/ZcashLightClientKit/Model/MigrationModels.swift
@@ -102,6 +102,70 @@ public enum MigrationAdvanceStep: Equatable, Sendable {
     case requiresAttention(id: UInt32)
 }
 
+/// The kind of upcoming work named by a ``MigrationAdvance/next`` outlook — a verbatim marshal of
+/// the upstream engine's `state::StepKind` (the outlook's kind ALONE: WHICH transaction a wake-up
+/// serves is decided by the `migrationAdvanceStep` call that serves it, not by this value).
+///
+/// ``prove``, ``broadcast``, ``rebuild`` and ``replan`` are the only outlooks the engine
+/// constructs today (upstream's own outlook derivation maps every other case to no outlook); the
+/// SDK still mirrors the full upstream enum — ``reevaluate``, ``waiting``, ``complete`` included —
+/// so this marshal never invents a projection of its own.
+public enum MigrationStepKind: Equatable, Sendable {
+    case prove
+    case broadcast
+    case rebuild
+    case replan
+    case reevaluate
+    case waiting
+    case complete
+}
+
+/// The engine's OUTLOOK (upstream #2936, `Advance::next`): what session to plan for next,
+/// assuming the step it rode in on (``MigrationAdvance/step``) is executed and recorded.
+public struct MigrationNextWork: Equatable, Sendable {
+    /// The earliest height at which the outlook's work becomes serviceable — upstream's `tip + 1`
+    /// target convention, directly comparable with a caller's own scanned/estimated targets. A
+    /// FLOOR, not an appointment: dependencies still have to mine, and the wake-up's own
+    /// `migrationAdvanceStep` call re-verifies (and may displace) it — this value holds only as of
+    /// the call that returned it, and the NEXT call's outlook supersedes it.
+    public let height: BlockHeight
+    /// What session to plan for the upcoming work: a ``MigrationStepKind/broadcast`` outlook needs
+    /// no sync, a ``MigrationStepKind/prove`` one is sync-bound (the ZIP 318 session separation
+    /// `migrationAdvanceStep`'s own doc describes), and ``MigrationStepKind/replan``/
+    /// ``MigrationStepKind/rebuild`` need user or spend-authority action.
+    /// ``MigrationStepKind/reevaluate``/``MigrationStepKind/waiting``/``MigrationStepKind/complete``
+    /// are not constructible outlooks upstream (see ``MigrationStepKind``'s doc) but are mirrored
+    /// so the marshal never projects one case onto another.
+    public let kind: MigrationStepKind
+
+    /// Creates a `MigrationNextWork`.
+    public init(height: BlockHeight, kind: MigrationStepKind) {
+        self.height = height
+        self.kind = kind
+    }
+}
+
+/// The engine's answer to `Synchronizer.migrationAdvanceStep(accountUUID:)` /
+/// `ZcashRustBackendWelding.migrationAdvanceStep(for:)`: the step to perform NOW
+/// (``MigrationAdvanceStep``, unchanged) plus the advisory OUTLOOK (upstream #2936) — what the
+/// migration will next need, assuming this step is executed. `next == nil` means nothing is
+/// height-schedulable: what follows is chain-driven (an in-flight transaction mining), user-driven
+/// (a signature, a replan), or the migration is terminal — see ``MigrationNextWork`` for the full
+/// contract.
+public struct MigrationAdvance: Equatable, Sendable {
+    /// The step to perform now — see ``MigrationAdvanceStep`` for the full discharge contract.
+    public let step: MigrationAdvanceStep
+    /// The advisory outlook: what session to plan for next, or `nil` when nothing is
+    /// height-schedulable.
+    public let next: MigrationNextWork?
+
+    /// Creates a `MigrationAdvance`.
+    public init(step: MigrationAdvanceStep, next: MigrationNextWork?) {
+        self.step = step
+        self.next = next
+    }
+}
+
 /// The outcome of one broadcast-lane delivery attempt
 /// (`Synchronizer.executeNextPendingMigrationTransfer(accountUUID:options:useEstimatedTip:)`).
 ///

--- a/Sources/ZcashLightClientKit/Rust/ZcashRustBackend.swift
+++ b/Sources/ZcashLightClientKit/Rust/ZcashRustBackend.swift
@@ -1475,7 +1475,7 @@ struct ZcashRustBackend: ZcashRustBackendWelding {
     // MARK: - Ironwood migration
 
     @DBActor
-    func migrationAdvanceStep(for account: AccountUUID) async throws -> MigrationAdvanceStep? {
+    func migrationAdvanceStep(for account: AccountUUID) async throws -> MigrationAdvance? {
         try await migrationAdvanceStep(for: account, estimatedTip: nil)
     }
 
@@ -1483,7 +1483,7 @@ struct ZcashRustBackend: ZcashRustBackendWelding {
     func migrationAdvanceStep(
         for account: AccountUUID,
         estimatedTip: BlockHeight?
-    ) async throws -> MigrationAdvanceStep? {
+    ) async throws -> MigrationAdvance? {
         // Clear any stale, unconsumed last-error before this sentinel read (see
         // `migrationIsNoteSplitNeeded` below): a NULL return overloads "no stored run" and
         // "error", and only a recorded last-error distinguishes the two.
@@ -1511,13 +1511,13 @@ struct ZcashRustBackend: ZcashRustBackendWelding {
 
         defer { zcashlc_free_migration_advance_step(stepPtr) }
 
-        guard let step = stepPtr.pointee.unsafeToMigrationAdvanceStep() else {
+        guard let advance = stepPtr.pointee.unsafeToMigrationAdvance() else {
             throw ZcashError.rustMigrationAdvanceStep(
                 lastErrorMessage(fallback: "`migrationAdvanceStep` returned a malformed step")
             )
         }
 
-        return step
+        return advance
     }
 
     // DB-READ (audited 2026-08-05): zcashlc_migration_sync_wakeups — opens through the
@@ -3032,16 +3032,20 @@ extension FfiMigrationTransactionStatuses {
 }
 
 extension FfiMigrationAdvanceStep {
-    /// Converts an [`FfiMigrationAdvanceStep`] into a [`MigrationAdvanceStep`], or `nil` for an
-    /// unrecognized step discriminant (should not happen; defensive only) or an EMPTY Prove batch
+    /// Converts an [`FfiMigrationAdvanceStep`] into a [`MigrationAdvance`], or `nil` for an
+    /// unrecognized step discriminant (should not happen; defensive only), an EMPTY Prove batch
     /// (`prove_targets_len == 0` — upstream documents the batch never empty, so this is a
-    /// malformed step, not the ordinary "nothing to prove" answer, which is `.waiting`). The
-    /// per-kind payload fields (`kind_layer`/`kind_index`/`kind_crossing`) now live on each
-    /// `FfiProveTarget` row rather than on the step itself. The step discriminants are matched
-    /// against the header's exported `ZCASHLC_ADVANCE_STEP_*` constants (U3), so this marshal and
-    /// the rust side share one set of names instead of re-hardcoding the numbers.
-    func unsafeToMigrationAdvanceStep() -> MigrationAdvanceStep? {
-        switch Int32(bitPattern: step) {
+    /// malformed step, not the ordinary "nothing to prove" answer, which is `.waiting`), or an
+    /// unrecognized `next_kind` while `next_height >= 0` (a malformed outlook — same defensive
+    /// contract as the step discriminant). The per-kind payload fields
+    /// (`kind_layer`/`kind_index`/`kind_crossing`) live on each `FfiProveTarget` row rather than on
+    /// the step itself. The step discriminants are matched against the header's exported
+    /// `ZCASHLC_ADVANCE_STEP_*` constants (U3), so this marshal and the rust side share one set of
+    /// names instead of re-hardcoding the numbers; the outlook's kind is matched the same way
+    /// against `ZCASHLC_STEP_KIND_*` (see [`MigrationStepKind.init(ffiValue:)`]).
+    func unsafeToMigrationAdvance() -> MigrationAdvance? {
+        let step: MigrationAdvanceStep
+        switch Int32(bitPattern: self.step) {
         case ZCASHLC_ADVANCE_STEP_PROVE:
             var transactions: [MigrationProveTarget] = []
             transactions.reserveCapacity(Int(prove_targets_len))
@@ -3055,17 +3059,50 @@ extension FfiMigrationAdvanceStep {
                 }
             }
             guard !transactions.isEmpty else { return nil }
-            return .prove(transactions: transactions)
+            step = .prove(transactions: transactions)
         case ZCASHLC_ADVANCE_STEP_BROADCAST:
-            return .broadcast(id: id)
+            step = .broadcast(id: self.id)
         case ZCASHLC_ADVANCE_STEP_REBUILD:
-            return .rebuild(id: id)
+            step = .rebuild(id: self.id)
         case ZCASHLC_ADVANCE_STEP_WAITING:
-            return .waiting
+            step = .waiting
         case ZCASHLC_ADVANCE_STEP_COMPLETE:
-            return .complete
+            step = .complete
         case ZCASHLC_ADVANCE_STEP_ATTEND:
-            return .requiresAttention(id: id)
+            step = .requiresAttention(id: self.id)
+        default:
+            return nil
+        }
+
+        var next: MigrationNextWork?
+        if next_height >= 0 {
+            guard let kind = MigrationStepKind(ffiValue: next_kind) else { return nil }
+            next = MigrationNextWork(height: BlockHeight(next_height), kind: kind)
+        }
+        return MigrationAdvance(step: step, next: next)
+    }
+}
+
+extension MigrationStepKind {
+    /// Marshals the header's `ZCASHLC_STEP_KIND_*` constants into a `MigrationStepKind`, or `nil`
+    /// for an unrecognized discriminant (should not happen; defensive only, same contract as the
+    /// step discriminant itself).
+    init?(ffiValue: UInt32) {
+        switch Int32(bitPattern: ffiValue) {
+        case ZCASHLC_STEP_KIND_PROVE:
+            self = .prove
+        case ZCASHLC_STEP_KIND_BROADCAST:
+            self = .broadcast
+        case ZCASHLC_STEP_KIND_REBUILD:
+            self = .rebuild
+        case ZCASHLC_STEP_KIND_REPLAN:
+            self = .replan
+        case ZCASHLC_STEP_KIND_REEVALUATE:
+            self = .reevaluate
+        case ZCASHLC_STEP_KIND_WAITING:
+            self = .waiting
+        case ZCASHLC_STEP_KIND_COMPLETE:
+            self = .complete
         default:
             return nil
         }

--- a/Sources/ZcashLightClientKit/Rust/ZcashRustBackend.swift
+++ b/Sources/ZcashLightClientKit/Rust/ZcashRustBackend.swift
@@ -3033,18 +3033,29 @@ extension FfiMigrationTransactionStatuses {
 
 extension FfiMigrationAdvanceStep {
     /// Converts an [`FfiMigrationAdvanceStep`] into a [`MigrationAdvanceStep`], or `nil` for an
-    /// unrecognized step discriminant (should not happen; defensive only). The per-kind payload
-    /// fields (`kind_layer`/`kind_index`/`kind_crossing`) are meaningful only for the Prove step
-    /// and are zeroed otherwise — a verbatim mirror of the FFI contract. The step discriminants
-    /// are matched against the header's exported `ZCASHLC_ADVANCE_STEP_*` constants (U3), so this
-    /// marshal and the rust side share one set of names instead of re-hardcoding the numbers.
+    /// unrecognized step discriminant (should not happen; defensive only) or an EMPTY Prove batch
+    /// (`prove_targets_len == 0` — upstream documents the batch never empty, so this is a
+    /// malformed step, not the ordinary "nothing to prove" answer, which is `.waiting`). The
+    /// per-kind payload fields (`kind_layer`/`kind_index`/`kind_crossing`) now live on each
+    /// `FfiProveTarget` row rather than on the step itself. The step discriminants are matched
+    /// against the header's exported `ZCASHLC_ADVANCE_STEP_*` constants (U3), so this marshal and
+    /// the rust side share one set of names instead of re-hardcoding the numbers.
     func unsafeToMigrationAdvanceStep() -> MigrationAdvanceStep? {
         switch Int32(bitPattern: step) {
         case ZCASHLC_ADVANCE_STEP_PROVE:
-            let kind: MigrationTransactionStatus.Kind = kind_is_preparation
-                ? .preparation(layer: Int(kind_layer), index: Int(kind_index))
-                : .transfer(crossing: Int(kind_crossing))
-            return .prove(id: id, kind: kind)
+            var transactions: [MigrationProveTarget] = []
+            transactions.reserveCapacity(Int(prove_targets_len))
+            if let proveTargets = prove_targets {
+                for index in 0 ..< Int(prove_targets_len) {
+                    let target = proveTargets.advanced(by: index).pointee
+                    let kind: MigrationTransactionStatus.Kind = target.kind_is_preparation
+                        ? .preparation(layer: Int(target.kind_layer), index: Int(target.kind_index))
+                        : .transfer(crossing: Int(target.kind_crossing))
+                    transactions.append(MigrationProveTarget(id: target.id, kind: kind))
+                }
+            }
+            guard !transactions.isEmpty else { return nil }
+            return .prove(transactions: transactions)
         case ZCASHLC_ADVANCE_STEP_BROADCAST:
             return .broadcast(id: id)
         case ZCASHLC_ADVANCE_STEP_REBUILD:

--- a/Sources/ZcashLightClientKit/Rust/ZcashRustBackendWelding.swift
+++ b/Sources/ZcashLightClientKit/Rust/ZcashRustBackendWelding.swift
@@ -415,23 +415,25 @@ protocol ZcashRustBackendWelding {
 
     // MARK: - Ironwood migration
 
-    /// The engine's next step to advance `account`'s stored migration run. This compatibility
-    /// overload drives at the scanned target; migration hosts use the estimate-aware overload.
-    /// Upstream `Reevaluate` and `Replan` project to ``MigrationAdvanceStep/requiresAttention(id:)``.
+    /// The engine's next step to advance `account`'s stored migration run, wrapped with its
+    /// advisory OUTLOOK (upstream #2936; see ``MigrationAdvance``). This compatibility overload
+    /// drives at the scanned target; migration hosts use the estimate-aware overload. Upstream
+    /// `Reevaluate` and `Replan` project to ``MigrationAdvanceStep/requiresAttention(id:)``.
     /// Mined
     /// transactions reconciled first like every other read. `nil` means NO run is stored at all
     /// (nothing to advance); a stored TERMINAL run — complete or cancelled — reports
-    /// ``MigrationAdvanceStep/complete`` verbatim and is never driven further. See
-    /// ``MigrationAdvanceStep`` for the step semantics and the discharge mapping.
+    /// ``MigrationAdvanceStep/complete`` verbatim (`next` is always `nil` for it) and is never
+    /// driven further. See ``MigrationAdvanceStep`` for the step semantics and the discharge
+    /// mapping, and ``MigrationAdvance`` / ``MigrationNextWork`` for the outlook's contract.
     /// - Throws: `rustMigrationAdvanceStep` if the rust layer returns an error.
-    func migrationAdvanceStep(for account: AccountUUID) async throws -> MigrationAdvanceStep?
+    func migrationAdvanceStep(for account: AccountUUID) async throws -> MigrationAdvance?
 
     /// Estimate-aware drive entry point. `estimatedTip` is the wall-clock chain-tip estimate;
     /// destructive judgments remain anchored to the wallet's fully-scanned height upstream.
     func migrationAdvanceStep(
         for account: AccountUUID,
         estimatedTip: BlockHeight?
-    ) async throws -> MigrationAdvanceStep?
+    ) async throws -> MigrationAdvance?
 
     /// Live migration progress, or `nil` when no snapshot is reportable: present only while an
     /// engine run is ACTIVE (not terminal) or a recorded immediate sweep is pending (unmined and
@@ -843,7 +845,7 @@ extension ZcashRustBackendWelding {
     func migrationAdvanceStep(
         for account: AccountUUID,
         estimatedTip: BlockHeight?
-    ) async throws -> MigrationAdvanceStep? {
+    ) async throws -> MigrationAdvance? {
         try await migrationAdvanceStep(for: account)
     }
 }

--- a/Sources/ZcashLightClientKit/Slipstream/SlipstreamSynchronizer.swift
+++ b/Sources/ZcashLightClientKit/Slipstream/SlipstreamSynchronizer.swift
@@ -1150,7 +1150,7 @@ public actor SlipstreamSynchronizer: Synchronizer {
     // -- an advisory point-in-time check, not a hard mutual-exclusion lock: sync and migration
     // broadcasts must never share a session, and hosts still sequence sessions themselves.
 
-    public func migrationAdvanceStep(accountUUID: AccountUUID) async throws -> MigrationAdvanceStep? {
+    public func migrationAdvanceStep(accountUUID: AccountUUID) async throws -> MigrationAdvance? {
         try await migrationHost.migration(for: accountUUID).advanceStep()
     }
 

--- a/Sources/ZcashLightClientKit/Synchronizer.swift
+++ b/Sources/ZcashLightClientKit/Synchronizer.swift
@@ -603,17 +603,21 @@ public protocol Synchronizer: AnyObject {
     // external (PCZT) signing. None of these methods require `prepare()` to have been called — a
     // host may broadcast a migration transfer from a background session without ever starting sync.
 
-    /// The migration engine's next step to advance `accountUUID`'s stored run — the replacement
-    /// for the removed SDK-side migration state machine, and a VERBATIM conduit of the upstream
-    /// engine's own `next_step`: no SDK ordering shims, no carve-outs — the attention step, the
-    /// broadcast-first ordering, and the prove step's kind are all the engine's own answer,
-    /// marshaled field-for-field. Call it on launch and after every migration operation.
+    /// The migration engine's next step to advance `accountUUID`'s stored run, paired with its
+    /// advisory OUTLOOK (upstream #2936) — the replacement for the removed SDK-side migration
+    /// state machine, and a VERBATIM conduit of the upstream engine's own `advance_migration`: no
+    /// SDK ordering shims, no carve-outs — the attention step, the broadcast-first ordering, and
+    /// the prove step's kind are all the engine's own answer, marshaled field-for-field. Call it on
+    /// launch and after every migration operation.
     ///
     /// `nil` means NO run is stored (none was ever committed) — nothing to advance, nothing to
-    /// poll. Evaluated on the SCANNED tip only (the estimated tip never enters this decision),
-    /// with the engine's attend > broadcast > prove > rebuild priority, and memoryless about
-    /// sessions: it reports what the run needs next, while session policy (one broadcast per
-    /// session, no sync in a broadcast session) stays with the caller and the sync gate.
+    /// poll. A non-`nil` answer is a ``MigrationAdvance``: `.step` is the step to perform NOW
+    /// (evaluated on the SCANNED tip only — the estimated tip never enters this decision — with the
+    /// engine's attend > broadcast > prove > rebuild priority, and memoryless about sessions: it
+    /// reports what the run needs next, while session policy — one broadcast per session, no sync
+    /// in a broadcast session — stays with the caller and the sync gate); `.next` is the advisory
+    /// outlook (``MigrationNextWork``) — what session to plan for once `.step` is executed, or
+    /// `nil` when nothing is height-schedulable.
     ///
     /// Discharging each step (see ``MigrationAdvanceStep`` for the full contract):
     /// - `.requiresAttention` — surfaced FIRST, before any actionable step, when a transaction of
@@ -636,18 +640,23 @@ public protocol Synchronizer: AnyObject {
     /// - `.rebuild` → ``refreshStaleMigrationTransfers(accountUUID:usk:)`` (needs spend
     ///   authority).
     /// - `.waiting` → register OS wake-ups from ``migrationSyncWakeups(accountUUID:)`` plus each
-    ///   ``migrationTransactionStatuses(accountUUID:)`` row's `scheduledHeight`.
+    ///   ``migrationTransactionStatuses(accountUUID:)`` row's `scheduledHeight`; the outlook's
+    ///   `.next`, when present, sharpens which of those wake-ups to arm FIRST — its `kind` says
+    ///   what session to plan (a `.broadcast` outlook needs no sync, a `.prove` one is sync-bound)
+    ///   — but ``migrationSyncWakeups(accountUUID:)`` remains the proving-schedule authority: the
+    ///   outlook is one call's lookahead, superseded by the next.
     ///
     /// `.complete` is terminal for the STORED run — including a CANCELLED one — and means "stop
-    /// polling". It is PER-RUN, never "nothing left to migrate": whether a migratable balance
-    /// remains is answered by ``proposeMigrationTransfers(accountUUID:)`` (an empty schedule
-    /// means no). For the other signals the removed state machine used to carry: "preparations
-    /// still confirming" is `isPreparationPhaseComplete` over
-    /// ``migrationTransactionStatuses(accountUUID:)``, live progress is
-    /// ``migrationProgress(accountUUID:)``, and invalid/expired transfers surface through
-    /// ``hasInvalidMigrationTransfers(accountUUID:)`` and per-row `state`/`blockedOn` values.
+    /// polling" (its outlook is always `nil`). It is PER-RUN, never "nothing left to migrate":
+    /// whether a migratable balance remains is answered by
+    /// ``proposeMigrationTransfers(accountUUID:)`` (an empty schedule means no). For the other
+    /// signals the removed state machine used to carry: "preparations still confirming" is
+    /// `isPreparationPhaseComplete` over ``migrationTransactionStatuses(accountUUID:)``, live
+    /// progress is ``migrationProgress(accountUUID:)``, and invalid/expired transfers surface
+    /// through ``hasInvalidMigrationTransfers(accountUUID:)`` and per-row `state`/`blockedOn`
+    /// values.
     /// - Parameter accountUUID: the account whose next step is of interest.
-    func migrationAdvanceStep(accountUUID: AccountUUID) async throws -> MigrationAdvanceStep?
+    func migrationAdvanceStep(accountUUID: AccountUUID) async throws -> MigrationAdvance?
 
     /// Live migration progress for `accountUUID`, or `nil` when no snapshot is reportable:
     /// present only while an engine run is ACTIVE (not terminal) or a recorded immediate sweep is
@@ -1283,7 +1292,7 @@ public extension Synchronizer {
     // members get inert defaults instead, documented below — conformers must override them to offer
     // real migration behavior.
 
-    func migrationAdvanceStep(accountUUID: AccountUUID) async throws -> MigrationAdvanceStep? {
+    func migrationAdvanceStep(accountUUID: AccountUUID) async throws -> MigrationAdvance? {
         throw MigrationUnimplemented(member: #function)
     }
 

--- a/Sources/ZcashLightClientKit/Synchronizer.swift
+++ b/Sources/ZcashLightClientKit/Synchronizer.swift
@@ -607,8 +607,8 @@ public protocol Synchronizer: AnyObject {
     /// advisory OUTLOOK (upstream #2936) — the replacement for the removed SDK-side migration
     /// state machine, and a VERBATIM conduit of the upstream engine's own `advance_migration`: no
     /// SDK ordering shims, no carve-outs — the attention step, the broadcast-first ordering, and
-    /// the prove step's kind are all the engine's own answer, marshaled field-for-field. Call it on
-    /// launch and after every migration operation.
+    /// the prove batch's per-entry kinds are all the engine's own answer, marshaled field-for-field.
+    /// Call it on launch and after every migration operation.
     ///
     /// `nil` means NO run is stored (none was ever committed) — nothing to advance, nothing to
     /// poll. A non-`nil` answer is a ``MigrationAdvance``: `.step` is the step to perform NOW
@@ -631,12 +631,13 @@ public protocol Synchronizer: AnyObject {
     ///   the sync gate (a dead transfer gates nothing).
     /// - `.broadcast` → ``executeNextPendingMigrationTransfer(accountUUID:options:useEstimatedTip:)``
     ///   — submit and END the session (no sync).
-    /// - `.prove` with a `.transfer` kind → ``finalizeReadyMigrationTransfers(accountUUID:)`` at a
-    ///   sync wake-up; the broadcast follows in its own LATER session. Proving has no deadline —
-    ///   boundary anchor checkpoints are durably retained, so a missed wake-up only defers it.
-    /// - `.prove` with a `.preparation` kind → the preparation is due by construction and may be
-    ///   proved AND broadcast at the same wake-up (it anchors near-tip, not against a drawn
-    ///   boundary).
+    /// - `.prove` → the WHOLE batch discharges in one call: ``finalizeReadyMigrationTransfers(accountUUID:)``
+    ///   at a sync wake-up, which proves every ready row in that pass. Each entry's `kind` decides
+    ///   what follows for THAT transaction: a `.preparation` entry is due by construction and may
+    ///   be proved AND broadcast at the SAME wake-up (it anchors near-tip, not against a drawn
+    ///   boundary), while a `.transfer` entry's broadcast follows in its own LATER session —
+    ///   proving has no deadline of its own, since its boundary anchor checkpoint is durably
+    ///   retained, so a missed wake-up only defers it.
     /// - `.rebuild` → ``refreshStaleMigrationTransfers(accountUUID:usk:)`` (needs spend
     ///   authority).
     /// - `.waiting` → register OS wake-ups from ``migrationSyncWakeups(accountUUID:)`` plus each

--- a/Sources/ZcashLightClientKit/Synchronizer/SDKSynchronizer.swift
+++ b/Sources/ZcashLightClientKit/Synchronizer/SDKSynchronizer.swift
@@ -1206,7 +1206,7 @@ public class SDKSynchronizer: Synchronizer {
     // mutual-exclusion lock: sync and migration broadcasts must never share a session, and hosts
     // still sequence sessions themselves.
 
-    public func migrationAdvanceStep(accountUUID: AccountUUID) async throws -> MigrationAdvanceStep? {
+    public func migrationAdvanceStep(accountUUID: AccountUUID) async throws -> MigrationAdvance? {
         try await migrationHost.migration(for: accountUUID).advanceStep()
     }
 

--- a/Tests/OfflineTests/MigrationFFITests.swift
+++ b/Tests/OfflineTests/MigrationFFITests.swift
@@ -1219,14 +1219,7 @@ final class MigrationFFITests: XCTestCase {
     /// outlook decode is exercised independently, in the dedicated section above.
     private func makeProveAdvanceStep(_ targets: [FfiProveTarget]) -> FfiMigrationAdvanceStep {
         guard !targets.isEmpty else {
-            return FfiMigrationAdvanceStep(
-                step: UInt32(ZCASHLC_ADVANCE_STEP_PROVE),
-                id: 0,
-                prove_targets: nil,
-                prove_targets_len: 0,
-                next_height: -1,
-                next_kind: 0
-            )
+            return makeAdvanceStep(step: UInt32(ZCASHLC_ADVANCE_STEP_PROVE), id: 0)
         }
         let pointer = UnsafeMutablePointer<FfiProveTarget>.allocate(capacity: targets.count)
         for (index, target) in targets.enumerated() {

--- a/Tests/OfflineTests/MigrationFFITests.swift
+++ b/Tests/OfflineTests/MigrationFFITests.swift
@@ -762,10 +762,11 @@ final class MigrationFFITests: XCTestCase {
 
     // MARK: - Advance step decode mapping
     //
-    // `FfiMigrationAdvanceStep`'s marshal into `MigrationAdvanceStep`, constructed directly like
+    // `FfiMigrationAdvanceStep`'s marshal into `MigrationAdvance`, constructed directly like
     // the status rows above. The discriminants are asserted through the header's exported
     // `ZCASHLC_ADVANCE_STEP_*` constants (U3) — the same names the decode itself matches on — so
-    // a renumbering on either side surfaces here.
+    // a renumbering on either side surfaces here. Assertions unwrap `.step`; the outlook
+    // (`.next`) has its own dedicated section below.
 
     /// Every step discriminant decodes to its case; `requiresAttention` (ATTEND) carries the id
     /// like the other id-bearing steps.
@@ -775,7 +776,7 @@ final class MigrationFFITests: XCTestCase {
         ])
         defer { freeProveAdvanceStep(prove) }
         XCTAssertEqual(
-            prove.unsafeToMigrationAdvanceStep(),
+            prove.unsafeToMigrationAdvance()?.step,
             .prove(transactions: [MigrationProveTarget(id: 4, kind: .transfer(crossing: 2))])
         )
 
@@ -784,32 +785,32 @@ final class MigrationFFITests: XCTestCase {
         ])
         defer { freeProveAdvanceStep(provePreparation) }
         XCTAssertEqual(
-            provePreparation.unsafeToMigrationAdvanceStep(),
+            provePreparation.unsafeToMigrationAdvance()?.step,
             .prove(transactions: [MigrationProveTarget(id: 5, kind: .preparation(layer: 1, index: 3))])
         )
 
         let broadcast = makeAdvanceStep(step: UInt32(ZCASHLC_ADVANCE_STEP_BROADCAST), id: 6)
-        XCTAssertEqual(broadcast.unsafeToMigrationAdvanceStep(), .broadcast(id: 6))
+        XCTAssertEqual(broadcast.unsafeToMigrationAdvance()?.step, .broadcast(id: 6))
 
         let rebuild = makeAdvanceStep(step: UInt32(ZCASHLC_ADVANCE_STEP_REBUILD), id: 7)
-        XCTAssertEqual(rebuild.unsafeToMigrationAdvanceStep(), .rebuild(id: 7))
+        XCTAssertEqual(rebuild.unsafeToMigrationAdvance()?.step, .rebuild(id: 7))
 
         let waiting = makeAdvanceStep(step: UInt32(ZCASHLC_ADVANCE_STEP_WAITING), id: 0)
-        XCTAssertEqual(waiting.unsafeToMigrationAdvanceStep(), .waiting)
+        XCTAssertEqual(waiting.unsafeToMigrationAdvance()?.step, .waiting)
 
         let complete = makeAdvanceStep(step: UInt32(ZCASHLC_ADVANCE_STEP_COMPLETE), id: 0)
-        XCTAssertEqual(complete.unsafeToMigrationAdvanceStep(), .complete)
+        XCTAssertEqual(complete.unsafeToMigrationAdvance()?.step, .complete)
 
         let attend = makeAdvanceStep(step: UInt32(ZCASHLC_ADVANCE_STEP_ATTEND), id: 9)
         XCTAssertEqual(
-            attend.unsafeToMigrationAdvanceStep(),
+            attend.unsafeToMigrationAdvance()?.step,
             .requiresAttention(id: 9),
             "the engine's Attend step must pass through verbatim, carrying the invalid transaction's id"
         )
     }
 
     func testAdvanceStepDecodeReturnsNilForAnOutOfRangeStep() {
-        XCTAssertNil(makeAdvanceStep(step: 99, id: 1).unsafeToMigrationAdvanceStep())
+        XCTAssertNil(makeAdvanceStep(step: 99, id: 1).unsafeToMigrationAdvance())
     }
 
     /// A multi-entry Prove batch marshals every row, ordered and typed, mixing preparation and
@@ -823,7 +824,7 @@ final class MigrationFFITests: XCTestCase {
         ])
         defer { freeProveAdvanceStep(prove) }
         XCTAssertEqual(
-            prove.unsafeToMigrationAdvanceStep(),
+            prove.unsafeToMigrationAdvance()?.step,
             .prove(transactions: [
                 MigrationProveTarget(id: 5, kind: .preparation(layer: 1, index: 3)),
                 MigrationProveTarget(id: 4, kind: .transfer(crossing: 2))
@@ -833,9 +834,55 @@ final class MigrationFFITests: XCTestCase {
 
         let empty = makeProveAdvanceStep([])
         XCTAssertNil(
-            empty.unsafeToMigrationAdvanceStep(),
+            empty.unsafeToMigrationAdvance(),
             "an empty Prove batch is malformed (upstream never serves one empty), not a valid step"
         )
+    }
+
+    // MARK: - Outlook decode mapping (librustzcash #2936)
+    //
+    // `FfiMigrationAdvanceStep.next_height`/`next_kind`'s marshal into `MigrationAdvance.next`,
+    // independent of which step they ride along with (`.waiting` here is an arbitrary carrier —
+    // the outlook decodes the same regardless of `.step`'s own case).
+
+    /// A non-negative `next_height` paired with a recognized `next_kind` decodes to the matching
+    /// `MigrationNextWork`.
+    func testAdvanceStepDecodeMapsAPresentOutlook() throws {
+        let step = makeAdvanceStep(
+            step: UInt32(ZCASHLC_ADVANCE_STEP_WAITING),
+            id: 0,
+            nextHeight: 850_000,
+            nextKind: UInt32(ZCASHLC_STEP_KIND_BROADCAST)
+        )
+        XCTAssertEqual(
+            step.unsafeToMigrationAdvance()?.next,
+            MigrationNextWork(height: 850_000, kind: .broadcast)
+        )
+    }
+
+    /// The `next_height == -1` sentinel decodes to `next == nil` -- nothing is height-schedulable.
+    func testAdvanceStepDecodeMapsTheNoOutlookSentinelToNil() throws {
+        let step = makeAdvanceStep(
+            step: UInt32(ZCASHLC_ADVANCE_STEP_WAITING),
+            id: 0,
+            nextHeight: -1,
+            nextKind: 0
+        )
+        XCTAssertNil(step.unsafeToMigrationAdvance()?.next)
+    }
+
+    /// An out-of-range `next_kind` alongside a non-negative `next_height` is a malformed outlook,
+    /// so the WHOLE decode fails -- mirroring the step discriminant's own defensive-nil contract
+    /// (`testAdvanceStepDecodeReturnsNilForAnOutOfRangeStep`), never a `MigrationAdvance` whose
+    /// `next` silently drops the unrecognized kind.
+    func testAdvanceStepDecodeReturnsNilForAnOutOfRangeOutlookKind() throws {
+        let step = makeAdvanceStep(
+            step: UInt32(ZCASHLC_ADVANCE_STEP_WAITING),
+            id: 0,
+            nextHeight: 850_000,
+            nextKind: 99
+        )
+        XCTAssertNil(step.unsafeToMigrationAdvance())
     }
 
     // MARK: - Routed migration error parsing (U13)
@@ -1145,23 +1192,40 @@ final class MigrationFFITests: XCTestCase {
     ///   `withUnsafeMutableBufferPointer`, mirroring `testDecodeContainerMapsMultipleRowsInEngineOrder`'s
     ///   existing pattern for the outer container.
     /// Builds an `FfiMigrationAdvanceStep` with no Prove batch (`prove_targets: nil`,
-    /// `prove_targets_len: 0`) — every step but Prove, mirroring the FFI contract.
-    private func makeAdvanceStep(step: UInt32, id: UInt32) -> FfiMigrationAdvanceStep {
-        FfiMigrationAdvanceStep(step: step, id: id, prove_targets: nil, prove_targets_len: 0)
+    /// `prove_targets_len: 0`) — every step but Prove, mirroring the FFI contract. `nextHeight`/
+    /// `nextKind` default to the no-outlook sentinel (`-1`/`0`); override them for the outlook
+    /// decode tests below.
+    private func makeAdvanceStep(
+        step: UInt32,
+        id: UInt32,
+        nextHeight: Int64 = -1,
+        nextKind: UInt32 = 0
+    ) -> FfiMigrationAdvanceStep {
+        FfiMigrationAdvanceStep(
+            step: step,
+            id: id,
+            prove_targets: nil,
+            prove_targets_len: 0,
+            next_height: nextHeight,
+            next_kind: nextKind
+        )
     }
 
     /// Builds an `FfiMigrationAdvanceStep` for `ZCASHLC_ADVANCE_STEP_PROVE`, heap-allocating one
     /// `FfiProveTarget` per entry of `targets` in order (an empty array leaves `prove_targets`
     /// `nil`, mirroring the malformed-empty-batch case). The caller must free the result with
     /// `freeProveAdvanceStep` — these fixtures are constructed directly rather than through the
-    /// real FFI, so nothing else owns the allocation.
+    /// real FFI, so nothing else owns the allocation. Carries no outlook (`next_height: -1`): the
+    /// outlook decode is exercised independently, in the dedicated section above.
     private func makeProveAdvanceStep(_ targets: [FfiProveTarget]) -> FfiMigrationAdvanceStep {
         guard !targets.isEmpty else {
             return FfiMigrationAdvanceStep(
                 step: UInt32(ZCASHLC_ADVANCE_STEP_PROVE),
                 id: 0,
                 prove_targets: nil,
-                prove_targets_len: 0
+                prove_targets_len: 0,
+                next_height: -1,
+                next_kind: 0
             )
         }
         let pointer = UnsafeMutablePointer<FfiProveTarget>.allocate(capacity: targets.count)
@@ -1172,7 +1236,9 @@ final class MigrationFFITests: XCTestCase {
             step: UInt32(ZCASHLC_ADVANCE_STEP_PROVE),
             id: 0,
             prove_targets: pointer,
-            prove_targets_len: UInt(targets.count)
+            prove_targets_len: UInt(targets.count),
+            next_height: -1,
+            next_kind: 0
         )
     }
 

--- a/Tests/OfflineTests/MigrationFFITests.swift
+++ b/Tests/OfflineTests/MigrationFFITests.swift
@@ -1180,17 +1180,6 @@ final class MigrationFFITests: XCTestCase {
         return bytes.withUnsafeBytes { $0.load(as: Bytes32.self) }
     }
 
-    /// Builds a valid row -- transfer 0, awaiting signature, ready, no next action, not blocked,
-    /// no txid, no dependencies, no drawn anchor boundary -- with every field defaulted; override
-    /// only the field(s) under test. Mirrors `FfiMigrationTransactionStatus`'s field-by-field
-    /// contract (see `rust/src/migration.rs`'s doc comments).
-    ///
-    /// - Note: `dependsOnPtr`/`dependsOnLen` default to `nil`/`0` (no dependencies -- the C side's
-    ///   own "empty" encoding, not a null-vs-empty distinction the decode makes). A test exercising
-    ///   a non-empty `dependsOn` must supply a pointer that stays valid for the call's duration --
-    ///   see `testDecodeMapsDependsOnIds` below, which scopes one via
-    ///   `withUnsafeMutableBufferPointer`, mirroring `testDecodeContainerMapsMultipleRowsInEngineOrder`'s
-    ///   existing pattern for the outer container.
     /// Builds an `FfiMigrationAdvanceStep` with no Prove batch (`prove_targets: nil`,
     /// `prove_targets_len: 0`) — every step but Prove, mirroring the FFI contract. `nextHeight`/
     /// `nextKind` default to the no-outlook sentinel (`-1`/`0`); override them for the outlook
@@ -1241,6 +1230,17 @@ final class MigrationFFITests: XCTestCase {
         step.prove_targets?.deallocate()
     }
 
+    /// Builds a valid row -- transfer 0, awaiting signature, ready, no next action, not blocked,
+    /// no txid, no dependencies, no drawn anchor boundary -- with every field defaulted; override
+    /// only the field(s) under test. Mirrors `FfiMigrationTransactionStatus`'s field-by-field
+    /// contract (see `rust/src/migration.rs`'s doc comments).
+    ///
+    /// - Note: `dependsOnPtr`/`dependsOnLen` default to `nil`/`0` (no dependencies -- the C side's
+    ///   own "empty" encoding, not a null-vs-empty distinction the decode makes). A test exercising
+    ///   a non-empty `dependsOn` must supply a pointer that stays valid for the call's duration --
+    ///   see `testDecodeMapsDependsOnIds` below, which scopes one via
+    ///   `withUnsafeMutableBufferPointer`, mirroring `testDecodeContainerMapsMultipleRowsInEngineOrder`'s
+    ///   existing pattern for the outer container.
     private func makeStatus(
         id: UInt32 = 7,
         isTransfer: Bool = true,

--- a/Tests/OfflineTests/MigrationFFITests.swift
+++ b/Tests/OfflineTests/MigrationFFITests.swift
@@ -770,17 +770,23 @@ final class MigrationFFITests: XCTestCase {
     /// Every step discriminant decodes to its case; `requiresAttention` (ATTEND) carries the id
     /// like the other id-bearing steps.
     func testAdvanceStepDecodeMapsEveryStepIncludingAttend() throws {
-        let prove = makeAdvanceStep(step: UInt32(ZCASHLC_ADVANCE_STEP_PROVE), id: 4, kindIsPreparation: false, kindCrossing: 2)
-        XCTAssertEqual(prove.unsafeToMigrationAdvanceStep(), .prove(id: 4, kind: .transfer(crossing: 2)))
-
-        let provePreparation = makeAdvanceStep(
-            step: UInt32(ZCASHLC_ADVANCE_STEP_PROVE),
-            id: 5,
-            kindIsPreparation: true,
-            kindLayer: 1,
-            kindIndex: 3
+        let prove = makeProveAdvanceStep([
+            FfiProveTarget(id: 4, kind_is_preparation: false, kind_layer: 0, kind_index: 0, kind_crossing: 2)
+        ])
+        defer { freeProveAdvanceStep(prove) }
+        XCTAssertEqual(
+            prove.unsafeToMigrationAdvanceStep(),
+            .prove(transactions: [MigrationProveTarget(id: 4, kind: .transfer(crossing: 2))])
         )
-        XCTAssertEqual(provePreparation.unsafeToMigrationAdvanceStep(), .prove(id: 5, kind: .preparation(layer: 1, index: 3)))
+
+        let provePreparation = makeProveAdvanceStep([
+            FfiProveTarget(id: 5, kind_is_preparation: true, kind_layer: 1, kind_index: 3, kind_crossing: 0)
+        ])
+        defer { freeProveAdvanceStep(provePreparation) }
+        XCTAssertEqual(
+            provePreparation.unsafeToMigrationAdvanceStep(),
+            .prove(transactions: [MigrationProveTarget(id: 5, kind: .preparation(layer: 1, index: 3))])
+        )
 
         let broadcast = makeAdvanceStep(step: UInt32(ZCASHLC_ADVANCE_STEP_BROADCAST), id: 6)
         XCTAssertEqual(broadcast.unsafeToMigrationAdvanceStep(), .broadcast(id: 6))
@@ -804,6 +810,32 @@ final class MigrationFFITests: XCTestCase {
 
     func testAdvanceStepDecodeReturnsNilForAnOutOfRangeStep() {
         XCTAssertNil(makeAdvanceStep(step: 99, id: 1).unsafeToMigrationAdvanceStep())
+    }
+
+    /// A multi-entry Prove batch marshals every row, ordered and typed, mixing preparation and
+    /// transfer kinds in one batch (upstream #2939); an EMPTY batch is a malformed step (upstream
+    /// documents the batch never empty), so it decodes to `nil` rather than an empty-transactions
+    /// case.
+    func testAdvanceStepDecodeMapsAMultiEntryProveBatchAndRejectsAnEmptyOne() throws {
+        let prove = makeProveAdvanceStep([
+            FfiProveTarget(id: 5, kind_is_preparation: true, kind_layer: 1, kind_index: 3, kind_crossing: 0),
+            FfiProveTarget(id: 4, kind_is_preparation: false, kind_layer: 0, kind_index: 0, kind_crossing: 2)
+        ])
+        defer { freeProveAdvanceStep(prove) }
+        XCTAssertEqual(
+            prove.unsafeToMigrationAdvanceStep(),
+            .prove(transactions: [
+                MigrationProveTarget(id: 5, kind: .preparation(layer: 1, index: 3)),
+                MigrationProveTarget(id: 4, kind: .transfer(crossing: 2))
+            ]),
+            "entries must marshal in array order, each keeping its own id and kind"
+        )
+
+        let empty = makeProveAdvanceStep([])
+        XCTAssertNil(
+            empty.unsafeToMigrationAdvanceStep(),
+            "an empty Prove batch is malformed (upstream never serves one empty), not a valid step"
+        )
     }
 
     // MARK: - Routed migration error parsing (U13)
@@ -1112,25 +1144,42 @@ final class MigrationFFITests: XCTestCase {
     ///   see `testDecodeMapsDependsOnIds` below, which scopes one via
     ///   `withUnsafeMutableBufferPointer`, mirroring `testDecodeContainerMapsMultipleRowsInEngineOrder`'s
     ///   existing pattern for the outer container.
-    /// Builds an `FfiMigrationAdvanceStep` with the per-kind payload fields defaulted to their
-    /// "not a Prove step" zeroes, mirroring the FFI contract (`kind_*` meaningful only for
-    /// `ZCASHLC_ADVANCE_STEP_PROVE`).
-    private func makeAdvanceStep(
-        step: UInt32,
-        id: UInt32,
-        kindIsPreparation: Bool = false,
-        kindLayer: UInt32 = 0,
-        kindIndex: UInt32 = 0,
-        kindCrossing: UInt32 = 0
-    ) -> FfiMigrationAdvanceStep {
-        FfiMigrationAdvanceStep(
-            step: step,
-            id: id,
-            kind_is_preparation: kindIsPreparation,
-            kind_layer: kindLayer,
-            kind_index: kindIndex,
-            kind_crossing: kindCrossing
+    /// Builds an `FfiMigrationAdvanceStep` with no Prove batch (`prove_targets: nil`,
+    /// `prove_targets_len: 0`) — every step but Prove, mirroring the FFI contract.
+    private func makeAdvanceStep(step: UInt32, id: UInt32) -> FfiMigrationAdvanceStep {
+        FfiMigrationAdvanceStep(step: step, id: id, prove_targets: nil, prove_targets_len: 0)
+    }
+
+    /// Builds an `FfiMigrationAdvanceStep` for `ZCASHLC_ADVANCE_STEP_PROVE`, heap-allocating one
+    /// `FfiProveTarget` per entry of `targets` in order (an empty array leaves `prove_targets`
+    /// `nil`, mirroring the malformed-empty-batch case). The caller must free the result with
+    /// `freeProveAdvanceStep` — these fixtures are constructed directly rather than through the
+    /// real FFI, so nothing else owns the allocation.
+    private func makeProveAdvanceStep(_ targets: [FfiProveTarget]) -> FfiMigrationAdvanceStep {
+        guard !targets.isEmpty else {
+            return FfiMigrationAdvanceStep(
+                step: UInt32(ZCASHLC_ADVANCE_STEP_PROVE),
+                id: 0,
+                prove_targets: nil,
+                prove_targets_len: 0
+            )
+        }
+        let pointer = UnsafeMutablePointer<FfiProveTarget>.allocate(capacity: targets.count)
+        for (index, target) in targets.enumerated() {
+            pointer.advanced(by: index).initialize(to: target)
+        }
+        return FfiMigrationAdvanceStep(
+            step: UInt32(ZCASHLC_ADVANCE_STEP_PROVE),
+            id: 0,
+            prove_targets: pointer,
+            prove_targets_len: UInt(targets.count)
         )
+    }
+
+    /// Frees the heap array `makeProveAdvanceStep` allocated (a no-op for an empty batch, whose
+    /// `prove_targets` is `nil`).
+    private func freeProveAdvanceStep(_ step: FfiMigrationAdvanceStep) {
+        step.prove_targets?.deallocate()
     }
 
     private func makeStatus(

--- a/Tests/OfflineTests/OrchardMigrationCompositionTests.swift
+++ b/Tests/OfflineTests/OrchardMigrationCompositionTests.swift
@@ -343,12 +343,12 @@ final class OrchardMigrationCompositionTests: ZcashTestCase {
         welding.migrationBlockRateSamplesWindowReturnValue = [
             MigrationBlockRateSample(height: 3_000_000, unixTime: Int64(sampleTime.timeIntervalSince1970))
         ]
-        welding.migrationAdvanceStepForEstimatedTipReturnValue = .waiting
+        welding.migrationAdvanceStepForEstimatedTipReturnValue = MigrationAdvance(step: .waiting, next: nil)
         let migration = makeMigration(broadcaster: ScriptedBroadcaster(script: .throwing(StubEngineError())))
 
-        let step = try await migration.advanceStep()
+        let advance = try await migration.advanceStep()
 
-        XCTAssertEqual(step, .waiting)
+        XCTAssertEqual(advance?.step, .waiting)
         let received = try XCTUnwrap(welding.migrationAdvanceStepForEstimatedTipReceivedArguments)
         XCTAssertEqual(received.account, accountA)
         XCTAssertEqual(
@@ -363,12 +363,12 @@ final class OrchardMigrationCompositionTests: ZcashTestCase {
     /// engine's scheduled-height due-ness, never block the call that consults it.
     func testAdvanceStepDegradesToNilTipWhenBlockRateSamplesThrows() async throws {
         welding.migrationBlockRateSamplesWindowThrowableError = StubEngineError()
-        welding.migrationAdvanceStepForEstimatedTipReturnValue = .waiting
+        welding.migrationAdvanceStepForEstimatedTipReturnValue = MigrationAdvance(step: .waiting, next: nil)
         let migration = makeMigration(broadcaster: ScriptedBroadcaster(script: .throwing(StubEngineError())))
 
-        let step = try await migration.advanceStep()
+        let advance = try await migration.advanceStep()
 
-        XCTAssertEqual(step, .waiting, "an estimator failure must not fail the advance step")
+        XCTAssertEqual(advance?.step, .waiting, "an estimator failure must not fail the advance step")
         XCTAssertNil(
             welding.migrationAdvanceStepForEstimatedTipReceivedArguments?.estimatedTip,
             "an estimator failure must degrade to the scanned-tip behavior"

--- a/Tests/OfflineTests/OrchardMigrationHostTests.swift
+++ b/Tests/OfflineTests/OrchardMigrationHostTests.swift
@@ -42,7 +42,7 @@ final class OrchardMigrationHostTests: ZcashTestCase {
     /// driving each actor reaches the welding with that actor's own account UUID.
     func testMigrationForAccountCachesPerAccountAndRoutesTheRightUUID() async throws {
         let welding = ZcashRustBackendWeldingMock()
-        welding.migrationAdvanceStepForEstimatedTipReturnValue = .waiting
+        welding.migrationAdvanceStepForEstimatedTipReturnValue = MigrationAdvance(step: .waiting, next: nil)
         welding.migrationHasReadyBroadcastForEstimatedTipReturnValue = false
         let host = makeHost(welding: welding, broadcaster: ScriptedBroadcaster(script: .throwing(ZcashError.migrationTorUnavailable)))
 

--- a/Tests/OfflineTests/SDKSynchronizerMigrationTests.swift
+++ b/Tests/OfflineTests/SDKSynchronizerMigrationTests.swift
@@ -51,8 +51,8 @@ final class SDKSynchronizerMigrationTests: ZcashTestCase {
 
         let cases: [MigrationAdvanceStep?] = [
             nil,
-            .prove(id: 3, kind: .preparation(layer: 0, index: 1)),
-            .prove(id: 4, kind: .transfer(crossing: 2)),
+            .prove(transactions: [MigrationProveTarget(id: 3, kind: .preparation(layer: 0, index: 1))]),
+            .prove(transactions: [MigrationProveTarget(id: 4, kind: .transfer(crossing: 2))]),
             .broadcast(id: 5),
             .rebuild(id: 6),
             .waiting,

--- a/Tests/OfflineTests/SDKSynchronizerMigrationTests.swift
+++ b/Tests/OfflineTests/SDKSynchronizerMigrationTests.swift
@@ -49,23 +49,29 @@ final class SDKSynchronizerMigrationTests: ZcashTestCase {
         let welding = ZcashRustBackendWeldingMock()
         let synchronizer = try makeSynchronizer(migrationHost: makeHost(welding: welding))
 
-        let cases: [MigrationAdvanceStep?] = [
+        let cases: [MigrationAdvance?] = [
             nil,
-            .prove(transactions: [MigrationProveTarget(id: 3, kind: .preparation(layer: 0, index: 1))]),
-            .prove(transactions: [MigrationProveTarget(id: 4, kind: .transfer(crossing: 2))]),
-            .broadcast(id: 5),
-            .rebuild(id: 6),
-            .waiting,
-            .complete,
-            .requiresAttention(id: 7)
+            MigrationAdvance(
+                step: .prove(transactions: [MigrationProveTarget(id: 3, kind: .preparation(layer: 0, index: 1))]),
+                next: nil
+            ),
+            MigrationAdvance(
+                step: .prove(transactions: [MigrationProveTarget(id: 4, kind: .transfer(crossing: 2))]),
+                next: nil
+            ),
+            MigrationAdvance(step: .broadcast(id: 5), next: nil),
+            MigrationAdvance(step: .rebuild(id: 6), next: nil),
+            MigrationAdvance(step: .waiting, next: MigrationNextWork(height: 850_000, kind: .broadcast)),
+            MigrationAdvance(step: .complete, next: nil),
+            MigrationAdvance(step: .requiresAttention(id: 7), next: nil)
         ]
 
-        for expectedStep in cases {
-            welding.migrationAdvanceStepForEstimatedTipReturnValue = expectedStep
+        for expectedAdvance in cases {
+            welding.migrationAdvanceStepForEstimatedTipReturnValue = expectedAdvance
 
-            let step = try await synchronizer.migrationAdvanceStep(accountUUID: accountUUID)
+            let advance = try await synchronizer.migrationAdvanceStep(accountUUID: accountUUID)
 
-            XCTAssertEqual(step, expectedStep)
+            XCTAssertEqual(advance, expectedAdvance)
             XCTAssertEqual(welding.migrationAdvanceStepForEstimatedTipReceivedArguments?.account, accountUUID)
         }
     }
@@ -197,7 +203,7 @@ final class SDKSynchronizerMigrationTests: ZcashTestCase {
     /// proposal. Hosts must not latch "never migrate again" off `migrationAdvanceStep` alone.
     func testAfterCompleteProposeMigrationTransfersAnswersWhetherAnythingRemains() async throws {
         let welding = ZcashRustBackendWeldingMock()
-        welding.migrationAdvanceStepForEstimatedTipReturnValue = .complete
+        welding.migrationAdvanceStepForEstimatedTipReturnValue = MigrationAdvance(step: .complete, next: nil)
         welding.migrationProposeTransfersForReturnValue = MigrationSchedule(
             transfers: [],
             estimatedDurationHours: 0,
@@ -207,8 +213,8 @@ final class SDKSynchronizerMigrationTests: ZcashTestCase {
         )
         let synchronizer = try makeSynchronizer(migrationHost: makeHost(welding: welding))
 
-        let step = try await synchronizer.migrationAdvanceStep(accountUUID: accountUUID)
-        XCTAssertEqual(step, .complete)
+        let advance = try await synchronizer.migrationAdvanceStep(accountUUID: accountUUID)
+        XCTAssertEqual(advance?.step, .complete)
 
         let remains = try await synchronizer.proposeMigrationTransfers(accountUUID: accountUUID)
         XCTAssertTrue(remains.transfers.isEmpty, "an empty schedule is the 'nothing remains' answer")

--- a/Tests/OfflineTests/SlipstreamSynchronizerMigrationTests.swift
+++ b/Tests/OfflineTests/SlipstreamSynchronizerMigrationTests.swift
@@ -73,8 +73,8 @@ final class SlipstreamSynchronizerMigrationTests: ZcashTestCase {
 
         let cases: [MigrationAdvanceStep?] = [
             nil,
-            .prove(id: 3, kind: .preparation(layer: 0, index: 1)),
-            .prove(id: 4, kind: .transfer(crossing: 2)),
+            .prove(transactions: [MigrationProveTarget(id: 3, kind: .preparation(layer: 0, index: 1))]),
+            .prove(transactions: [MigrationProveTarget(id: 4, kind: .transfer(crossing: 2))]),
             .broadcast(id: 5),
             .rebuild(id: 6),
             .waiting,

--- a/Tests/OfflineTests/SlipstreamSynchronizerMigrationTests.swift
+++ b/Tests/OfflineTests/SlipstreamSynchronizerMigrationTests.swift
@@ -71,23 +71,29 @@ final class SlipstreamSynchronizerMigrationTests: ZcashTestCase {
         let welding = ZcashRustBackendWeldingMock()
         let synchronizer = try makeSynchronizer(migrationHost: makeHost(welding: welding))
 
-        let cases: [MigrationAdvanceStep?] = [
+        let cases: [MigrationAdvance?] = [
             nil,
-            .prove(transactions: [MigrationProveTarget(id: 3, kind: .preparation(layer: 0, index: 1))]),
-            .prove(transactions: [MigrationProveTarget(id: 4, kind: .transfer(crossing: 2))]),
-            .broadcast(id: 5),
-            .rebuild(id: 6),
-            .waiting,
-            .complete,
-            .requiresAttention(id: 7)
+            MigrationAdvance(
+                step: .prove(transactions: [MigrationProveTarget(id: 3, kind: .preparation(layer: 0, index: 1))]),
+                next: nil
+            ),
+            MigrationAdvance(
+                step: .prove(transactions: [MigrationProveTarget(id: 4, kind: .transfer(crossing: 2))]),
+                next: nil
+            ),
+            MigrationAdvance(step: .broadcast(id: 5), next: nil),
+            MigrationAdvance(step: .rebuild(id: 6), next: nil),
+            MigrationAdvance(step: .waiting, next: MigrationNextWork(height: 850_000, kind: .broadcast)),
+            MigrationAdvance(step: .complete, next: nil),
+            MigrationAdvance(step: .requiresAttention(id: 7), next: nil)
         ]
 
-        for expectedStep in cases {
-            welding.migrationAdvanceStepForEstimatedTipReturnValue = expectedStep
+        for expectedAdvance in cases {
+            welding.migrationAdvanceStepForEstimatedTipReturnValue = expectedAdvance
 
-            let step = try await synchronizer.migrationAdvanceStep(accountUUID: accountUUID)
+            let advance = try await synchronizer.migrationAdvanceStep(accountUUID: accountUUID)
 
-            XCTAssertEqual(step, expectedStep)
+            XCTAssertEqual(advance, expectedAdvance)
             XCTAssertEqual(welding.migrationAdvanceStepForEstimatedTipReceivedArguments?.account, accountUUID)
         }
     }
@@ -537,13 +543,13 @@ final class SlipstreamSynchronizerMigrationTests: ZcashTestCase {
     /// `testMigrationSyncBlockedStreamForwardsToHostStream`).
     func testThrowingMigrationMemberIsSlipstreamSynchronizersOwnWitnessNotTheProtocolDefault() async throws {
         let welding = ZcashRustBackendWeldingMock()
-        welding.migrationAdvanceStepForEstimatedTipReturnValue = .waiting
+        welding.migrationAdvanceStepForEstimatedTipReturnValue = MigrationAdvance(step: .waiting, next: nil)
         let synchronizer = try makeSynchronizer(migrationHost: makeHost(welding: welding))
 
         // If SlipstreamSynchronizer still fell through to the protocol default, this would throw
         // `MigrationUnimplemented` instead of returning the host-scripted value.
-        let step = try await synchronizer.migrationAdvanceStep(accountUUID: accountUUID)
-        XCTAssertEqual(step, .waiting)
+        let advance = try await synchronizer.migrationAdvanceStep(accountUUID: accountUUID)
+        XCTAssertEqual(advance?.step, .waiting)
     }
 
     // MARK: - Enforcement: start() privacy gate

--- a/Tests/TestUtils/Sourcery/GeneratedMocks/AutoMockable.generated.swift
+++ b/Tests/TestUtils/Sourcery/GeneratedMocks/AutoMockable.generated.swift
@@ -2709,10 +2709,10 @@ class SynchronizerMock: Synchronizer {
         return migrationAdvanceStepAccountUUIDCallsCount > 0
     }
     var migrationAdvanceStepAccountUUIDReceivedAccountUUID: AccountUUID?
-    var migrationAdvanceStepAccountUUIDReturnValue: MigrationAdvanceStep?
-    var migrationAdvanceStepAccountUUIDClosure: ((AccountUUID) async throws -> MigrationAdvanceStep?)?
+    var migrationAdvanceStepAccountUUIDReturnValue: MigrationAdvance?
+    var migrationAdvanceStepAccountUUIDClosure: ((AccountUUID) async throws -> MigrationAdvance?)?
 
-    func migrationAdvanceStep(accountUUID: AccountUUID) async throws -> MigrationAdvanceStep? {
+    func migrationAdvanceStep(accountUUID: AccountUUID) async throws -> MigrationAdvance? {
         if let error = migrationAdvanceStepAccountUUIDThrowableError {
             throw error
         }
@@ -2770,30 +2770,6 @@ class SynchronizerMock: Synchronizer {
             return try await closure(accountUUID)
         } else {
             return finalizeReadyMigrationTransfersAccountUUIDReturnValue
-        }
-    }
-
-    // MARK: - reconcileUnrecordedMigrationBroadcasts
-
-    var reconcileUnrecordedMigrationBroadcastsAccountUUIDThrowableError: Error?
-    var reconcileUnrecordedMigrationBroadcastsAccountUUIDCallsCount = 0
-    var reconcileUnrecordedMigrationBroadcastsAccountUUIDCalled: Bool {
-        return reconcileUnrecordedMigrationBroadcastsAccountUUIDCallsCount > 0
-    }
-    var reconcileUnrecordedMigrationBroadcastsAccountUUIDReceivedAccountUUID: AccountUUID?
-    var reconcileUnrecordedMigrationBroadcastsAccountUUIDReturnValue: Bool!
-    var reconcileUnrecordedMigrationBroadcastsAccountUUIDClosure: ((AccountUUID) async throws -> Bool)?
-
-    func reconcileUnrecordedMigrationBroadcasts(accountUUID: AccountUUID) async throws -> Bool {
-        if let error = reconcileUnrecordedMigrationBroadcastsAccountUUIDThrowableError {
-            throw error
-        }
-        reconcileUnrecordedMigrationBroadcastsAccountUUIDCallsCount += 1
-        reconcileUnrecordedMigrationBroadcastsAccountUUIDReceivedAccountUUID = accountUUID
-        if let closure = reconcileUnrecordedMigrationBroadcastsAccountUUIDClosure {
-            return try await closure(accountUUID)
-        } else {
-            return reconcileUnrecordedMigrationBroadcastsAccountUUIDReturnValue
         }
     }
 
@@ -5031,10 +5007,10 @@ class ZcashRustBackendWeldingMock: ZcashRustBackendWelding {
         return migrationAdvanceStepForCallsCount > 0
     }
     var migrationAdvanceStepForReceivedAccount: AccountUUID?
-    var migrationAdvanceStepForReturnValue: MigrationAdvanceStep?
-    var migrationAdvanceStepForClosure: ((AccountUUID) async throws -> MigrationAdvanceStep?)?
+    var migrationAdvanceStepForReturnValue: MigrationAdvance?
+    var migrationAdvanceStepForClosure: ((AccountUUID) async throws -> MigrationAdvance?)?
 
-    func migrationAdvanceStep(for account: AccountUUID) async throws -> MigrationAdvanceStep? {
+    func migrationAdvanceStep(for account: AccountUUID) async throws -> MigrationAdvance? {
         if let error = migrationAdvanceStepForThrowableError {
             throw error
         }
@@ -5055,10 +5031,10 @@ class ZcashRustBackendWeldingMock: ZcashRustBackendWelding {
         return migrationAdvanceStepForEstimatedTipCallsCount > 0
     }
     var migrationAdvanceStepForEstimatedTipReceivedArguments: (account: AccountUUID, estimatedTip: BlockHeight?)?
-    var migrationAdvanceStepForEstimatedTipReturnValue: MigrationAdvanceStep?
-    var migrationAdvanceStepForEstimatedTipClosure: ((AccountUUID, BlockHeight?) async throws -> MigrationAdvanceStep?)?
+    var migrationAdvanceStepForEstimatedTipReturnValue: MigrationAdvance?
+    var migrationAdvanceStepForEstimatedTipClosure: ((AccountUUID, BlockHeight?) async throws -> MigrationAdvance?)?
 
-    func migrationAdvanceStep(for account: AccountUUID, estimatedTip: BlockHeight?) async throws -> MigrationAdvanceStep? {
+    func migrationAdvanceStep(for account: AccountUUID, estimatedTip: BlockHeight?) async throws -> MigrationAdvance? {
         if let error = migrationAdvanceStepForEstimatedTipThrowableError {
             throw error
         }
@@ -5140,30 +5116,6 @@ class ZcashRustBackendWeldingMock: ZcashRustBackendWelding {
             return try await closure(window)
         } else {
             return migrationBlockRateSamplesWindowReturnValue
-        }
-    }
-
-    // MARK: - migrationReconcileUnrecordedBroadcasts
-
-    var migrationReconcileUnrecordedBroadcastsForThrowableError: Error?
-    var migrationReconcileUnrecordedBroadcastsForCallsCount = 0
-    var migrationReconcileUnrecordedBroadcastsForCalled: Bool {
-        return migrationReconcileUnrecordedBroadcastsForCallsCount > 0
-    }
-    var migrationReconcileUnrecordedBroadcastsForReceivedAccount: AccountUUID?
-    var migrationReconcileUnrecordedBroadcastsForReturnValue: Bool!
-    var migrationReconcileUnrecordedBroadcastsForClosure: ((AccountUUID) async throws -> Bool)?
-
-    func migrationReconcileUnrecordedBroadcasts(for account: AccountUUID) async throws -> Bool {
-        if let error = migrationReconcileUnrecordedBroadcastsForThrowableError {
-            throw error
-        }
-        migrationReconcileUnrecordedBroadcastsForCallsCount += 1
-        migrationReconcileUnrecordedBroadcastsForReceivedAccount = account
-        if let closure = migrationReconcileUnrecordedBroadcastsForClosure {
-            return try await closure(account)
-        } else {
-            return migrationReconcileUnrecordedBroadcastsForReturnValue
         }
     }
 

--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -241,6 +241,11 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `zcashlc_slipstream_wallet_summary` no longer returns the empty sentinel during the ~30 s gap after
   a restore completes, and once NU6.3 is active reports the collapsed recovery balance in the
   Ironwood pool rather than Orchard.
+- Committing (signing) a migration plan is linear in the wallet's note count again: the FFI's
+  wallet adapter now snapshots the spendable-note selection per call (the same fix librustzcash
+  #2946 applied to the upstream adapter), where it previously re-ran the full selection for every
+  input being signed — on a large wallet, accepting a plan could stall for many minutes and get
+  the app killed.
 
 ## 2.8.0-rc.2 - 2026-07-28
 

--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -58,7 +58,9 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     length, for the caller to re-slice its own ordered PCZT array by.
   - Note split: `zcashlc_migration_prepare_note_split`, `_sign_note_split`.
   - Proposal and commit: `zcashlc_migration_residual_after_migration`, `_propose_transfers`,
-    `_sign_and_store_schedule`.
+    `_sign_and_store_schedule`. Committing a plan is linear in the wallet's note count: the FFI's
+    wallet adapter snapshots its spendable-note selection per call (the pattern librustzcash #2946
+    set for the upstream adapter).
   - Proving: `zcashlc_migration_prove_pending` proves everything currently provable and returns the
     count proved (`-1` = error), skipping rather than failing on a row whose anchor is not yet
     scanned or retained. Call it from the sync path.
@@ -241,11 +243,6 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `zcashlc_slipstream_wallet_summary` no longer returns the empty sentinel during the ~30 s gap after
   a restore completes, and once NU6.3 is active reports the collapsed recovery balance in the
   Ironwood pool rather than Orchard.
-- Committing (signing) a migration plan is linear in the wallet's note count again: the FFI's
-  wallet adapter now snapshots the spendable-note selection per call (the same fix librustzcash
-  #2946 applied to the upstream adapter), where it previously re-ran the full selection for every
-  input being signed — on a large wallet, accepting a plan could stall for many minutes and get
-  the app killed.
 
 ## 2.8.0-rc.2 - 2026-07-28
 

--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -19,7 +19,10 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     decision into `FfiMigrationAdvanceStep`, freed by
     `zcashlc_free_migration_advance_step`; `NULL` with no last error means no run is stored; the
     step discriminants are exported as `ZCASHLC_ADVANCE_STEP_*` constants; upstream `Reevaluate`
-    and `Replan` map to the compatibility `_ATTEND` case), `_progress`,
+    and `Replan` map to the compatibility `_ATTEND` case; a `Prove` step's `kind_*` fields moved
+    off the step itself onto `FfiProveTarget` rows — `prove_targets`/`prove_targets_len`, freed by
+    the step's own destructor — one per transaction of the WHOLE provable batch upstream now
+    serves in one call; `id` is `0` for `Prove`, the batch entries carrying their own), `_progress`,
     `_is_note_split_needed`, `_has_overdue_transfers`, `_has_invalid_transfers` (true iff the
     NON-terminal stored run holds an engine-`Invalid` or expired-unmined transaction; a cancelled
     run answers `false`), `_has_ready_broadcast` (the sync-gate's work-pending predicate:

--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -22,7 +22,12 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     and `Replan` map to the compatibility `_ATTEND` case; a `Prove` step's `kind_*` fields moved
     off the step itself onto `FfiProveTarget` rows — `prove_targets`/`prove_targets_len`, freed by
     the step's own destructor — one per transaction of the WHOLE provable batch upstream now
-    serves in one call; `id` is `0` for `Prove`, the batch entries carrying their own), `_progress`,
+    serves in one call; `id` is `0` for `Prove`, the batch entries carrying their own; the step now
+    also carries the engine's advisory OUTLOOK (upstream #2936, `Advance::next`) as
+    `next_height`/`next_kind` — the earliest target height and kind of the migration's next
+    serviceable work, assuming the served step is executed and recorded, `next_height = -1` when
+    nothing is height-schedulable — with the kind exported as the `ZCASHLC_STEP_KIND_*` constants,
+    a verbatim mirror of upstream `state::StepKind`), `_progress`,
     `_is_note_split_needed`, `_has_overdue_transfers`, `_has_invalid_transfers` (true iff the
     NON-terminal stored run holds an engine-`Invalid` or expired-unmined transaction; a cancelled
     run answers `false`), `_has_ready_broadcast` (the sync-gate's work-pending predicate:

--- a/rust/src/migration.rs
+++ b/rust/src/migration.rs
@@ -103,7 +103,9 @@ use zcash_pool_migration::signing_rounds::{
     NextFit, PREPARATION_ACTIONS, PlannedTx, SigningRoundBudget, SigningRoundStrategy,
     TRANSFER_ACTIONS, action_weight,
 };
-use zcash_pool_migration::state::{AdvanceStep, Blocker, NextAction, TransactionStatus};
+use zcash_pool_migration::state::{
+    AdvanceStep, Blocker, NextAction, ProveTarget, TransactionStatus,
+};
 use zcash_pool_migration::wallet::WalletMigrationProver;
 
 use crate::migration_engine::{Backend, MigrationWallet};
@@ -1539,41 +1541,49 @@ pub const ZCASHLC_ADVANCE_STEP_WAITING: u32 = 3;
 pub const ZCASHLC_ADVANCE_STEP_COMPLETE: u32 = 4;
 pub const ZCASHLC_ADVANCE_STEP_ATTEND: u32 = 5;
 
+/// One transaction of a Prove batch (element of [`FfiMigrationAdvanceStep::prove_targets`]): a
+/// verbatim marshal of upstream `state::ProveTarget` — the transaction to prove, with the kind
+/// that routes it (a preparation proves against the tip anchor and may broadcast at the same
+/// wake-up; a transfer proves against its drawn boundary and broadcasts in its own later
+/// session).
+#[repr(C)]
+pub struct FfiProveTarget {
+    /// The engine's raw transaction id.
+    pub id: u32,
+    /// Whether the transaction is a preparation (`true`) or a transfer (`false`).
+    pub kind_is_preparation: bool,
+    /// The preparation's layer, when `kind_is_preparation`; `0` otherwise.
+    pub kind_layer: u32,
+    /// The preparation's index within its layer, when `kind_is_preparation`; `0` otherwise.
+    pub kind_index: u32,
+    /// The transfer's crossing index, when `!kind_is_preparation`; `0` otherwise.
+    pub kind_crossing: u32,
+}
+
 /// The engine's next-step decision for the stored run (returned by
 /// [`zcashlc_migration_advance_step`]) — a verbatim marshal of upstream
 /// the public satisfiability advance API's [`AdvanceStep`].
 #[repr(C)]
 pub struct FfiMigrationAdvanceStep {
-    /// The step discriminant (see the `ZCASHLC_ADVANCE_STEP_*` constants): `0` = Prove,
-    /// `1` = Broadcast, `2` = Rebuild, `3` = Waiting, `4` = Complete, `5` = Attend (a
-    /// transaction is marked invalid and no automatic step can advance the run — resolve
-    /// out-of-band, typically by cancelling and re-planning).
+    /// The step discriminant (see the `ZCASHLC_ADVANCE_STEP_*` constants).
     pub step: u32,
-    /// The engine's raw transaction id for Prove/Broadcast/Rebuild/Attend; `0` for
-    /// Waiting/Complete.
+    /// The engine's raw transaction id for Broadcast/Rebuild/Attend; `0` for Prove (the batch
+    /// entries carry their own ids) and for Waiting/Complete.
     pub id: u32,
-    /// Whether the Prove step's transaction is a preparation (`true`) or a transfer (`false`).
-    /// Meaningful only for `step == 0`; `false` otherwise.
-    pub kind_is_preparation: bool,
-    /// The preparation's layer, when `step == 0` and `kind_is_preparation`; `0` otherwise.
-    pub kind_layer: u32,
-    /// The preparation's index within its layer, when `step == 0` and `kind_is_preparation`; `0`
-    /// otherwise.
-    pub kind_index: u32,
-    /// The transfer's crossing index, when `step == 0` and `!kind_is_preparation`; `0` otherwise.
-    pub kind_crossing: u32,
+    /// Heap array of `prove_targets_len` batch entries when `step == 0` (Prove) — the WHOLE
+    /// provable set, earliest-ready first, never empty for a served Prove; null/0 otherwise.
+    pub prove_targets: *mut FfiProveTarget,
+    pub prove_targets_len: usize,
 }
 
 impl FfiMigrationAdvanceStep {
-    /// A step that names a transaction but carries no kind payload (Broadcast/Rebuild/Attend).
+    /// A step that names a transaction but carries no batch payload (Broadcast/Rebuild/Attend).
     fn with_id(step: u32, id: MigrationTransferId) -> *mut Self {
         Box::into_raw(Box::new(FfiMigrationAdvanceStep {
             step,
             id: u32::from(id),
-            kind_is_preparation: false,
-            kind_layer: 0,
-            kind_index: 0,
-            kind_crossing: 0,
+            prove_targets: ptr::null_mut(),
+            prove_targets_len: 0,
         }))
     }
 
@@ -1582,27 +1592,38 @@ impl FfiMigrationAdvanceStep {
         Box::into_raw(Box::new(FfiMigrationAdvanceStep {
             step,
             id: 0,
-            kind_is_preparation: false,
-            kind_layer: 0,
-            kind_index: 0,
-            kind_crossing: 0,
+            prove_targets: ptr::null_mut(),
+            prove_targets_len: 0,
         }))
     }
 
-    /// The Prove step, carrying the transaction's kind so the platform can route it (preparations
-    /// prove against the tip anchor, transfers against their drawn boundary).
-    fn prove(id: MigrationTransferId, kind: MigrationTxKind) -> *mut Self {
-        let (kind_is_preparation, kind_layer, kind_index, kind_crossing) = match kind {
-            MigrationTxKind::Preparation { layer, index } => (true, layer as u32, index as u32, 0),
-            MigrationTxKind::Transfer { crossing } => (false, 0, 0, crossing as u32),
-        };
+    /// The Prove step, carrying the whole provable set (upstream #2939): each entry's kind lets the
+    /// platform route it without a lookup.
+    fn prove(transactions: &[ProveTarget]) -> *mut Self {
+        let targets: Vec<FfiProveTarget> = transactions
+            .iter()
+            .map(|t| {
+                let (kind_is_preparation, kind_layer, kind_index, kind_crossing) = match t.kind() {
+                    MigrationTxKind::Preparation { layer, index } => {
+                        (true, layer as u32, index as u32, 0)
+                    }
+                    MigrationTxKind::Transfer { crossing } => (false, 0, 0, crossing as u32),
+                };
+                FfiProveTarget {
+                    id: u32::from(t.id()),
+                    kind_is_preparation,
+                    kind_layer,
+                    kind_index,
+                    kind_crossing,
+                }
+            })
+            .collect();
+        let (prove_targets, prove_targets_len) = ptr_from_vec(targets);
         Box::into_raw(Box::new(FfiMigrationAdvanceStep {
             step: ZCASHLC_ADVANCE_STEP_PROVE,
-            id: u32::from(id),
-            kind_is_preparation,
-            kind_layer,
-            kind_index,
-            kind_crossing,
+            id: 0,
+            prove_targets,
+            prove_targets_len,
         }))
     }
 }
@@ -2085,15 +2106,16 @@ fn cstring_raw(s: &str, what: &str) -> anyhow::Result<*mut c_char> {
 
 // ----- free functions -----
 
-/// Frees a [`FfiMigrationAdvanceStep`].
+/// Frees a [`FfiMigrationAdvanceStep`], including its `prove_targets` batch array (if any).
 ///
 /// # Safety
 /// `ptr` must be null or point to a [`FfiMigrationAdvanceStep`] handed out by this module.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn zcashlc_free_migration_advance_step(ptr: *mut FfiMigrationAdvanceStep) {
     if !ptr.is_null() {
-        // Every field is plain data, so dropping the box is the whole of the cleanup.
-        drop(unsafe { Box::from_raw(ptr) });
+        let boxed = unsafe { Box::from_raw(ptr) };
+        free_ptr_from_vec(boxed.prove_targets, boxed.prove_targets_len);
+        drop(boxed);
     }
 }
 
@@ -2352,7 +2374,10 @@ pub unsafe extern "C" fn zcashlc_migration_advance_step(
         }
         let targets = dueness_targets(ctx.tip()?, estimated_tip);
         let mut backend = Backend::new(&ctx.wallet, ctx.account, None, &mut ctx.store_conn)?;
-        let step = advance_migration(
+        // librustzcash #2936: the advance returns the verified step plus a next-wake outlook;
+        // this conduit marshals the step via the borrow `.step()` now returns (Task 2a adds the
+        // outlook fields to the FFI struct).
+        let advance = advance_migration(
             &mut backend,
             &mut state,
             targets,
@@ -2360,11 +2385,8 @@ pub unsafe extern "C" fn zcashlc_migration_advance_step(
             // librustzcash #2910: re-spreading a missed broadcast schedule draws fresh
             // inter-broadcast gaps, so advancing needs entropy.
             &mut OsRng,
-        )?
-        // librustzcash #2936: the advance returns the verified step plus a next-wake outlook;
-        // this conduit marshals the step alone (no FFI field carries the outlook yet).
-        .step();
-        Ok(match step {
+        )?;
+        Ok(match advance.step() {
             AdvanceStep::Reevaluate | AdvanceStep::Replan => {
                 let id = state
                     .transaction_statuses(targets)
@@ -2383,12 +2405,12 @@ pub unsafe extern "C" fn zcashlc_migration_advance_step(
                     .unwrap_or_else(|| MigrationTransferId::new(0));
                 FfiMigrationAdvanceStep::with_id(ZCASHLC_ADVANCE_STEP_ATTEND, id)
             }
-            AdvanceStep::Prove { id, kind } => FfiMigrationAdvanceStep::prove(id, kind),
+            AdvanceStep::Prove { transactions } => FfiMigrationAdvanceStep::prove(transactions),
             AdvanceStep::Broadcast { id } => {
-                FfiMigrationAdvanceStep::with_id(ZCASHLC_ADVANCE_STEP_BROADCAST, id)
+                FfiMigrationAdvanceStep::with_id(ZCASHLC_ADVANCE_STEP_BROADCAST, *id)
             }
             AdvanceStep::Rebuild { id } => {
-                FfiMigrationAdvanceStep::with_id(ZCASHLC_ADVANCE_STEP_REBUILD, id)
+                FfiMigrationAdvanceStep::with_id(ZCASHLC_ADVANCE_STEP_REBUILD, *id)
             }
             AdvanceStep::Waiting => FfiMigrationAdvanceStep::bare(ZCASHLC_ADVANCE_STEP_WAITING),
             AdvanceStep::Complete => FfiMigrationAdvanceStep::bare(ZCASHLC_ADVANCE_STEP_COMPLETE),
@@ -4552,6 +4574,43 @@ mod tests {
             rusqlite::params![birthday, height + 1],
         )
         .expect("the scanned range inserts");
+    }
+
+    /// Seeds a synthetic RECEIVED Orchard note whose nullifier is `nf`, so the satisfiability
+    /// oracle's per-nullifier input observation resolves a fixture migration transaction's
+    /// `spend_nullifiers` to "known, unspent" rather than `Unknown` — an unknown nullifier defers
+    /// the candidate silently (`Waiting`) rather than ever offering it as `Prove`.
+    /// [`test_transaction_from_parts`] gives every non-`Mined` fixture transaction the SAME
+    /// placeholder nullifier (`[0u8; 32]`), so one seeded row here covers every `Signed` row a
+    /// fixture adds. The note's other fields are meaningless placeholders — the oracle's
+    /// observation query joins only on `nf`/`account_id` and whether a MINED spend exists (there
+    /// is none here), never touching diversifier/rho/rseed.
+    fn seed_placeholder_received_note(path: &std::path::Path, nf: [u8; 32]) {
+        let conn = Connection::open(path).expect("the wallet connection opens");
+        let account_id: i64 = conn
+            .query_row("SELECT id FROM accounts", [], |row| row.get(0))
+            .expect("the fixture account exists");
+        conn.execute(
+            "INSERT INTO transactions (txid, min_observed_height) VALUES (?1, ?2)",
+            rusqlite::params![&[0xABu8; 32][..], 0],
+        )
+        .expect("the placeholder receiving-transaction row inserts");
+        let transaction_id = conn.last_insert_rowid();
+        conn.execute(
+            "INSERT INTO orchard_received_notes \
+             (transaction_id, action_index, account_id, diversifier, value, rho, rseed, nf, is_change) \
+             VALUES (?1, 0, ?2, ?3, ?4, ?5, ?6, ?7, 0)",
+            rusqlite::params![
+                transaction_id,
+                account_id,
+                &[0u8; 11][..],
+                100_000_000i64,
+                &[0u8; 32][..],
+                &[0u8; 32][..],
+                &nf[..],
+            ],
+        )
+        .expect("the placeholder received-note row inserts");
     }
 
     /// A view-only account imported by UFVK (no seed) — the negative-path counterpart to
@@ -8648,9 +8707,16 @@ mod tests {
         );
     }
 
-    /// Reads one advance step over the FFI, asserting success, and frees the DTO after copying it
-    /// out (every field is plain data).
-    fn read_advance_step(path_bytes: &[u8], account: &[u8; 16]) -> (u32, u32, bool, u32, u32, u32) {
+    /// One copied-out `FfiProveTarget` row, as `(id, kind_is_preparation, kind_layer, kind_index,
+    /// kind_crossing)` — the tuple shape [`read_advance_step`] collects `prove_targets` into.
+    type ProveTargetTuple = (u32, bool, u32, u32, u32);
+
+    /// Reads one advance step over the FFI, asserting success, and frees the DTO (and its
+    /// `prove_targets` batch array, if any) after copying everything out.
+    fn read_advance_step(
+        path_bytes: &[u8],
+        account: &[u8; 16],
+    ) -> (u32, u32, Vec<ProveTargetTuple>) {
         let ptr = unsafe {
             zcashlc_migration_advance_step(
                 path_bytes.as_ptr(),
@@ -8666,14 +8732,19 @@ mod tests {
             ffi_helpers::error_handling::error_message()
         );
         let step = unsafe { &*ptr };
-        let out = (
-            step.step,
-            step.id,
-            step.kind_is_preparation,
-            step.kind_layer,
-            step.kind_index,
-            step.kind_crossing,
-        );
+        let targets = unsafe { slice_or_empty(step.prove_targets, step.prove_targets_len) }
+            .iter()
+            .map(|t| {
+                (
+                    t.id,
+                    t.kind_is_preparation,
+                    t.kind_layer,
+                    t.kind_index,
+                    t.kind_crossing,
+                )
+            })
+            .collect();
+        let out = (step.step, step.id, targets);
         unsafe { zcashlc_free_migration_advance_step(ptr) };
         out
     }
@@ -8729,11 +8800,11 @@ mod tests {
     /// run is terminal, so the conduit answers `Complete` and the attention queries answer
     /// `false`, with no separate clearing machinery involved.
 
-    /// A provable PREPARATION reports `Prove` with `kind_is_preparation` and its layer/index —
-    /// carried natively by upstream's `AdvanceStep::Prove { id, kind }`, no stored-row lookup
-    /// involved.
+    /// A provable PREPARATION reports `Prove` with a batch entry whose `kind_is_preparation` and
+    /// layer/index are set — carried natively by upstream's `AdvanceStep::Prove { transactions }`,
+    /// no stored-row lookup involved.
 
-    /// A provable TRANSFER reports `Prove` with its crossing index populated.
+    /// A provable TRANSFER reports `Prove` with a batch entry whose crossing index is populated.
 
     /// Every transaction mined -> the `Complete` step (upstream's own all-mined arm).
     #[test]
@@ -8798,6 +8869,69 @@ mod tests {
         let (step, id, ..) = read_advance_step(path_bytes, &account);
         assert_eq!(step, 3, "nothing actionable must report Waiting");
         assert_eq!(id, 0, "the Waiting step names no transaction");
+        let _ = std::fs::remove_file(&path);
+    }
+
+    /// The batch marshal pin (librustzcash #2939): with MULTIPLE provable rows outstanding, the
+    /// Prove step carries the WHOLE provable set in one call rather than one candidate at a time
+    /// — each entry keeping its own id and kind, ordered earliest-ready-first (a transfer by its
+    /// settled anchor boundary) with distinct ids — and the step's own `id` is `0` (the batch
+    /// entries carry their own).
+    #[test]
+    fn advance_step_prove_carries_the_whole_batch() {
+        let path = init_fixture_db("zcashlc_advance_step_prove_batch");
+        let path_bytes = path.to_str().unwrap().as_bytes();
+        let account = create_fixture_account(&path);
+        set_fixture_tip(path_bytes);
+        // The satisfiability oracle verifies a transfer's boundary checkpoint against SCANNED
+        // data, not just the stored schedule — an unscanned wallet cannot vouch for either
+        // boundary however far below the tip they sit.
+        mark_fixture_scanned_through(&path, 3_600_000);
+        // Both rows below share the fixture's placeholder spend nullifier; the oracle must find
+        // it as a known, unspent input before either row is satisfiable.
+        seed_placeholder_received_note(&path, [0u8; 32]);
+        let state = custom_state(
+            MigrationStatus::InProgress,
+            vec![
+                tx_row(
+                    0,
+                    MigrationTxKind::Transfer { crossing: 0 },
+                    &[],
+                    3_700_000,
+                    4_000_000,
+                    Some(3_500_000), // settled well below the tip: provable now
+                    MigrationTxState::Signed,
+                ),
+                tx_row(
+                    1,
+                    MigrationTxKind::Transfer { crossing: 1 },
+                    &[],
+                    3_750_000,
+                    4_000_000,
+                    Some(3_550_000), // also settled, but later than row 0's boundary
+                    MigrationTxState::Signed,
+                ),
+            ],
+        );
+        store_fixture_state(&path, &account, &state);
+
+        let (step, id, targets) = read_advance_step(path_bytes, &account);
+        assert_eq!(step, 0, "multiple provable rows must report Prove");
+        assert_eq!(id, 0, "the step itself names no single transaction");
+        assert!(
+            targets.len() >= 2,
+            "the batch must carry every provable row, got {targets:?}"
+        );
+        let ids: Vec<u32> = targets.iter().map(|t| t.0).collect();
+        assert_eq!(
+            ids,
+            vec![0, 1],
+            "entries must be earliest-ready-first (row 0's boundary settled first) with distinct ids"
+        );
+        assert!(
+            targets.iter().all(|t| !t.1),
+            "both rows are transfers, so kind_is_preparation must be false throughout"
+        );
         let _ = std::fs::remove_file(&path);
     }
 

--- a/rust/src/migration.rs
+++ b/rust/src/migration.rs
@@ -5596,9 +5596,13 @@ mod tests {
     /// behind the `test-dependencies` feature this crate does not enable) using only the
     /// non-test-gated `orchard`/`zcash_note_encryption` APIs that helper itself is built from —
     /// the same relationship [`fixture_transfer_pczt_bytes`] already has to a hand-built PCZT.
+    /// `seed_offset` displaces the deterministic RNG seed, so [`fund_fixture_account_with_orchard_notes`]
+    /// can fund several distinct notes (distinct nullifier/rho/rseed) in one call; `0` reproduces
+    /// the single-note fixture's original, byte-for-byte fixed output.
     fn fixture_orchard_compact_action(
         usk: &zcash_keys::keys::UnifiedSpendingKey,
         value_zat: u64,
+        seed_offset: u64,
     ) -> zcash_client_backend::proto::compact_formats::CompactOrchardAction {
         use orchard::keys::{FullViewingKey, Scope};
         use orchard::note::{ExtractedNoteCommitment, Note, NoteVersion, RandomSeed, Rho};
@@ -5611,7 +5615,7 @@ mod tests {
         let fvk = FullViewingKey::from(usk.orchard());
         let recipient = fvk.address_at(0u32, Scope::External);
 
-        let mut rng = StdRng::seed_from_u64(0x1806_0002);
+        let mut rng = StdRng::seed_from_u64(0x1806_0002 + seed_offset);
         // The wire `nullifier` field IS the spend half of this same action: by construction the
         // new note's `rho` always equals the nullifier revealed by the action's spend
         // (`Rho::from_nf_old(nf) == Rho(nf.inner())` -- same underlying field element, just
@@ -5659,20 +5663,33 @@ mod tests {
         }
     }
 
-    /// Funds the account whose spending key is `usk_bytes` ([`Era::Orchard`]-encoded exactly as
-    /// [`create_fixture_account_with_usk`] returns it) with one real, spendable Orchard note of
-    /// `value_zat`, by scanning ONE synthetic compact block at height 1 — right after the empty
-    /// birthday frontier every [`create_fixture_account_with_usk`] fixture starts from — through
-    /// the production [`scan_cached_blocks`] entry point: the same trial-decryption and
-    /// commitment-tree insert the real sync pipeline runs, just fed an in-memory block instead of
-    /// the filesystem cache `zcashlc_scan_blocks` reads from (so no FS block-metadata-db setup is
-    /// needed for one block). `value_zat` should be an amount that is not itself a single
+    /// [`fund_fixture_account_with_orchard_notes`] for exactly one note — the common case nearly
+    /// every fixture wallet wants. `value_zat` should be an amount that is not itself a single
     /// canonical ZIP 318 denomination (e.g. not an exact `{1,2,5}·10^k` ZEC amount), so the note
     /// actually needs splitting — exercising preparation transactions, not just a transfer.
     fn fund_fixture_account_with_orchard_note(
         path: &std::path::Path,
         usk_bytes: &[u8],
         value_zat: u64,
+    ) {
+        fund_fixture_account_with_orchard_notes(path, usk_bytes, &[value_zat]);
+    }
+
+    /// Funds the account whose spending key is `usk_bytes` ([`Era::Orchard`]-encoded exactly as
+    /// [`create_fixture_account_with_usk`] returns it) with one real, spendable Orchard note per
+    /// entry of `values_zat`, by scanning ONE synthetic compact block at height 1 — right after
+    /// the empty birthday frontier every [`create_fixture_account_with_usk`] fixture starts from
+    /// — through the production [`scan_cached_blocks`] entry point: the same trial-decryption and
+    /// commitment-tree insert the real sync pipeline runs, just fed an in-memory block instead of
+    /// the filesystem cache `zcashlc_scan_blocks` reads from (so no FS block-metadata-db setup is
+    /// needed for one block). Each note is its own transaction (txid `[0xAB + i; 32]`, distinct
+    /// nullifier/rho/rseed via [`fixture_orchard_compact_action`]'s `seed_offset = i`), so the
+    /// wallet ends up with `values_zat.len()` independently addressable spendable notes after the
+    /// one scan — needed to exercise ordering/snapshot behavior a single note cannot.
+    fn fund_fixture_account_with_orchard_notes(
+        path: &std::path::Path,
+        usk_bytes: &[u8],
+        values_zat: &[u64],
     ) {
         use zcash_client_backend::data_api::chain::scan_cached_blocks;
         use zcash_client_backend::proto::compact_formats::{
@@ -5685,22 +5702,28 @@ mod tests {
 
         let usk = unsafe { crate::decode_usk(usk_bytes.as_ptr(), usk_bytes.len()) }
             .expect("the fixture usk decodes");
-        let action = fixture_orchard_compact_action(&usk, value_zat);
 
-        let ctx = CompactTx {
-            index: 1,
-            txid: vec![0xABu8; 32],
-            actions: vec![action],
-            ..Default::default()
-        };
+        let vtx: Vec<CompactTx> = values_zat
+            .iter()
+            .enumerate()
+            .map(|(i, &value_zat)| {
+                let action = fixture_orchard_compact_action(&usk, value_zat, i as u64);
+                CompactTx {
+                    index: (i + 1) as u64,
+                    txid: vec![0xABu8 + i as u8; 32],
+                    actions: vec![action],
+                    ..Default::default()
+                }
+            })
+            .collect();
         let block = CompactBlock {
             height: 1,
             hash: vec![0x11u8; 32],
             prev_hash: vec![0x00u8; 32],
-            vtx: vec![ctx],
+            vtx,
             chain_metadata: Some(ChainMetadata {
                 sapling_commitment_tree_size: 0,
-                orchard_commitment_tree_size: 1,
+                orchard_commitment_tree_size: values_zat.len() as u32,
                 ironwood_commitment_tree_size: 0,
             }),
             ..Default::default()
@@ -5730,9 +5753,135 @@ mod tests {
         .expect("scanning the one fixture block must succeed");
         assert_eq!(
             summary.received_orchard_note_count(),
-            1,
-            "the fixture block's one action must be detected as belonging to this wallet"
+            values_zat.len(),
+            "every funded action must be detected as belonging to this wallet"
         );
+    }
+
+    /// #1806 / MOB-1466 (librustzcash #2946 parity): `Backend::spendable_orchard_notes` must
+    /// serve every read through ONE adapter from a snapshot taken on first use, never re-running
+    /// the wallet's full note selection per call — the quadratic-in-note-count behavior #2946
+    /// fixed upstream in `zcash_pool_migration::wallet::WalletMigration`, which this SDK's own
+    /// `Backend` cannot use (it requires an unconditional spending key; this adapter exists
+    /// precisely to also serve imported hardware-wallet accounts whose `usk` is `None`).
+    ///
+    /// The mutation locks both funded notes through a SECOND wallet connection
+    /// (`zcashlc_migration_lock_residual`, the same kind of reservation a real migration commit
+    /// takes over the notes it is about to spend) — exactly the sort of wallet change a per-call
+    /// re-selection is unsafe against: a plan's `PrepInput::Wallet { index }` names a position in
+    /// the FIRST read's selection, so a later read observing a different set would resolve the
+    /// wrong note (or none) for an index the plan already committed to. The backend under test
+    /// must not observe the lock: a second read through the SAME backend stays identical to the
+    /// first. A FRESH backend, constructed after the lock, must observe it.
+    #[test]
+    fn spendable_orchard_notes_snapshots_per_backend_not_per_call() {
+        use incrementalmerkletree::Position;
+        use orchard::note::ExtractedNoteCommitment;
+        use zcash_pool_migration::engine::MigrationCrypto;
+
+        let path = init_fixture_db("zcashlc_migration_spendable_snapshot");
+        let (account_bytes, usk_bytes) = create_fixture_account_with_usk(&path);
+        fund_fixture_account_with_orchard_notes(&path, &usk_bytes, &[1_000_000_000, 2_000_000_000]);
+        let path_bytes = path.to_str().unwrap().as_bytes();
+        assert!(
+            unsafe {
+                crate::zcashlc_update_chain_tip(
+                    path_bytes.as_ptr(),
+                    path_bytes.len(),
+                    3_600_000,
+                    NETWORK_ID_MAINNET,
+                )
+            },
+            "chain-tip update must succeed"
+        );
+
+        let mut ctx = unsafe {
+            open(
+                path_bytes.as_ptr(),
+                path_bytes.len(),
+                account_bytes.as_ptr(),
+                NETWORK_ID_MAINNET,
+            )
+        }
+        .expect("the fixture context opens");
+
+        let backend = Backend::new(&ctx.wallet, ctx.account, None, &mut ctx.store_conn)
+            .expect("backend construction must succeed");
+
+        let first_snapshot: Vec<(Position, u64)> = {
+            let first = backend
+                .spendable_orchard_notes()
+                .expect("selection must succeed");
+            assert_eq!(
+                first.len(),
+                2,
+                "the fixture funds exactly two spendable notes"
+            );
+            // Index-space stability: `resolve_wallet_note(i)` must name the SAME note
+            // `spendable_orchard_notes()[i]` does, through the SAME backend — the property the
+            // engine's `PrepInput::Wallet { index }` depends on.
+            for (i, &(note, _, value)) in first.iter().enumerate() {
+                let resolved = backend
+                    .resolve_wallet_note(i)
+                    .unwrap_or_else(|e| panic!("resolve_wallet_note({i}) must succeed: {e}"));
+                assert_eq!(
+                    ExtractedNoteCommitment::from(resolved.commitment()).to_bytes(),
+                    ExtractedNoteCommitment::from(note.commitment()).to_bytes(),
+                    "resolve_wallet_note({i}) must name the same note spendable_orchard_notes()[{i}] does"
+                );
+                assert_eq!(
+                    resolved.value().inner(),
+                    value,
+                    "resolve_wallet_note({i})'s value must match the selection's own"
+                );
+            }
+            first.iter().map(|&(_, pos, value)| (pos, value)).collect()
+        };
+
+        // Mutate the wallet through a SECOND connection: lock every currently-spendable note,
+        // exactly what a real migration commit does when it reserves the notes it is about to
+        // spend.
+        let locked = unsafe {
+            zcashlc_migration_lock_residual(
+                path_bytes.as_ptr(),
+                path_bytes.len(),
+                account_bytes.as_ptr(),
+                NETWORK_ID_MAINNET,
+            )
+        };
+        assert_eq!(
+            locked, 3_000_000_000,
+            "locking must report both notes' total value"
+        );
+
+        // SAME backend: a second read must be served from the snapshot, unaffected by the lock
+        // the second connection just took.
+        let second_snapshot: Vec<(Position, u64)> = {
+            let second = backend
+                .spendable_orchard_notes()
+                .expect("the cached selection must still succeed");
+            second.iter().map(|&(_, pos, value)| (pos, value)).collect()
+        };
+        assert_eq!(
+            first_snapshot, second_snapshot,
+            "a second read through the SAME backend must be unchanged by the second \
+             connection's note lock"
+        );
+
+        // A FRESH backend (same wallet connection, new instance) must observe the mutation.
+        drop(backend);
+        let fresh = Backend::new(&ctx.wallet, ctx.account, None, &mut ctx.store_conn)
+            .expect("backend construction must succeed");
+        let third = fresh
+            .spendable_orchard_notes()
+            .expect("the fresh selection must succeed");
+        assert!(
+            third.is_empty(),
+            "a fresh backend must see every note the second connection locked, got {} notes",
+            third.len()
+        );
+
+        let _ = std::fs::remove_file(&path);
     }
 
     /// Item 1 of the plan-cache supersession contract: `plan_and_cache` → `commit_or_resume`

--- a/rust/src/migration.rs
+++ b/rust/src/migration.rs
@@ -1570,6 +1570,15 @@ fn step_kind_to_ffi(kind: StepKind) -> u32 {
     }
 }
 
+/// The outlook pair as the FFI carries it: `(-1, 0)` for "no outlook", else the target height
+/// widened to `i64` beside the kind discriminant — one encoding, shared by every constructor.
+fn outlook_to_ffi(next: Option<(BlockHeight, StepKind)>) -> (i64, u32) {
+    (
+        next.map_or(-1, |(h, _)| i64::from(u32::from(h))),
+        next.map_or(0, |(_, k)| step_kind_to_ffi(k)),
+    )
+}
+
 /// One transaction of a Prove batch (element of [`FfiMigrationAdvanceStep::prove_targets`]): a
 /// verbatim marshal of upstream `state::ProveTarget` — the transaction to prove, with the kind
 /// that routes it (a preparation proves against the tip anchor and may broadcast at the same
@@ -1622,25 +1631,27 @@ impl FfiMigrationAdvanceStep {
         id: MigrationTransferId,
         next: Option<(BlockHeight, StepKind)>,
     ) -> *mut Self {
+        let (next_height, next_kind) = outlook_to_ffi(next);
         Box::into_raw(Box::new(FfiMigrationAdvanceStep {
             step,
             id: u32::from(id),
             prove_targets: ptr::null_mut(),
             prove_targets_len: 0,
-            next_height: next.map_or(-1, |(h, _)| i64::from(u32::from(h))),
-            next_kind: next.map_or(0, |(_, k)| step_kind_to_ffi(k)),
+            next_height,
+            next_kind,
         }))
     }
 
     /// A payload-free step (Waiting/Complete).
     fn bare(step: u32, next: Option<(BlockHeight, StepKind)>) -> *mut Self {
+        let (next_height, next_kind) = outlook_to_ffi(next);
         Box::into_raw(Box::new(FfiMigrationAdvanceStep {
             step,
             id: 0,
             prove_targets: ptr::null_mut(),
             prove_targets_len: 0,
-            next_height: next.map_or(-1, |(h, _)| i64::from(u32::from(h))),
-            next_kind: next.map_or(0, |(_, k)| step_kind_to_ffi(k)),
+            next_height,
+            next_kind,
         }))
     }
 
@@ -1666,13 +1677,14 @@ impl FfiMigrationAdvanceStep {
             })
             .collect();
         let (prove_targets, prove_targets_len) = ptr_from_vec(targets);
+        let (next_height, next_kind) = outlook_to_ffi(next);
         Box::into_raw(Box::new(FfiMigrationAdvanceStep {
             step: ZCASHLC_ADVANCE_STEP_PROVE,
             id: 0,
             prove_targets,
             prove_targets_len,
-            next_height: next.map_or(-1, |(h, _)| i64::from(u32::from(h))),
-            next_kind: next.map_or(0, |(_, k)| step_kind_to_ffi(k)),
+            next_height,
+            next_kind,
         }))
     }
 }
@@ -2431,7 +2443,7 @@ pub unsafe extern "C" fn zcashlc_migration_advance_step(
         let mut backend = Backend::new(&ctx.wallet, ctx.account, None, &mut ctx.store_conn)?;
         // librustzcash #2936: the advance returns the verified step plus a next-wake OUTLOOK
         // (`Advance::next`) — this conduit marshals both, the step via the borrow `.step()`
-        // returns and the outlook via `.next()`, onto every arm below (Task 2a).
+        // returns and the outlook via `.next()`, onto every arm below.
         let advance = advance_migration(
             &mut backend,
             &mut state,
@@ -9103,14 +9115,11 @@ mod tests {
         let _ = std::fs::remove_file(&path);
     }
 
-    /// The batch marshal pin (librustzcash #2939): with MULTIPLE provable rows outstanding, the
-    /// Prove step carries the WHOLE provable set in one call rather than one candidate at a time
-    /// — each entry keeping its own id and kind, ordered earliest-ready-first (a transfer by its
-    /// settled anchor boundary) with distinct ids — and the step's own `id` is `0` (the batch
-    /// entries carry their own).
-    #[test]
-    fn advance_step_prove_carries_the_whole_batch() {
-        let path = init_fixture_db("zcashlc_advance_step_prove_batch");
+    /// The two-provable-transfers state both the batch pin and the outlook pin drive: two
+    /// Signed transfers, both settled below the tip — row 0 is earliest-ready, its boundary
+    /// settling before row 1's.
+    fn store_two_provable_transfers(db_name: &str) -> (std::path::PathBuf, [u8; 16]) {
+        let path = init_fixture_db(db_name);
         let path_bytes = path.to_str().unwrap().as_bytes();
         let account = create_fixture_account(&path);
         set_fixture_tip(path_bytes);
@@ -9145,6 +9154,18 @@ mod tests {
             ],
         );
         store_fixture_state(&path, &account, &state);
+        (path, account)
+    }
+
+    /// The batch marshal pin (librustzcash #2939): with MULTIPLE provable rows outstanding, the
+    /// Prove step carries the WHOLE provable set in one call rather than one candidate at a time
+    /// — each entry keeping its own id and kind, ordered earliest-ready-first (a transfer by its
+    /// settled anchor boundary) with distinct ids — and the step's own `id` is `0` (the batch
+    /// entries carry their own).
+    #[test]
+    fn advance_step_prove_carries_the_whole_batch() {
+        let (path, account) = store_two_provable_transfers("zcashlc_advance_step_prove_batch");
+        let path_bytes = path.to_str().unwrap().as_bytes();
 
         let (step, id, targets, ..) = read_advance_step(path_bytes, &account);
         assert_eq!(step, 0, "multiple provable rows must report Prove");
@@ -9173,39 +9194,8 @@ mod tests {
     /// broadcast schedule is what the outlook reports next.
     #[test]
     fn advance_step_outlook_reports_next_work() {
-        // Served step: the whole provable batch (the `advance_step_prove_carries_the_whole_batch`
-        // fixture, reused verbatim); once proved, the earliest entry's own (still-future)
-        // broadcast schedule is the outlook -- a proved-and-scheduled follower.
-        let path = init_fixture_db("zcashlc_advance_step_outlook_prove");
+        let (path, account) = store_two_provable_transfers("zcashlc_advance_step_outlook_prove");
         let path_bytes = path.to_str().unwrap().as_bytes();
-        let account = create_fixture_account(&path);
-        set_fixture_tip(path_bytes);
-        mark_fixture_scanned_through(&path, 3_600_000);
-        seed_placeholder_received_note(&path, [0u8; 32]);
-        let state = custom_state(
-            MigrationStatus::InProgress,
-            vec![
-                tx_row(
-                    0,
-                    MigrationTxKind::Transfer { crossing: 0 },
-                    &[],
-                    3_700_000,
-                    4_000_000,
-                    Some(3_500_000), // settled well below the tip: provable now
-                    MigrationTxState::Signed,
-                ),
-                tx_row(
-                    1,
-                    MigrationTxKind::Transfer { crossing: 1 },
-                    &[],
-                    3_750_000,
-                    4_000_000,
-                    Some(3_550_000), // also settled, but later than row 0's boundary
-                    MigrationTxState::Signed,
-                ),
-            ],
-        );
-        store_fixture_state(&path, &account, &state);
 
         let (step, _id, targets, next_height, next_kind) = read_advance_step(path_bytes, &account);
         assert_eq!(

--- a/rust/src/migration.rs
+++ b/rust/src/migration.rs
@@ -5683,10 +5683,12 @@ mod tests {
     /// — through the production [`scan_cached_blocks`] entry point: the same trial-decryption and
     /// commitment-tree insert the real sync pipeline runs, just fed an in-memory block instead of
     /// the filesystem cache `zcashlc_scan_blocks` reads from (so no FS block-metadata-db setup is
-    /// needed for one block). Each note is its own transaction (txid `[0xAB + i; 32]`, distinct
-    /// nullifier/rho/rseed via [`fixture_orchard_compact_action`]'s `seed_offset = i`), so the
-    /// wallet ends up with `values_zat.len()` independently addressable spendable notes after the
-    /// one scan — needed to exercise ordering/snapshot behavior a single note cannot.
+    /// needed for one block). Each note is its own transaction (txid tag byte `0xAC` plus a
+    /// little-endian `u16` index at bytes 1-2 over a zero background, disjoint from
+    /// `seed_placeholder_received_note`'s `[0xAB; 32]`, and distinct nullifier/rho/rseed via
+    /// [`fixture_orchard_compact_action`]'s `seed_offset = i`), so the wallet ends up with
+    /// `values_zat.len()` independently addressable spendable notes after the one scan — needed to
+    /// exercise ordering/snapshot behavior a single note cannot.
     fn fund_fixture_account_with_orchard_notes(
         path: &std::path::Path,
         usk_bytes: &[u8],
@@ -5711,7 +5713,16 @@ mod tests {
                 let action = fixture_orchard_compact_action(&usk, value_zat, i as u64);
                 CompactTx {
                     index: (i + 1) as u64,
-                    txid: vec![0xABu8 + i as u8; 32],
+                    txid: {
+                        // Disjoint from `seed_placeholder_received_note`'s [0xAB; 32] by the tag
+                        // byte, and unique for arbitrary i via the two-byte index — the old
+                        // `0xAB + i` scheme overflowed u8 at i = 85 and collided with the
+                        // placeholder at i = 0.
+                        let mut txid = vec![0u8; 32];
+                        txid[0] = 0xAC;
+                        txid[1..3].copy_from_slice(&(i as u16).to_le_bytes());
+                        txid
+                    },
                     actions: vec![action],
                     ..Default::default()
                 }

--- a/rust/src/migration.rs
+++ b/rust/src/migration.rs
@@ -9187,6 +9187,51 @@ mod tests {
         let _ = std::fs::remove_file(&path);
     }
 
+    /// The preparation arm of the batch marshal: `kind_is_preparation`, `kind_layer`, and
+    /// `kind_index` survive the crossing into the FFI row with layer and index NOT transposed
+    /// (both cast to `u32`, so a swap would compile silently).
+    #[test]
+    fn advance_step_prove_marshals_a_preparation_target() {
+        let path = init_fixture_db("zcashlc_advance_step_prove_preparation");
+        let path_bytes = path.to_str().unwrap().as_bytes();
+        let account = create_fixture_account(&path);
+        set_fixture_tip(path_bytes);
+        mark_fixture_scanned_through(&path, 3_600_000);
+        seed_placeholder_received_note(&path, [0u8; 32]);
+        let state = custom_state(
+            MigrationStatus::InProgress,
+            vec![tx_row(
+                0,
+                MigrationTxKind::Preparation { layer: 2, index: 5 },
+                &[],
+                3_500_000, // due: at or below the scanned target, so the schedule offers it
+                4_000_000,
+                None, // a preparation draws no anchor boundary
+                MigrationTxState::Signed,
+            )],
+        );
+        store_fixture_state(&path, &account, &state);
+
+        let (step, id, targets, ..) = read_advance_step(path_bytes, &account);
+        assert_eq!(
+            step, ZCASHLC_ADVANCE_STEP_PROVE,
+            "a due preparation is provable"
+        );
+        assert_eq!(id, 0, "the step itself names no single transaction");
+        assert_eq!(
+            targets.len(),
+            1,
+            "exactly the one preparation, got {targets:?}"
+        );
+        let (target_id, is_preparation, layer, index, crossing) = targets[0];
+        assert_eq!(target_id, 0);
+        assert!(is_preparation, "the kind must marshal as a preparation");
+        assert_eq!(layer, 2, "layer must not be transposed with index");
+        assert_eq!(index, 5, "index must not be transposed with layer");
+        assert_eq!(crossing, 0, "a preparation carries no crossing");
+        let _ = std::fs::remove_file(&path);
+    }
+
     /// The OUTLOOK (upstream #2936, `Advance::next`): the earliest height at which the migration
     /// next has serviceable work, assuming the served step is executed — mirrors upstream's own
     /// `outlook_after_a_prove_is_the_broadcast_that_follows` (satisfiability.rs ~3089): a served

--- a/rust/src/migration.rs
+++ b/rust/src/migration.rs
@@ -1602,6 +1602,7 @@ pub struct FfiMigrationAdvanceStep {
     /// Heap array of `prove_targets_len` batch entries when `step == 0` (Prove) — the WHOLE
     /// provable set, earliest-ready first, never empty for a served Prove; null/0 otherwise.
     pub prove_targets: *mut FfiProveTarget,
+    /// Length of `prove_targets`.
     pub prove_targets_len: usize,
     /// The OUTLOOK (upstream #2936, `Advance::next`): the earliest target height (`tip + 1`
     /// convention, directly comparable with the drive's own targets) at which the migration next

--- a/rust/src/migration.rs
+++ b/rust/src/migration.rs
@@ -104,7 +104,7 @@ use zcash_pool_migration::signing_rounds::{
     TRANSFER_ACTIONS, action_weight,
 };
 use zcash_pool_migration::state::{
-    AdvanceStep, Blocker, NextAction, ProveTarget, TransactionStatus,
+    AdvanceStep, Blocker, NextAction, ProveTarget, StepKind, TransactionStatus,
 };
 use zcash_pool_migration::wallet::WalletMigrationProver;
 
@@ -1541,6 +1541,35 @@ pub const ZCASHLC_ADVANCE_STEP_WAITING: u32 = 3;
 pub const ZCASHLC_ADVANCE_STEP_COMPLETE: u32 = 4;
 pub const ZCASHLC_ADVANCE_STEP_ATTEND: u32 = 5;
 
+/// The step-kind discriminants of [`FfiMigrationAdvanceStep::next_kind`], a verbatim export of
+/// upstream `state::StepKind` (the outlook's kind — WHICH transaction a wake-up serves is decided
+/// by the `advance_migration` call that serves it). Only Prove, Broadcast, Rebuild and Replan are
+/// constructible outlooks today (upstream's `upcoming_step` maps the rest to "no outlook"), but
+/// the export mirrors the full enum so the marshal never invents a projection.
+pub const ZCASHLC_STEP_KIND_PROVE: u32 = 0;
+pub const ZCASHLC_STEP_KIND_BROADCAST: u32 = 1;
+pub const ZCASHLC_STEP_KIND_REBUILD: u32 = 2;
+pub const ZCASHLC_STEP_KIND_REPLAN: u32 = 3;
+pub const ZCASHLC_STEP_KIND_REEVALUATE: u32 = 4;
+pub const ZCASHLC_STEP_KIND_WAITING: u32 = 5;
+pub const ZCASHLC_STEP_KIND_COMPLETE: u32 = 6;
+
+/// Marshals upstream `state::StepKind` into the [`ZCASHLC_STEP_KIND_*`] discriminants — the
+/// [`FfiMigrationAdvanceStep::next_kind`] counterpart of the step discriminants above. Exhaustive
+/// (no wildcard arm): a new upstream variant must be assigned an explicit number here rather than
+/// silently falling into whatever the last arm was.
+fn step_kind_to_ffi(kind: StepKind) -> u32 {
+    match kind {
+        StepKind::Prove => ZCASHLC_STEP_KIND_PROVE,
+        StepKind::Broadcast => ZCASHLC_STEP_KIND_BROADCAST,
+        StepKind::Rebuild => ZCASHLC_STEP_KIND_REBUILD,
+        StepKind::Replan => ZCASHLC_STEP_KIND_REPLAN,
+        StepKind::Reevaluate => ZCASHLC_STEP_KIND_REEVALUATE,
+        StepKind::Waiting => ZCASHLC_STEP_KIND_WAITING,
+        StepKind::Complete => ZCASHLC_STEP_KIND_COMPLETE,
+    }
+}
+
 /// One transaction of a Prove batch (element of [`FfiMigrationAdvanceStep::prove_targets`]): a
 /// verbatim marshal of upstream `state::ProveTarget` — the transaction to prove, with the kind
 /// that routes it (a preparation proves against the tip anchor and may broadcast at the same
@@ -1574,32 +1603,49 @@ pub struct FfiMigrationAdvanceStep {
     /// provable set, earliest-ready first, never empty for a served Prove; null/0 otherwise.
     pub prove_targets: *mut FfiProveTarget,
     pub prove_targets_len: usize,
+    /// The OUTLOOK (upstream #2936, `Advance::next`): the earliest target height (`tip + 1`
+    /// convention, directly comparable with the drive's own targets) at which the migration next
+    /// has serviceable work, assuming this step is executed and recorded; `-1` when nothing is
+    /// height-schedulable (chain- or user-driven followers, terminal runs — upstream documents
+    /// the cases). ADVISORY: a floor, not an appointment; the serving call re-verifies.
+    pub next_height: i64,
+    /// The kind of that upcoming work (see the `ZCASHLC_STEP_KIND_*` constants); meaningful only
+    /// when `next_height >= 0`.
+    pub next_kind: u32,
 }
 
 impl FfiMigrationAdvanceStep {
     /// A step that names a transaction but carries no batch payload (Broadcast/Rebuild/Attend).
-    fn with_id(step: u32, id: MigrationTransferId) -> *mut Self {
+    fn with_id(
+        step: u32,
+        id: MigrationTransferId,
+        next: Option<(BlockHeight, StepKind)>,
+    ) -> *mut Self {
         Box::into_raw(Box::new(FfiMigrationAdvanceStep {
             step,
             id: u32::from(id),
             prove_targets: ptr::null_mut(),
             prove_targets_len: 0,
+            next_height: next.map_or(-1, |(h, _)| i64::from(u32::from(h))),
+            next_kind: next.map_or(0, |(_, k)| step_kind_to_ffi(k)),
         }))
     }
 
     /// A payload-free step (Waiting/Complete).
-    fn bare(step: u32) -> *mut Self {
+    fn bare(step: u32, next: Option<(BlockHeight, StepKind)>) -> *mut Self {
         Box::into_raw(Box::new(FfiMigrationAdvanceStep {
             step,
             id: 0,
             prove_targets: ptr::null_mut(),
             prove_targets_len: 0,
+            next_height: next.map_or(-1, |(h, _)| i64::from(u32::from(h))),
+            next_kind: next.map_or(0, |(_, k)| step_kind_to_ffi(k)),
         }))
     }
 
     /// The Prove step, carrying the whole provable set (upstream #2939): each entry's kind lets the
     /// platform route it without a lookup.
-    fn prove(transactions: &[ProveTarget]) -> *mut Self {
+    fn prove(transactions: &[ProveTarget], next: Option<(BlockHeight, StepKind)>) -> *mut Self {
         let targets: Vec<FfiProveTarget> = transactions
             .iter()
             .map(|t| {
@@ -1624,6 +1670,8 @@ impl FfiMigrationAdvanceStep {
             id: 0,
             prove_targets,
             prove_targets_len,
+            next_height: next.map_or(-1, |(h, _)| i64::from(u32::from(h))),
+            next_kind: next.map_or(0, |(_, k)| step_kind_to_ffi(k)),
         }))
     }
 }
@@ -2328,14 +2376,15 @@ fn remaining_orchard(ctx: &mut CallCtx) -> anyhow::Result<Zatoshis> {
 }
 
 /// Advances the stored run with upstream's public satisfiability API, using scanned and estimated
-/// targets plus a ten-block reorg-settle depth. Reevaluate and Replan are projected onto the
-/// existing Attend DTO case so the Swift public enum remains source-compatible.
+/// targets plus the provable-anchor reorg-settle depth. Reevaluate and Replan are projected onto
+/// the existing Attend DTO case so the Swift public enum remains source-compatible.
 ///
 /// Returns NULL **with no error recorded** when `get_migration()` returns `None` — no run is
 /// stored, so there is nothing to advance and no step to report. Distinguish that benign NULL
 /// from an error NULL via `zcashlc_last_error_length`. A stored TERMINAL run (Complete, or
 /// Failed/cancelled) reports the `Complete` step VERBATIM, exactly as upstream's `next_step`
-/// does — a cancelled run is never driven further, and is NEVER remapped to any other step.
+/// does — a cancelled run is never driven further, and is NEVER remapped to any other step; it
+/// also carries no outlook (`next_height = -1`), same as every other terminal answer below.
 /// (The terminal check here is upstream's own first check, hoisted only so the answer needs no
 /// chain-tip lookup — the same answer `next_step` would give, available on a wallet that never
 /// saw a chain tip.)
@@ -2368,24 +2417,32 @@ pub unsafe extern "C" fn zcashlc_migration_advance_step(
         };
         // Upstream `next_step`'s own first check, hoisted ahead of the target lookup (not a
         // carve-out — identical answers): a cancelled or failed run reports Complete even on a
-        // wallet with no chain tip, and is never driven further.
+        // wallet with no chain tip, and is never driven further. No outlook is knowable either
+        // (no targets were even looked up), so this hoisted answer carries `None`, same as every
+        // other Complete below.
         if state.is_terminal() {
-            return Ok(FfiMigrationAdvanceStep::bare(ZCASHLC_ADVANCE_STEP_COMPLETE));
+            return Ok(FfiMigrationAdvanceStep::bare(
+                ZCASHLC_ADVANCE_STEP_COMPLETE,
+                None,
+            ));
         }
         let targets = dueness_targets(ctx.tip()?, estimated_tip);
         let mut backend = Backend::new(&ctx.wallet, ctx.account, None, &mut ctx.store_conn)?;
-        // librustzcash #2936: the advance returns the verified step plus a next-wake outlook;
-        // this conduit marshals the step via the borrow `.step()` now returns (Task 2a adds the
-        // outlook fields to the FFI struct).
+        // librustzcash #2936: the advance returns the verified step plus a next-wake OUTLOOK
+        // (`Advance::next`) — this conduit marshals both, the step via the borrow `.step()`
+        // returns and the outlook via `.next()`, onto every arm below (Task 2a).
         let advance = advance_migration(
             &mut backend,
             &mut state,
             targets,
-            &AdvanceConfig::new(ReorgSettleDepth::new(10)),
+            &AdvanceConfig::new(ReorgSettleDepth::new(
+                zcash_pool_migration::scheduling::PROVABLE_ANCHOR_DEPTH,
+            )),
             // librustzcash #2910: re-spreading a missed broadcast schedule draws fresh
             // inter-broadcast gaps, so advancing needs entropy.
             &mut OsRng,
         )?;
+        let next = advance.next();
         Ok(match advance.step() {
             AdvanceStep::Reevaluate | AdvanceStep::Replan => {
                 let id = state
@@ -2403,17 +2460,23 @@ pub unsafe extern "C" fn zcashlc_migration_advance_step(
                     })
                     .map(|status| status.id())
                     .unwrap_or_else(|| MigrationTransferId::new(0));
-                FfiMigrationAdvanceStep::with_id(ZCASHLC_ADVANCE_STEP_ATTEND, id)
+                FfiMigrationAdvanceStep::with_id(ZCASHLC_ADVANCE_STEP_ATTEND, id, next)
             }
-            AdvanceStep::Prove { transactions } => FfiMigrationAdvanceStep::prove(transactions),
+            AdvanceStep::Prove { transactions } => {
+                FfiMigrationAdvanceStep::prove(transactions, next)
+            }
             AdvanceStep::Broadcast { id } => {
-                FfiMigrationAdvanceStep::with_id(ZCASHLC_ADVANCE_STEP_BROADCAST, *id)
+                FfiMigrationAdvanceStep::with_id(ZCASHLC_ADVANCE_STEP_BROADCAST, *id, next)
             }
             AdvanceStep::Rebuild { id } => {
-                FfiMigrationAdvanceStep::with_id(ZCASHLC_ADVANCE_STEP_REBUILD, *id)
+                FfiMigrationAdvanceStep::with_id(ZCASHLC_ADVANCE_STEP_REBUILD, *id, next)
             }
-            AdvanceStep::Waiting => FfiMigrationAdvanceStep::bare(ZCASHLC_ADVANCE_STEP_WAITING),
-            AdvanceStep::Complete => FfiMigrationAdvanceStep::bare(ZCASHLC_ADVANCE_STEP_COMPLETE),
+            AdvanceStep::Waiting => {
+                FfiMigrationAdvanceStep::bare(ZCASHLC_ADVANCE_STEP_WAITING, next)
+            }
+            AdvanceStep::Complete => {
+                FfiMigrationAdvanceStep::bare(ZCASHLC_ADVANCE_STEP_COMPLETE, next)
+            }
         })
     });
     unwrap_exc_or_null(res)
@@ -8712,11 +8775,12 @@ mod tests {
     type ProveTargetTuple = (u32, bool, u32, u32, u32);
 
     /// Reads one advance step over the FFI, asserting success, and frees the DTO (and its
-    /// `prove_targets` batch array, if any) after copying everything out.
+    /// `prove_targets` batch array, if any) after copying everything out. The trailing pair is
+    /// the OUTLOOK (upstream #2936): `next_height` (`-1` = no outlook) and `next_kind`.
     fn read_advance_step(
         path_bytes: &[u8],
         account: &[u8; 16],
-    ) -> (u32, u32, Vec<ProveTargetTuple>) {
+    ) -> (u32, u32, Vec<ProveTargetTuple>, i64, u32) {
         let ptr = unsafe {
             zcashlc_migration_advance_step(
                 path_bytes.as_ptr(),
@@ -8744,7 +8808,13 @@ mod tests {
                 )
             })
             .collect();
-        let out = (step.step, step.id, targets);
+        let out = (
+            step.step,
+            step.id,
+            targets,
+            step.next_height,
+            step.next_kind,
+        );
         unsafe { zcashlc_free_migration_advance_step(ptr) };
         out
     }
@@ -8915,7 +8985,7 @@ mod tests {
         );
         store_fixture_state(&path, &account, &state);
 
-        let (step, id, targets) = read_advance_step(path_bytes, &account);
+        let (step, id, targets, ..) = read_advance_step(path_bytes, &account);
         assert_eq!(step, 0, "multiple provable rows must report Prove");
         assert_eq!(id, 0, "the step itself names no single transaction");
         assert!(
@@ -8931,6 +9001,109 @@ mod tests {
         assert!(
             targets.iter().all(|t| !t.1),
             "both rows are transfers, so kind_is_preparation must be false throughout"
+        );
+        let _ = std::fs::remove_file(&path);
+    }
+
+    /// The OUTLOOK (upstream #2936, `Advance::next`): the earliest height at which the migration
+    /// next has serviceable work, assuming the served step is executed — mirrors upstream's own
+    /// `outlook_after_a_prove_is_the_broadcast_that_follows` (satisfiability.rs ~3089): a served
+    /// Prove batch's own entries become `Proved` in the hypothetical, so their own (still-future)
+    /// broadcast schedule is what the outlook reports next.
+    #[test]
+    fn advance_step_outlook_reports_next_work() {
+        // Served step: the whole provable batch (the `advance_step_prove_carries_the_whole_batch`
+        // fixture, reused verbatim); once proved, the earliest entry's own (still-future)
+        // broadcast schedule is the outlook -- a proved-and-scheduled follower.
+        let path = init_fixture_db("zcashlc_advance_step_outlook_prove");
+        let path_bytes = path.to_str().unwrap().as_bytes();
+        let account = create_fixture_account(&path);
+        set_fixture_tip(path_bytes);
+        mark_fixture_scanned_through(&path, 3_600_000);
+        seed_placeholder_received_note(&path, [0u8; 32]);
+        let state = custom_state(
+            MigrationStatus::InProgress,
+            vec![
+                tx_row(
+                    0,
+                    MigrationTxKind::Transfer { crossing: 0 },
+                    &[],
+                    3_700_000,
+                    4_000_000,
+                    Some(3_500_000), // settled well below the tip: provable now
+                    MigrationTxState::Signed,
+                ),
+                tx_row(
+                    1,
+                    MigrationTxKind::Transfer { crossing: 1 },
+                    &[],
+                    3_750_000,
+                    4_000_000,
+                    Some(3_550_000), // also settled, but later than row 0's boundary
+                    MigrationTxState::Signed,
+                ),
+            ],
+        );
+        store_fixture_state(&path, &account, &state);
+
+        let (step, _id, targets, next_height, next_kind) = read_advance_step(path_bytes, &account);
+        assert_eq!(
+            step, ZCASHLC_ADVANCE_STEP_PROVE,
+            "the whole provable batch is served now"
+        );
+        assert_eq!(targets.len(), 2, "both rows are provable now");
+        assert!(
+            next_height > 0,
+            "once proved, row 0's own (still-future) broadcast schedule is a real height: {next_height}"
+        );
+        assert_eq!(
+            next_height, 3_700_000,
+            "the earliest of the two proved-and-scheduled followers wins"
+        );
+        assert_eq!(
+            next_kind, ZCASHLC_STEP_KIND_BROADCAST,
+            "once proved, a transfer's own later broadcast is the outlook"
+        );
+        let _ = std::fs::remove_file(&path);
+
+        // Nothing height-schedulable: the sole transaction is already in flight (Broadcast,
+        // unmined) -- mining is chain-derived, so upstream's `step_floor` reports no floor for
+        // it, and the Waiting step's outlook is `None` (mirrors upstream's own
+        // `outlook_is_none_when_nothing_is_height_schedulable`, satisfiability.rs, second case).
+        // No anchor boundary: an in-flight row's boundary would otherwise route the drive's own
+        // reorg-displacement check through the stored PCZT, which this fixture's placeholder
+        // bytes cannot satisfy -- orthogonal to what this scenario exercises (`step_floor`
+        // reports no floor for a `Broadcast`-state row regardless of its boundary).
+        let path = init_fixture_db("zcashlc_advance_step_outlook_none");
+        let path_bytes = path.to_str().unwrap().as_bytes();
+        let account = create_fixture_account(&path);
+        set_fixture_tip(path_bytes);
+        mark_fixture_scanned_through(&path, 3_600_000);
+        let state = custom_state(
+            MigrationStatus::InProgress,
+            vec![tx_row(
+                0,
+                MigrationTxKind::Transfer { crossing: 0 },
+                &[],
+                3_100_000,
+                4_000_000,
+                None,
+                MigrationTxState::Broadcast {
+                    txid: TxId::from_bytes([9u8; 32]),
+                },
+            )],
+        );
+        store_fixture_state(&path, &account, &state);
+
+        let (step, _id, _targets, next_height, _next_kind) =
+            read_advance_step(path_bytes, &account);
+        assert_eq!(
+            step, ZCASHLC_ADVANCE_STEP_WAITING,
+            "an in-flight-only run must report Waiting"
+        );
+        assert_eq!(
+            next_height, -1,
+            "mining is chain-derived: nothing is height-schedulable"
         );
         let _ = std::fs::remove_file(&path);
     }

--- a/rust/src/migration_engine.rs
+++ b/rust/src/migration_engine.rs
@@ -19,6 +19,7 @@
 //! [`crate::migration_finalize`].
 
 use anyhow::anyhow;
+use core::cell::{Ref, RefCell};
 use incrementalmerkletree::Position;
 use orchard::keys::{FullViewingKey, SpendAuthorizingKey};
 use orchard::note::Note as OrchardNote;
@@ -60,6 +61,13 @@ pub(crate) struct Backend<'a> {
     account: AccountUuid,
     usk: Option<UnifiedSpendingKey>,
     store: PoolMigrations<&'a mut rusqlite::Connection, NetworkParams, SystemClock>,
+    /// The spendable-note snapshot every read is served from, filled on first use — the same
+    /// contract upstream's `WalletMigration` adapter adopted in #2946: the engine addresses a
+    /// note by its index into this sequence, so every read through one adapter must see the same
+    /// set, and resolving each spent note through a fresh selection made signing a large plan
+    /// quadratic in the wallet's note count. Wallet changes are observed by constructing a fresh
+    /// adapter (every FFI entry point does).
+    spendable: RefCell<Option<Vec<SpendableNote>>>,
 }
 
 impl<'a> Backend<'a> {
@@ -86,6 +94,7 @@ impl<'a> Backend<'a> {
                 account,
             )
             .map_err(|e| anyhow!("opening the account-scoped migration store failed: {e}"))?,
+            spendable: RefCell::new(None),
         })
     }
 
@@ -123,31 +132,42 @@ impl<'a> Backend<'a> {
     }
 
     /// The account's spendable Orchard notes as `(note, tree position, value)`, sorted by tree
-    /// position so the index is stable across calls (the engine maps a value index from
-    /// `spendable_orchard_note_values` back to a note by the same order).
-    pub(crate) fn spendable_orchard_notes(&self) -> anyhow::Result<Vec<SpendableNote>> {
-        let target = self.selection_target()?;
-        let received = self
-            .wallet
-            .select_unspent_notes(
-                self.account,
-                &[ShieldedPool::Orchard],
-                target,
-                &[],
-                LockFilter::Policy(&LockedInputPolicy::Exclude),
-            )
-            .map_err(|e| anyhow!("spendable-note selection failed: {e}"))?;
-        let mut notes: Vec<SpendableNote> = received
-            .orchard()
-            .iter()
-            .map(|rn| {
-                let note = *rn.note();
-                let value = note.value().inner();
-                (note, rn.note_commitment_tree_position(), value)
-            })
-            .collect();
-        notes.sort_by_key(|(_, pos, _)| *pos);
-        Ok(notes)
+    /// position and SNAPSHOTTED on the first read: the engine addresses a note by its index into
+    /// this sequence (a plan's `PrepInput::Wallet { index, .. }` names the selection its planning
+    /// call observed), so every read through one adapter must see the same set. The snapshot also
+    /// keeps a commit linear in the plan's inputs — resolving each spent note through a fresh
+    /// selection made signing a large plan quadratic in the wallet's note count (librustzcash
+    /// #2946 fixed the same defect in the upstream `WalletMigration` adapter; this mirrors it).
+    ///
+    /// Wallet changes are observed by constructing a fresh adapter; this one's selection is fixed.
+    pub(crate) fn spendable_orchard_notes(&self) -> anyhow::Result<Ref<'_, [SpendableNote]>> {
+        if self.spendable.borrow().is_none() {
+            let target = self.selection_target()?;
+            let received = self
+                .wallet
+                .select_unspent_notes(
+                    self.account,
+                    &[ShieldedPool::Orchard],
+                    target,
+                    &[],
+                    LockFilter::Policy(&LockedInputPolicy::Exclude),
+                )
+                .map_err(|e| anyhow!("spendable-note selection failed: {e}"))?;
+            let mut notes: Vec<SpendableNote> = received
+                .orchard()
+                .iter()
+                .map(|rn| {
+                    let note = *rn.note();
+                    let value = note.value().inner();
+                    (note, rn.note_commitment_tree_position(), value)
+                })
+                .collect();
+            notes.sort_by_key(|(_, pos, _)| *pos);
+            *self.spendable.borrow_mut() = Some(notes);
+        }
+        Ok(Ref::map(self.spendable.borrow(), |cached| {
+            cached.as_deref().expect("filled above")
+        }))
     }
 
     /// The account's Orchard full viewing key, from its STORED unified full viewing key (not the
@@ -173,9 +193,9 @@ impl MigrationBackend for Backend<'_> {
 
     fn spendable_orchard_note_values(&self) -> Result<Vec<Zatoshis>, Self::Error> {
         self.spendable_orchard_notes()?
-            .into_iter()
+            .iter()
             .enumerate()
-            .map(|(i, (_, _, value))| {
+            .map(|(i, &(_, _, value))| {
                 Zatoshis::from_u64(value)
                     .map_err(|_| anyhow!("spendable note {i} has an out-of-range value"))
             })


### PR DESCRIPTION
References #1806.

Moves the librustzcash `[patch.crates-io]` pin from `41a1e17c` to `4d654982c4` — the `michal/tmp-next-due-plus-exact-funding-note-count` head: the rebased public next-due selection plus the exact-funding-note-count merge (#2949), over a main that now carries #2939 (batch Prove), #2946 (adapter spendable-note snapshot), #2943 + #2945 + #2947 (preparation/denomination rework), and #2916/#2915/#2911 (ZIP 318 classification at store time, idempotent sent-transaction stores) — and adapts the SDK to the two API generations this brings, plus one SDK-side parity fix the pin alone does not deliver.

## What changed

**1. `63ebafeb` — pin move + the batch Prove generation (librustzcash #2939).** Upstream's `AdvanceStep::Prove` now serves the WHOLE provable set (`Vec<ProveTarget>`) instead of one transaction: proving emits nothing on-chain, so a synced session proves everything provable at once, while broadcast stays one-at-a-time on the privacy schedule. The FFI struct grows a `FfiProveTarget` array (the per-step `kind_*` fields moved onto the entries), and the Swift case becomes `MigrationAdvanceStep.prove(transactions: [MigrationProveTarget])` — earliest-ready first, never empty. The discharge path is unchanged: `finalizeReadyMigrationTransfers(accountUUID:)` already proves every ready row in one pass.

**2. `e9c819c8` — the advance outlook surfaced (librustzcash #2936).** `advance_migration` has returned `Advance { step, next }` since the previous pin; the conduit used to discard `next`. It now marshals both: `migrationAdvanceStep(accountUUID:)` returns `MigrationAdvance?` — the step plus an advisory outlook (`MigrationNextWork`: the earliest target height at which the migration next has serviceable work, and its `MigrationStepKind`), letting a host register its next wake-up from the engine's own plan (a `.broadcast` outlook needs no sync session; a `.prove` one is sync-bound). `migrationSyncWakeups` remains the proving-schedule authority. Rider: the conduit's `ReorgSettleDepth::new(10)` now names upstream's exported `PROVABLE_ANCHOR_DEPTH` (same value).

**3. `a08bdc49` — spendable-note snapshot for the SDK's own adapter (parity with librustzcash #2946).** Upstream's fix landed in THEIR `WalletMigration` adapter, which this SDK cannot use (it requires an unconditional spending key; our `Backend` exists to serve hardware-wallet accounts holding only a viewing key). Our adapter had the same quadratic shape — `resolve_wallet_note` re-ran the full note selection per input during commit-time signing — which on a large wallet stalled plan-accept for ~25 minutes until the app was killed, and could shift the selection index space mid-commit when locks landed. The adapter now snapshots the selection per instance (`RefCell`, upstream's exact pattern); a regression test pins snapshot stability, fresh-adapter freshness, and index-space agreement.

**4. `61e275a8`** — aligns the remaining doc prose (MIGRATING.md, `Synchronizer` protocol docs, changelog Added bullet, one FFI field doc) with the batch-and-outlook generation.

Consumer-facing detail is in `CHANGELOG.md` (`## Changed`), `rust/CHANGELOG.md`, and `MIGRATING.md` (before/after snippets for both breaking shapes). The Sourcery mock regeneration in `e9c819c8` also swept two stubs of a protocol member the base branch had already removed — expected, not scope creep. Known nit left in place: one singular "prove step's kind" phrase in MIGRATING.md's intro prose (the batch framing is fully spelled out in the same file's discharge list).

## Test plan

- `cargo test`: 147 passed / 1 pre-existing documented failure (`migration_keystone.rs`, see f83a5226) — the only tolerated failure.
- `cargo fmt --check` clean; `cargo clippy` 13 warnings (lib) / 47 (all-targets), exactly the branch-point baseline.
- `make check` (macOS local FFI): 798/798 offline Swift tests, including new coverage: batch-Prove marshal (multi-entry order + kinds, empty batch → nil), outlook marshal (height+kind, `-1` sentinel, unknown-kind nil), and the adapter-snapshot regression test.
- `make ffi-all`: all five architectures build; XCFramework assembles.
- `./Scripts/update-proposal-proto.sh --check`: no drift from the moved `zcash_client_backend` pin.
- Manual (testnet): accept a migration plan on a large wallet — commit completes without the multi-minute stall; drive a run and observe the advance log line now carrying the batch and the outlook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
