### PR TITLE
Pin the batch-signing contract that Keystone actually requires

### DIFF
--- a/rust/src/migration_keystone.rs
+++ b/rust/src/migration_keystone.rs
@@ -440,14 +440,16 @@ mod tests {
         base.serialize().expect("serialize")
     }
 
-    /// The batch request RETAINS a pre-existing Orchard `spend_auth_sig` rather than stripping it.
-    /// The only pre-signed actions in a wallet PCZT are the protocol padding dummies, which carry
-    /// no ZIP 32 derivation and whose `dummy_sk` the compact view has already cleared — stripping
-    /// their signature would leave an action neither the signer nor the wallet could ever
-    /// authorize. Upstream's `redact_pczt_for_batch_signer` states and enforces that contract; this
-    /// pins that we get the redacted request it produces.
+    /// The batch request STRIPS a pre-existing Orchard `spend_auth_sig` rather than retaining it.
+    /// The only pre-signed actions in a wallet PCZT are the protocol padding dummies, and the
+    /// Keystone batch-signing firmware rejects any request that carries an Orchard spend
+    /// authorization signature at all. Stripping strands nothing: the request is a signing
+    /// request, not the authoritative PCZT, and `apply_batch_signatures` puts the device's
+    /// signatures back onto the caller's retained unredacted bytes, which still hold the dummy's.
+    /// Upstream's `redact_pczt_for_batch_signer` states and enforces that contract; this pins that
+    /// we get the redacted request it produces.
     #[test]
-    fn build_sign_batch_qr_parts_retains_the_dummy_orchard_spend_auth_sig() {
+    fn build_sign_batch_qr_parts_strips_the_dummy_orchard_spend_auth_sig() {
         let unsigned = build_single_pool_orchard_pczt();
 
         // Sanity-check the premise: the IO-finalized PCZT already carries a dummy spend_auth_sig
@@ -490,14 +492,27 @@ mod tests {
         let request = BatchSignRequest::parse(batch.get_data()).expect("parse batch sign request");
 
         assert_eq!(request.pczts().len(), 1);
-        // The pre-signed dummy keeps its signature; the signer needs nothing further for it.
+        // No action reaches the device carrying a signature; the firmware rejects the whole
+        // request if one does.
         assert!(
             request.pczts()[0]
                 .orchard()
                 .actions()
                 .iter()
+                .all(|action| action.spend().spend_auth_sig().is_none()),
+            "redaction must strip every Orchard spend_auth_sig from the batch request",
+        );
+
+        // The caller's retained bytes are untouched, so the dummy's signature is still there to
+        // be combined with whatever the device returns.
+        assert!(
+            pczt::parse(&unsigned)
+                .expect("re-parse retained pczt")
+                .orchard()
+                .actions()
+                .iter()
                 .any(|action| action.spend().spend_auth_sig().is_some()),
-            "the dummy's signature must survive redaction",
+            "redaction must not disturb the caller's retained PCZT",
         );
     }
 


### PR DESCRIPTION
`migration_keystone::tests::build_sign_batch_qr_parts_retains_the_dummy_orchard_spend_auth_sig` fails on this branch today, and has since the librustzcash pin moved. It asserted that redaction leaves a pre-existing Orchard `spend_auth_sig` on the batch-signing request. It does not, and must not.

### Why it went stale

The test was added by 550c6312 alongside a pin to librustzcash `a00f4a7a`, where `redact_pczt_for_batch_signer` cleared only the spend FVK. Upstream then changed it to clear the signature as well, on the grounds that deployed batch Signers reject requests that already carry one:

> Existing signatures MUST be omitted: deployed batch Signers reject requests that already carry signatures. Omitting them strands nothing — this view is a signing request, not the authoritative PCZT, and the caller's authoritative copy retains them.

Every librustzcash revision from `59ed8930` onward clears it, including the `41a1e17c` this branch pins.

### The assertion contradicted our own documentation

The doc comment on `build_sign_batch_qr_parts` — written earlier, in 5960351a, from the Android SDK port — already recorded the device's actual requirement, with its error string:

> the Keystone batch-signing firmware rejects any batch request containing a pre-existing Orchard/Ironwood `spend_auth_sig` outright ("Invalid pczt, Zcash batch request must not contain Orchard spend authorization signatures")

So the test was pinning the behaviour of one dependency revision rather than the contract the device imposes, and it asserted behaviour that would make a real Keystone reject the request.

### Stripping strands nothing

That was the original comment's stated worry. The redacted view is a signing request, not the authoritative PCZT: `apply_batch_signatures` applies the device's returned signatures onto the caller's retained, unredacted bytes, which still carry the dummy's signature.

The test now asserts both halves of that contract — no signature reaches the device, **and** the caller's retained PCZT is undisturbed — so it pins the contract itself rather than one dependency revision's implementation of it.

### Test plan

- `cargo test` — 145 passed, 0 failed on this branch (debug). The corrected test fails against a pre-`59ed8930` pin and passes against the current one, which is the point of it.
- `cargo test --release` — the keystone tests pass in release too, checked because 947d220b recorded a release-mode-only failure in this area.
- No manual testnet verification: the change is confined to `#[cfg(test)]` code. No FFI symbol, signature or public API moves, so no XCFramework rebuild and no `CHANGELOG.md` entry.

Context: part of #1806. No closing keyword — this corrects one stale assertion, not that whole effort.

Found while merging this branch into `main`, where `cargo test` is not run by any workflow. A follow-up adds that gate, starting on `maint/v2.7.x`; this fix has to land first, or the gate arrives red.

---
🤖 Opened with [Claude Code](https://claude.com/claude-code) assistance.
